### PR TITLE
fix SyntaxWarning due to incorrect  escaping of backtick in docstring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,11 @@ per-file-ignores = [
     "slackblocks/rich_text/__init__.py:F401",
     "slackblocks/rich_text/objects.py:W605",
 ]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    #transform warnings into errors so they are not possible to ignore
+    "error",
+    #except when defined explicitly as per example below. See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#controlling-warnings
+    #"ignore::UserWarning",
+]

--- a/slackblocks/rich_text/objects.py
+++ b/slackblocks/rich_text/objects.py
@@ -161,7 +161,7 @@ class RichTextCodeBlock(RichTextObject):
     A rich text element for representing blocks of code in
         [`RichTextBlocks`](/slackblocks/latest/reference/blocks/#blocks.RichTextBlock).
 
-    This is roughly equivalent to the triple-backtick \`\`\``code`\`\`\` syntax in markdown.
+    This is roughly equivalent to the triple-backtick ```code``` syntax in markdown.
 
     See: <https://api.slack.com/reference/block-kit/blocks#rich_text_preformatted>.
 


### PR DESCRIPTION
Hi, thanks for library! 🙇 

In this PR, I'd like to suggest couple of changes to fix one warning (docstring fix), and also to prevent more warnings slipping with the library (see changes in `pyproject.toml`) 🙏 

It is important for us to have as little of unneeded logs on our production runs to minimize the monitoring noise.

To reproduce the warning:
 * revert changes for docstring in `slackblocks.rich_text.objects.RichTextSection`
 * run following before the test to clean all python cache, so that pytest can catch warnings

```bash
find ./ -type f -name '*.pyc' -delete -print && find ./ -type d -name '__pycache__' -delete -print
```

 * run tests, eg:

```bash 
poetry run pytest test/unit
```

Expected: no SyntaxWarning
Actual:
```
slackblocks/rich_text/objects.py:160
  /Users/runner/work/slackblocks/slackblocks/slackblocks/rich_text/objects.py:160: SyntaxWarning: invalid escape sequence '\`'
    """

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Also can be seen as during the GHA unit test runs, ag https://github.com/nicklambourne/slackblocks/actions/runs/13890401733/job/38861282979#step:8:30