### PR TITLE
Fix ephemeral MessageResponse

### DIFF
--- a/slackblocks/messages.py
+++ b/slackblocks/messages.py
@@ -92,6 +92,8 @@ class MessageResponse(BaseMessage):
         self.ephemeral = ephemeral
 
     def _resolve(self) -> Dict[str, Any]:
-        return {**super()._resolve(),
-                "replace_original": self.replace_original,
-                "ephemeral": self.ephemeral}
+        result = {**super()._resolve(),
+                "replace_original": self.replace_original}
+        if self.ephemeral:
+            result["response_type"] = "ephemeral"
+        return result

--- a/test/samples/message_response.json
+++ b/test/samples/message_response.json
@@ -13,5 +13,5 @@
     ],
     "text": "",
     "replace_original": false,
-    "ephemeral": false
+    "response_type": "ephemeral"
 }

--- a/test/test_messages.py
+++ b/test/test_messages.py
@@ -19,6 +19,6 @@ def test_message_with_attachment() -> None:
 
 def test_message_response() -> None:
     block = SectionBlock("Hello, world!", block_id="fake_block_id")
-    message = MessageResponse(blocks=block)
+    message = MessageResponse(blocks=block, ephemeral=True)
     with open("test/samples/message_response.json", "r") as expected:
         assert repr(message) == expected.read()


### PR DESCRIPTION
Just slightly off, the JSON should contain `response_type: "ephemeral"` (afaik there are no other possible values for `response_type`, if you want the response treated as a regular message it is simply omitted).