### PR TITLE
Allow RichTextInput as an InputBlock Element

### DIFF
--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -25,6 +25,7 @@ from slackblocks.elements import (
     ExternalSelectMenu,
     PlainTextInput,
     RadioButtonGroup,
+    RichTextInput,
     StaticMultiSelectMenu,
     StaticSelectMenu,
     UserMultiSelectMenu,
@@ -63,6 +64,7 @@ ALLOWED_INPUT_ELEMENTS = (
     StaticMultiSelectMenu,
     UserSelectMenu,
     UserMultiSelectMenu,
+    RichTextInput,
 )
 
 


### PR DESCRIPTION
`rich_text_input` elements seem to be allowed in input blocks as seen [here](https://app.slack.com/block-kit-builder/T065FDZTQ#%7B%22title%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Modal%20Title%22%7D,%22submit%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Submit%22%7D,%22type%22:%22modal%22,%22blocks%22:%5B%7B%22type%22:%22input%22,%22block_id%22:%22test_session_description%22,%22label%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Description%22%7D,%22element%22:%7B%22type%22:%22rich_text_input%22,%22action_id%22:%22description_input%22,%22focus_on_load%22:false%7D%7D%5D%7D).

This adds `RichTextInput` to the list of `ALLOWED_INPUT_ELEMENTS` so it will pass validation during resolution.