### PR TITLE
[BUG] Do not submit default fields for ModalViews

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slackblocks"
-version = "0.9.8"
+version = "0.9.9"
 description = "Python wrapper for the Slack Blocks API"
 authors = [
     "Nicholas Lambourne <dev@ndl.im>",

--- a/slackblocks/views.py
+++ b/slackblocks/views.py
@@ -89,11 +89,11 @@ class ModalView(View):
             modal_view["close"] = self.close._resolve()
         if self.submit:
             modal_view["submit"] = self.submit._resolve()
-        if self.clear_on_close is not None:
+        if self.clear_on_close:
             modal_view["clear_on_close"] = self.clear_on_close
-        if self.notify_on_close is not None:
+        if self.notify_on_close:
             modal_view["notify_on_close"] = self.notify_on_close
-        if self.submit_disabled is not None:
+        if self.submit_disabled:
             modal_view["submit_disabled"] = self.submit_disabled
         return modal_view
 

--- a/test/samples/views/modal_with_blocks.json
+++ b/test/samples/views/modal_with_blocks.json
@@ -33,8 +33,5 @@
     "submit": {
         "type": "plain_text",
         "text": "Submit button"
-    },
-    "clear_on_close": false,
-    "notify_on_close": false,
-    "submit_disabled": false
+    }
 }

--- a/test/unit/test_views.py
+++ b/test/unit/test_views.py
@@ -45,7 +45,4 @@ def test_to_dict() -> None:
                 },
             }
         ],
-        "clear_on_close": False,
-        "notify_on_close": False,
-        "submit_disabled": False,
     }


### PR DESCRIPTION
Fixes https://github.com/nicklambourne/slackblocks/issues/36

The `submit_disabled` field is only valid for certain types of views (specifically: https://api.slack.com/reference/workflows/configuration-view) so providing the an (unnecessary) default value in the rendered JSON would cause it to be rejected for other `ModalView` types.