### PR TITLE
feat: add fallback option to Attachments

### DIFF
--- a/slackblocks/attachments.py
+++ b/slackblocks/attachments.py
@@ -150,7 +150,9 @@ class Attachment:
         color: the color (in hex format, e.g. #ffffff) of the vertical bar to the left of the
             attachment content. Consider using the `Color` enum from this module.
         fields: a list of `Field` objects to be included in what's rendered in the attachment.
-
+        fallback: A plain text summary of the attachment used in clients that don't show 
+            formatted text (eg. IRC, mobile notifications).
+        
     Throws:
         InvalidUsageError: if the `color` code provided is invalid.
     """
@@ -160,9 +162,11 @@ class Attachment:
         blocks: Optional[Union[Block, List[Block]]] = None,
         color: Optional[Union[str, Color]] = None,
         fields: Optional[Union[Field, List[Field]]] = None,
+        fallback: Optional[str] = None,
     ):
         self.blocks = coerce_to_list(blocks, Block, allow_none=True)
         self.fields = coerce_to_list(fields, Field, allow_none=True)
+        self.fallback = fallback
         if type(color) is Color:
             self.color = color.value
         elif type(color) is str:
@@ -183,6 +187,8 @@ class Attachment:
             attachment["blocks"] = [block._resolve() for block in self.blocks]
         if self.color:
             attachment["color"] = self.color
+        if self.fallback:
+            attachment["fallback"] = self.fallback
         return attachment
 
     def __repr__(self) -> str:

--- a/test/samples/attachments/attachment_simple.json
+++ b/test/samples/attachments/attachment_simple.json
@@ -9,5 +9,6 @@
             }
         }
     ],
-    "color": "#000000"
+    "color": "#000000",
+    "fallback": "Colours preference"
 }

--- a/test/unit/test_attachments.py
+++ b/test/unit/test_attachments.py
@@ -3,7 +3,7 @@ from slackblocks import Attachment, Color, SectionBlock
 
 def test_single_attachment() -> None:
     block = SectionBlock("I like pretty colours", block_id="fake_block_id")
-    attachment = Attachment(blocks=block, color=Color.BLACK)
+    attachment = Attachment(blocks=block, color=Color.BLACK, fallback="Colours preference")
     with open("test/samples/attachments/attachment_simple.json", "r") as expected:
         assert repr(attachment) == expected.read()
 


### PR DESCRIPTION
Added the `fallback` parameter to Attachments, which provides plain text summaries for clients that don't support formatted messages (mobile notifications, IRC, etc.). 

This parameter allows developers to ensure their messages remain accessible across all platforms while maintaining rich formatting where supported. It also can give these messages a meaningful title when they show up in the "Activity" list
in the Slack app (see screens).

Key changes:
- Added fallback parameter to Attachment class
- Updated test samples and tests to verify correct implementation 
- Fully backward compatible with existing code

**Tests passing locally:**
![image](https://github.com/user-attachments/assets/8be658bb-4737-4ab9-8933-70f45ec9c4a4)

**Block Kit Builder test:**

_Before:_ 
![image](https://github.com/user-attachments/assets/62a45ef0-bf5d-4935-bd36-22ba719984d8)

_After:_ 
![image](https://github.com/user-attachments/assets/57bfd22f-a975-4dc4-9981-54db3db7d5fc)
![image](https://github.com/user-attachments/assets/f9717e7a-6acd-4d52-b207-555be264e7af)