### PR TITLE
[FIX] Correct validation for SectionBlock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slackblocks"
-version = "0.9.6"
+version = "0.9.7"
 description = "Python wrapper for the Slack Blocks API"
 authors = [
     "Nicholas Lambourne <dev@ndl.im>",

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -215,15 +215,22 @@ class SectionBlock(Block):
     ):
         super().__init__(type_=BlockType.SECTION, block_id=block_id)
         if not text and not fields:
-            raise InvalidUsageError("Must supply either `text` or `fields` or `both` to SectionBlock.")
+            raise InvalidUsageError(
+                "Must supply either `text` or `fields` or `both` to SectionBlock."
+            )
         self.text = Text.to_text(text, max_length=3000, allow_none=True)
         self.fields = coerce_to_list(
-            [Text.to_text(field, max_length=2000, allow_none=False) for field in fields] if fields else None, 
-            class_=Text, 
+            [
+                Text.to_text(field, max_length=2000, allow_none=False)
+                for field in coerce_to_list(fields, class_=(str, Text), allow_none=True)
+            ]
+            if fields
+            else None,
+            class_=Text,
             allow_none=True,
             max_size=10,
         )
-        
+
         self.accessory = accessory
 
     def _resolve(self) -> Dict[str, Any]:

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -210,12 +210,20 @@ class SectionBlock(Block):
         self,
         text: Optional[TextLike] = None,
         block_id: Optional[str] = None,
-        fields: Optional[List[Text]] = None,
+        fields: Optional[Union[TextLike, List[TextLike]]] = None,
         accessory: Optional[Element] = None,
     ):
         super().__init__(type_=BlockType.SECTION, block_id=block_id)
-        self.text = Text.to_text(text)
-        self.fields = fields
+        if not text and not fields:
+            raise InvalidUsageError("Must supply either `text` or `fields` or `both` to SectionBlock.")
+        self.text = Text.to_text(text, max_length=3000, allow_none=True)
+        self.fields = coerce_to_list(
+            [Text.to_text(field, max_length=2000, allow_none=False) for field in fields] if fields else None, 
+            class_=Text, 
+            allow_none=True,
+            max_size=10,
+        )
+        
         self.accessory = accessory
 
     def _resolve(self) -> Dict[str, Any]:

--- a/test/samples/blocks/section_block_both_text_and_fields.json
+++ b/test/samples/blocks/section_block_both_text_and_fields.json
@@ -1,0 +1,19 @@
+{
+    "type": "section",
+    "block_id": "fake_block_id",
+    "text": {
+        "type": "mrkdwn",
+        "text": "Hello"
+    },
+    "fields": [
+        {
+            "type": "mrkdwn",
+            "text": "Are you"
+        },
+        {
+            "type": "plain_text",
+            "text": "There?",
+            "emoji": true
+        }
+    ]
+}

--- a/test/samples/blocks/section_block_empty_text_field_value.json
+++ b/test/samples/blocks/section_block_empty_text_field_value.json
@@ -1,0 +1,15 @@
+{
+    "type": "section",
+    "block_id": "fake_block_id",
+    "fields": [
+        {
+            "type": "mrkdwn",
+            "text": "Highly"
+        },
+        {
+            "type": "plain_text",
+            "text": "Strung",
+            "emoji": true
+        }
+    ]
+}

--- a/test/samples/blocks/section_block_single_field_value_coercion.json
+++ b/test/samples/blocks/section_block_single_field_value_coercion.json
@@ -1,0 +1,10 @@
+{
+    "type": "section",
+    "block_id": "fake_block_id",
+    "fields": [
+        {
+            "type": "mrkdwn",
+            "text": "Lowly"
+        }
+    ]
+}

--- a/test/unit/test_blocks.py
+++ b/test/unit/test_blocks.py
@@ -14,7 +14,7 @@ from slackblocks import (
     TextType,
 )
 
-from .utils import OPTION_A, THREE_OPTIONS, TWO_OPTIONS, fetch_sample
+from .utils import fetch_sample
 
 
 def test_basic_section_block() -> None:

--- a/test/unit/test_blocks.py
+++ b/test/unit/test_blocks.py
@@ -11,11 +11,12 @@ from slackblocks import (
     TextType,
 )
 
