### PR TITLE
[ENH] Add length validation to Text object

### DIFF
--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -77,7 +77,9 @@ class Text(CompositionObject):
     ):
         super().__init__(type_=CompositionObjectType.TEXT)
         self.text_type = type_
-        self.text = validate_string(text, field_name="text", min_length=1, max_length=3000)
+        self.text = validate_string(
+            text, field_name="text", min_length=1, max_length=3000
+        )
         if self.text_type == TextType.MARKDOWN:
             self.verbatim = verbatim
             self.emoji = None

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -77,7 +77,7 @@ class Text(CompositionObject):
     ):
         super().__init__(type_=CompositionObjectType.TEXT)
         self.text_type = type_
-        self.text = text
+        self.text = validate_string(text, min_length=1, max_length=3000)
         if self.text_type == TextType.MARKDOWN:
             self.verbatim = verbatim
             self.emoji = None

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -77,7 +77,7 @@ class Text(CompositionObject):
     ):
         super().__init__(type_=CompositionObjectType.TEXT)
         self.text_type = type_
-        self.text = validate_string(text, min_length=1, max_length=3000)
+        self.text = validate_string(text, field_name="text", min_length=1, max_length=3000)
         if self.text_type == TextType.MARKDOWN:
             self.verbatim = verbatim
             self.emoji = None

--- a/slackblocks/utils.py
+++ b/slackblocks/utils.py
@@ -74,6 +74,7 @@ def validate_string(
     string: Optional[str],
     field_name: str,
     max_length: Optional[int] = None,
+    min_length: Optional[int] = None,
     allow_none: bool = False,
 ) -> Optional[str]:
     if string is None:
@@ -83,6 +84,11 @@ def validate_string(
             )
     else:
         length = len(string)
+        if min_length and length < min_length:
+            raise InvalidUsageError(
+                f"Argument to field `{field_name}` ({length} characters) "
+                f"is less than minimum length of {max_length} characters"
+            )
         if max_length and length > max_length:
             raise InvalidUsageError(
                 f"Argument to field `{field_name}` ({length} characters) "


### PR DESCRIPTION
This issue (https://github.com/nicklambourne/slackblocks/issues/53) made me realise there was no length checking on the `Text` object. This PR corrects that (and adds a minimum length check to the string validation utility).