### PR TITLE
add NumberInput to ALLOWED_INPUT_ELEMENTS

### DIFF
--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -30,6 +30,7 @@ from slackblocks.elements import (
     StaticSelectMenu,
     UserMultiSelectMenu,
     UserSelectMenu,
+    NumberInput,
 )
 from slackblocks.errors import InvalidUsageError
 from slackblocks.objects import (
@@ -50,6 +51,7 @@ from slackblocks.utils import coerce_to_list, validate_string
 
 ALLOWED_INPUT_ELEMENTS = (
     PlainTextInput,
+    NumberInput,
     CheckboxGroup,
     RadioButtonGroup,
     DatePicker,


### PR DESCRIPTION
Hey @nicklambourne, could you have a look at this tiny PR? according to [slack docs](https://api.slack.com/reference/block-kit/blocks#input) `NumberInput` can be an element of `InputBlock` for sure


Thanks in advance!