### PR TITLE
Make sure ActionsBlock elements are initialized properly

### DIFF
--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -137,10 +137,11 @@ class ActionsBlock(Block):
                  block_id: Optional[str] = None):
         super().__init__(type_=BlockType.ACTIONS,
                          block_id=block_id)
-        if type(elements) is List[Element]:
-            self.elements = elements
-        elif type(elements) is Element:
+        if isinstance(elements, Element):
             self.elements = [elements, ]
+        elif (isinstance(elements, list) and
+              all([isinstance(el, Element) for el in elements])):
+            self.elements = elements
 
     def _resolve(self):
         actions = self._attributes()


### PR DESCRIPTION
Previously, the `elements` attribute of `ActionsBlock` was not initialized correctly when passed a list of `Button`s or some other subclass of `Element`, because the conditional checked for an exact match between types. Now, typechecks are performed with `isinstance` instead, which supports subclasses.

Fixes #2.