+from .utils import OPTION_A, THREE_OPTIONS, TWO_OPTIONS, fetch_sample
+
 
 def test_basic_section_block() -> None:
     block = SectionBlock("Hello, world!", block_id="fake_block_id")
-    with open("test/samples/blocks/section_block_text_only.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/section_block_text_only.json") == repr(block)
 
 
 def test_basic_section_fields() -> None:
@@ -24,20 +25,28 @@ def test_basic_section_fields() -> None:
         fields=[Text(text="foo", type_=TextType.PLAINTEXT), Text(text="bar")],
         block_id="fake_block_id",
     )
-    with open("test/samples/blocks/section_block_fields.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/section_block_fields.json") == repr(block)
+
+
+def test_section_empty_text_field_value() -> None:
+    block = SectionBlock(
+        block_id="fake_block_id",
+        fields=[
+            Text("Highly", type_=TextType.MARKDOWN),
+            Text("Strung", type_=TextType.PLAINTEXT, emoji=True),
+        ]
+    )
+    assert fetch_sample(path="test/samples/blocks/section_block_empty_text_field_value.json") == repr(block)
 
 
 def test_basic_context_block() -> None:
     block = ContextBlock(elements=[Text("Hello, world!")], block_id="fake_block_id")
-    with open("test/samples/blocks/context_block_text_only.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/context_block_text_only.json") == repr(block)
 
 
 def test_basic_divider_block() -> None:
     block = DividerBlock(block_id="fake_block_id")
-    with open("test/samples/blocks/divider_block_only.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/divider_block_only.json") == repr(block)
 
 
 def test_basic_image_block() -> None:
@@ -47,14 +56,12 @@ def test_basic_image_block() -> None:
         title="image1",
         block_id="fake_block_id",
     )
-    with open("test/samples/blocks/image_block_only.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/image_block_only.json") == repr(block)
 
 
 def test_basic_header_block() -> None:
     block = HeaderBlock(text="AloHa!", block_id="fake_block_id")
-    with open("test/samples/blocks/header_block_only.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/header_block_only.json") == repr(block)
 
 
 def test_basic_action_block() -> None:
@@ -62,8 +69,7 @@ def test_basic_action_block() -> None:
         block_id="5d1d342f-d65c-4ac5-a2f5-690e48ef207e",
         elements=[Option(text="Hi", value="Hi")],
     )
-    with open("test/samples/blocks/actions_block_only.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/actions_block_only.json") == repr(block)
 
 
 def test_checkbox_action_block() -> None:
@@ -76,5 +82,4 @@ def test_checkbox_action_block() -> None:
         block_id="fake_block_id",
         elements=CheckboxGroup(action_id="actionId-0", options=options),
     )
-    with open("test/samples/blocks/actions_block_checkboxes.json", "r") as expected:
-        assert repr(block) == expected.read()
+    assert fetch_sample(path="test/samples/blocks/actions_block_checkboxes.json") == repr(block)

--- a/test/unit/test_blocks.py
+++ b/test/unit/test_blocks.py
@@ -1,3 +1,5 @@
+import pytest
+
 from slackblocks import (
     ActionsBlock,
     CheckboxGroup,
@@ -5,6 +7,7 @@ from slackblocks import (
     DividerBlock,
     HeaderBlock,
     ImageBlock,
+    InvalidUsageError,
     Option,
     SectionBlock,
     Text,
@@ -16,7 +19,9 @@ from .utils import OPTION_A, THREE_OPTIONS, TWO_OPTIONS, fetch_sample
 
 def test_basic_section_block() -> None:
     block = SectionBlock("Hello, world!", block_id="fake_block_id")
-    assert fetch_sample(path="test/samples/blocks/section_block_text_only.json") == repr(block)
+    assert fetch_sample(
+        path="test/samples/blocks/section_block_text_only.json"
+    ) == repr(block)
 
 
 def test_basic_section_fields() -> None:
@@ -25,7 +30,9 @@ def test_basic_section_fields() -> None:
         fields=[Text(text="foo", type_=TextType.PLAINTEXT), Text(text="bar")],
         block_id="fake_block_id",
     )
-    assert fetch_sample(path="test/samples/blocks/section_block_fields.json") == repr(block)
+    assert fetch_sample(path="test/samples/blocks/section_block_fields.json") == repr(
+        block
+    )
 
 
 def test_section_empty_text_field_value() -> None:
@@ -34,19 +41,68 @@ def test_section_empty_text_field_value() -> None:
         fields=[
             Text("Highly", type_=TextType.MARKDOWN),
             Text("Strung", type_=TextType.PLAINTEXT, emoji=True),
-        ]
+        ],
     )
