### PR TITLE
Make ContextBlock elements use correct CompositionObject Type

### DIFF
--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -31,7 +31,13 @@ from slackblocks.elements import (
     UserSelectMenu,
 )
 from slackblocks.errors import InvalidUsageError
-from slackblocks.objects import CompositionObject, Text, TextLike, TextType
+from slackblocks.objects import (
+    CompositionObject,
+    CompositionObjectType,
+    Text,
+    TextLike,
+    TextType,
+)
 from slackblocks.rich_text import (
     RichTextCodeBlock,
     RichTextList,


### PR DESCRIPTION
The `elements` argument in the `ContextBlock` class incorrectly types for `CompositionObjectType`, an enum, and not `CompositionObject`, the intended ABC. 

This fix updates the import and fixes the type. 

Thanks for making a great repo.  Makes interacting with slack webhooks significantly easier. 

Resolves Issue #86 