### PR TITLE
fix: Fix Check for Text Blocks

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -86,7 +86,7 @@ class Text(Element):
             return Text(text=text,
                         type_=type_)
         else:
-            if max_length and len(text) > max_length:
+            if max_length and len(text.text) > max_length:
                 raise InvalidUsageError("Text length exceeds Slack-imposed limit")
             return Text(text=text.text,
                         type_=type_)


### PR DESCRIPTION
While building a button with an emoji, I was presented with the following error:

```
app_1          |   File "/usr/local/lib/python3.8/site-packages/slackblocks/elements.py", line 158, in __init__
app_1          |     self.text = Text.to_text(text, max_length=75, force_plaintext=True)
app_1          |   File "/usr/local/lib/python3.8/site-packages/slackblocks/elements.py", line 89, in to_text
app_1          |     if max_length and len(text) > max_length:
app_1          | TypeError: object of type 'Text' has no len()
```
