### PR TITLE
Fix RichTextUserGroup payload to match Slack API (fixes #114)

### DIFF
--- a/slackblocks/rich_text/elements.py
+++ b/slackblocks/rich_text/elements.py
@@ -22,7 +22,7 @@ class RichTextElementType(Enum):
     LINK = "link"
     TEXT = "text"
     USER = "user"
-    USER_GROUP = "user_group"
+    USER_GROUP = "usergroup"
 
 
 class RichTextElement(ABC):
@@ -333,7 +333,7 @@ class RichTextUserGroup(RichTextElement):
 
     def _resolve(self) -> Dict[str, Any]:
         user_group = super()._resolve()
-        user_group["user_group_id"] = self.user_group_id
+        user_group["usergroup_id"] = self.user_group_id
         style = {}
         if self.bold is not None:
             style["bold"] = self.bold

--- a/test/samples/rich_text/rich_text_user_group_basic.json
+++ b/test/samples/rich_text/rich_text_user_group_basic.json
@@ -1,6 +1,6 @@
 {
-    "type": "user_group",
-    "user_group_id": "C01RGRU0RUK",
+    "type": "usergroup",
+    "usergroup_id": "C01RGRU0RUK",
     "style": {
         "bold": true,
         "italic": false,


### PR DESCRIPTION
## Summary

- Fixes #114 — `RichTextUserGroup` was producing payloads that the Slack API rejects with a 400 "invalid block" error.
- The Slack API spec uses `usergroup` (no underscore) for the element type and `usergroup_id` for the ID field, but slackblocks was emitting `user_group` and `user_group_id`.

## Changes

- `slackblocks/rich_text/elements.py`: `RichTextElementType.USER_GROUP` value `"user_group"` → `"usergroup"`.
- `slackblocks/rich_text/elements.py`: serialized field key `"user_group_id"` → `"usergroup_id"` in `RichTextUserGroup._resolve()`.
- `test/samples/rich_text/rich_text_user_group_basic.json`: updated fixture to reflect the corrected payload.

The Python constructor argument and attribute name `user_group_id` are kept (Pythonic snake_case); only the JSON sent to Slack changes.

## Testing

`pytest test/unit` — all 105 unit tests pass, including `test_rich_text_user_group_basic`.