### PR TITLE
Allow email input in Input Block

### DIFF
--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -31,6 +31,7 @@ from slackblocks.elements import (
     UserMultiSelectMenu,
     UserSelectMenu,
     NumberInput,
+    EmailInput,
 )
 from slackblocks.errors import InvalidUsageError
 from slackblocks.objects import (
@@ -67,6 +68,7 @@ ALLOWED_INPUT_ELEMENTS = (
     UserSelectMenu,
     UserMultiSelectMenu,
     RichTextInput,
+    EmailInput,
 )
 
 


### PR DESCRIPTION
Hi @nicklambourne thanks for creating an maintaining this library.

When using `EmailInput` in an `InputBlock` an error was being thrown. `EmailInput` is [supported by `InputBlocks`](https://api.slack.com/reference/block-kit/block-elements#email) and this error is prevent us from using that Element. 