-    assert fetch_sample(path="test/samples/blocks/section_block_empty_text_field_value.json") == repr(block)
+    assert fetch_sample(
+        path="test/samples/blocks/section_block_empty_text_field_value.json"
+    ) == repr(block)
+
+
+def test_section_neither_fields_nor_text() -> None:
+    with pytest.raises(InvalidUsageError):
+        SectionBlock(
+            block_id="fake_block_id",
+            text=None,
+            fields=None,
+        )
+
+
+def test_section_invalid_field_content() -> None:
+    with pytest.raises(InvalidUsageError):
+        SectionBlock(
+            block_id="fake_block_id",
+            fields=[
+                None,
+            ],
+        )
+
+
+def test_section_single_field_value_coercion() -> None:
+    block = SectionBlock(
+        block_id="fake_block_id",
+        fields="Lowly",
+    )
+    assert fetch_sample(
+        path="test/samples/blocks/section_block_single_field_value_coercion.json"
+    ) == repr(block)
+
+
+def test_section_both_text_and_fields() -> None:
+    block = SectionBlock(
+        text="Hello",
+        block_id="fake_block_id",
+        fields=[
+            Text("Are you", type_=TextType.MARKDOWN),
+            Text("There?", type_=TextType.PLAINTEXT, emoji=True),
+        ],
+    )
+    assert fetch_sample(
+        path="test/samples/blocks/section_block_both_text_and_fields.json"
+    ) == repr(block)
 
 
 def test_basic_context_block() -> None:
     block = ContextBlock(elements=[Text("Hello, world!")], block_id="fake_block_id")
-    assert fetch_sample(path="test/samples/blocks/context_block_text_only.json") == repr(block)
+    assert fetch_sample(
+        path="test/samples/blocks/context_block_text_only.json"
+    ) == repr(block)
 
 
 def test_basic_divider_block() -> None:
     block = DividerBlock(block_id="fake_block_id")
-    assert fetch_sample(path="test/samples/blocks/divider_block_only.json") == repr(block)
+    assert fetch_sample(path="test/samples/blocks/divider_block_only.json") == repr(
+        block
+    )
 
 
 def test_basic_image_block() -> None:
@@ -61,7 +117,9 @@ def test_basic_image_block() -> None:
 
 def test_basic_header_block() -> None:
     block = HeaderBlock(text="AloHa!", block_id="fake_block_id")
-    assert fetch_sample(path="test/samples/blocks/header_block_only.json") == repr(block)
+    assert fetch_sample(path="test/samples/blocks/header_block_only.json") == repr(
+        block
+    )
 
 
 def test_basic_action_block() -> None:
@@ -69,7 +127,9 @@ def test_basic_action_block() -> None:
         block_id="5d1d342f-d65c-4ac5-a2f5-690e48ef207e",
         elements=[Option(text="Hi", value="Hi")],
     )
-    assert fetch_sample(path="test/samples/blocks/actions_block_only.json") == repr(block)
+    assert fetch_sample(path="test/samples/blocks/actions_block_only.json") == repr(
+        block
+    )
 
 
 def test_checkbox_action_block() -> None:
@@ -82,4 +142,6 @@ def test_checkbox_action_block() -> None:
         block_id="fake_block_id",
         elements=CheckboxGroup(action_id="actionId-0", options=options),
     )
-    assert fetch_sample(path="test/samples/blocks/actions_block_checkboxes.json") == repr(block)
+    assert fetch_sample(
+        path="test/samples/blocks/actions_block_checkboxes.json"
+    ) == repr(block)


### PR DESCRIPTION
Fixes: https://github.com/nicklambourne/slackblocks/issues/31

### Change List:
- Corrects out of date validation for `SectionBlock`, allowing `None` as a valid option for `text` when `fields` is provided.
- Adds a test for that use case, as well as several others related to the new validation.
- Shifts the `test_block` tests to using the new `fetch_sample` utility instead of `reads`.
- Bumps version to `v0.9.7`.

### Breaking Changes:
- None