### PR TITLE
Improve README and docs

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -1,9 +1,9 @@
 name: Package Check
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,33 +15,18 @@ jobs:
     name: Build sdist/wheel and validate README rendering
     steps:
       - name: Check Out Source Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Set Up Python Environment
-        id: setup-python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
         with:
-          python-version: "3.12"
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load Cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          enable-cache: true
 
       - name: Install Dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root --only dev
+        run: uv sync
 
       - name: Build sdist and wheel
-        run: poetry build
+        run: uv build
 
       - name: Validate package metadata and README
-        run: poetry run twine check --strict dist/*
+        run: uv run twine check --strict dist/*

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -1,0 +1,47 @@
+name: Package Check
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package-check:
+    runs-on: ubuntu-latest
+    name: Build sdist/wheel and validate README rendering
+    steps:
+      - name: Check Out Source Repository
+        uses: actions/checkout@v4
+
+      - name: Set Up Python Environment
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load Cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install Dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root --only dev
+
+      - name: Build sdist and wheel
+        run: poetry build
+
+      - name: Validate package metadata and README
+        run: poetry run twine check --strict dist/*

--- a/README.md
+++ b/README.md
@@ -8,84 +8,140 @@
 [![Build Status](https://github.com/nicklambourne/slackblocks/actions/workflows/unit-tests.yml/badge.svg?branch=master)](https://github.com/nicklambourne/slackblocks/actions)
 [![Docs](https://img.shields.io/badge/Docs-8A2BE2.svg)](https://nicklambourne.github.io/slackblocks)
 
-## What is it?
-`slackblocks` is a Python API for building messages in the fancy Slack [Block Kit API](https://api.slack.com/block-kit)
+> **Build Slack messages in Python — without writing JSON by hand.**
 
-## Documentation
-Full documentation is provided [here](https://nicklambourne.github.io/slackblocks/latest/).
+`slackblocks` is a typed, validating Python wrapper around the Slack [Block Kit API](https://api.slack.com/block-kit). It exists because Block Kit JSON is verbose, easy to get subtly wrong, and unpleasant to maintain in source control.
 
-## Requirements
-`slackblocks` requires Python >= 3.8.
+## Why `slackblocks`?
 
-As of version 0.1.0 it has no dependencies outside the Python standard library.
+- **Concise** — `SectionBlock("Hello, *world*!")` instead of a 10-line JSON object.
+- **Validated** — character limits, required fields, mutually-exclusive options, and element-type restrictions are enforced at construction time, so you find out *before* hitting Slack's API.
+- **Drop-in compatible** with both the official [`slack-sdk`](https://pypi.org/project/slack-sdk/) and the legacy [`slackclient`](https://pypi.org/project/slackclient/) — unpack a `Message` directly into `client.chat_postMessage(**message)`.
+- **Typed** — full type hints; ships `py.typed`.
+- **Zero runtime dependencies.**
 
 ## Installation
+
 ```bash
 pip install slackblocks
 ```
 
-## Basic Usage
-```python
-from slackblocks import Message, SectionBlock
+Requires Python 3.8.1 or newer.
 
-
-block = SectionBlock("Hello, world!")
-message = Message(channel="#general", blocks=block)
-message.json()
-
-```
-
-Will produce the following JSON string:
-```json
-{
-    "channel": "#general",
-    "mrkdwn": true,
-    "blocks": [
-        {
-            "type": "section",
-            "block_id": "992ceb6b-9ad4-496b-b8e6-1bd8a632e8b3",
-            "text": {
-                "type": "mrkdwn",
-                "text": "Hello, world!"
-            }
-        }
-    ]
-}
-```
-Which can be sent as payload to the Slack message API HTTP endpoints.
-
-Of more practical use is the ability to unpack the objects directly into 
-the [(Legacy) Python Slack Client](https://pypi.org/project/slackclient/) in order to send messages:
+## Quickstart
 
 ```python
-from os import environ
-from slack import WebClient
-from slackblocks import Message, SectionBlock
+from slackblocks import (
+    ActionsBlock,
+    Button,
+    DividerBlock,
+    HeaderBlock,
+    Message,
+    SectionBlock,
+)
 
-
-client = WebClient(token=environ["SLACK_API_TOKEN"])
-block = SectionBlock("Hello, world!")
-message = Message(channel="#general", blocks=block)
-
-response = client.chat_postMessage(**message)
+message = Message(
+    channel="#general",
+    text="Build #482 passed",  # plain-text fallback for notifications
+    blocks=[
+        HeaderBlock("Build #482 passed :white_check_mark:"),
+        SectionBlock(
+            fields=[
+                "*Branch*\n`main`",
+                "*Author*\n@nick",
+                "*Duration*\n3m 12s",
+                "*Tests*\n1,247 passed",
+            ],
+        ),
+        DividerBlock(),
+        ActionsBlock(
+            elements=[
+                Button(text="View build", action_id="view", url="https://ci.example.com/482"),
+                Button(text="Re-run", action_id="rerun", value="482", style="primary"),
+            ],
+        ),
+    ],
+)
 ```
 
-Or the modern Python [Slack SDK](https://pypi.org/project/slack-sdk/):
+`message` can be sent in one line with the official Slack SDK:
+
 ```python
-from os import environ
+import os
 from slack_sdk import WebClient
-from slackblocks import Message, SectionBlock
 
-
-client = WebClient(token=environ["SLACK_API_TOKEN"])
-block = SectionBlock("Hello, world!")
-message = Message(channel="#general", blocks=block)
-
-response = client.chat_postMessage(**message)
+client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+client.chat_postMessage(**message)
 ```
 
-Note the `**` operator in front of the `message` object.
+The `**` operator unpacks `slackblocks` `Message` objects directly into the SDK call — no `to_dict()` boilerplate required.
 
-## Can I use this in my project?
-Yes, please do! The code is all open source and dual BSD-3.0 and MIT licensed
-    (use what suits you best).
+<p align="center">
+  <img src="https://github.com/nicklambourne/slackblocks/raw/master/docs_src/img/hello_world.png" alt="A simple Slack message rendered in Slack" width="600px" />
+</p>
+
+## What's supported
+
+| Surface             | Status |
+|---------------------|:------:|
+| Blocks              | ✅ All current block types (Section, Header, Divider, Image, Context, Actions, Input, RichText, File, Table) |
+| Elements            | ✅ Buttons, all select menus, date/time pickers, checkboxes, radio groups, all input types, overflow menus, workflow buttons |
+| Composition Objects | ✅ Text, Option, Confirm, Conversation/Dispatch filters, Workflow, Trigger |
+| Rich Text           | ✅ Sections, lists, quotes, code blocks, inline links/users/channels/emoji |
+| Modals & Home Tabs  | ✅ Full views API |
+| Messages            | ✅ `chat.postMessage`, webhook messages, slash-command/interaction responses, threaded replies, ephemeral messages |
+| Attachments         | ⚠️ Supported but [deprecated by Slack](https://api.slack.com/reference/messaging/attachments) |
+
+## Documentation
+
+- **Full docs:** <https://nicklambourne.github.io/slackblocks/>
+- [Installation](https://nicklambourne.github.io/slackblocks/latest/usage/installation/)
+- [Using Blocks](https://nicklambourne.github.io/slackblocks/latest/usage/using_blocks/) — every block type with code, JSON, and screenshots.
+- [Sending Messages](https://nicklambourne.github.io/slackblocks/latest/usage/sending_messages/)
+- [Cookbook](https://nicklambourne.github.io/slackblocks/latest/usage/cookbook/) — end-to-end recipes for build notifications, approval requests, modals, and more.
+- [Troubleshooting & FAQ](https://nicklambourne.github.io/slackblocks/latest/usage/troubleshooting/)
+
+## Comparison with `slack-sdk` block classes
+
+The official `slack-sdk` ships its own block classes. `slackblocks` predates them and offers a more concise API, stricter up-front validation, and independent versioning. They produce equivalent JSON; pick whichever you find more ergonomic.
+
+```python
+# slackblocks
+SectionBlock("Hello, *world*!")
+
+# slack-sdk equivalent
+from slack_sdk.models.blocks import SectionBlock as SDKSectionBlock
+from slack_sdk.models.blocks.basic_components import MarkdownTextObject
+SDKSectionBlock(text=MarkdownTextObject(text="Hello, *world*!"))
+```
+
+## Licensing
+
+`slackblocks` is dual-licensed under [MIT](./LICENSE) and [BSD-3-Clause](./LICENSE.BSD-3-Clause). Use whichever fits your project — this makes it safe to vendor into projects under either license.
+
+## Contributing
+
+Contributions are welcome. To set up a local development environment:
+
+```bash
+git clone https://github.com/nicklambourne/slackblocks.git
+cd slackblocks
+poetry install --with dev,docs
+```
+
+Run the test suite, lint, and type checks:
+
+```bash
+poetry run pytest
+poetry run flake8 slackblocks
+poetry run mypy slackblocks
+```
+
+Preview the documentation locally:
+
+```bash
+poetry run mkdocs serve
+# then visit http://127.0.0.1:8000/
+```
+
+Bug reports and feature requests: <https://github.com/nicklambourne/slackblocks/issues>.

--- a/README.md
+++ b/README.md
@@ -121,27 +121,21 @@ SDKSectionBlock(text=MarkdownTextObject(text="Hello, *world*!"))
 
 ## Contributing
 
-Contributions are welcome. To set up a local development environment:
+Contributions are welcome. Quick start:
 
 ```bash
 git clone https://github.com/nicklambourne/slackblocks.git
 cd slackblocks
 poetry install --with dev,docs
-```
 
-Run the test suite, lint, and type checks:
-
-```bash
-poetry run pytest
+poetry run pytest test/unit
+poetry run black . --check
 poetry run flake8 slackblocks
 poetry run mypy slackblocks
 ```
 
-Preview the documentation locally:
+Preview the documentation locally with `poetry run mkdocs serve`.
 
-```bash
-poetry run mkdocs serve
-# then visit http://127.0.0.1:8000/
-```
+For the full development guide — testing conventions, validation patterns, docstring style, release process, and a PR checklist — see the [Contributing page](https://nicklambourne.github.io/slackblocks/latest/contributing/).
 
 Bug reports and feature requests: <https://github.com/nicklambourne/slackblocks/issues>.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ SDKSectionBlock(text=MarkdownTextObject(text="Hello, *world*!"))
 
 ## Licensing
 
-`slackblocks` is dual-licensed under [MIT](./LICENSE) and [BSD-3-Clause](./LICENSE.BSD-3-Clause). Use whichever fits your project — this makes it safe to vendor into projects under either license.
+`slackblocks` is dual-licensed under [MIT](https://github.com/nicklambourne/slackblocks/blob/master/LICENSE) and [BSD-3-Clause](https://github.com/nicklambourne/slackblocks/blob/master/LICENSE.BSD-3-Clause). Use whichever fits your project — this makes it safe to vendor into projects under either license.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -121,20 +121,20 @@ SDKSectionBlock(text=MarkdownTextObject(text="Hello, *world*!"))
 
 ## Contributing
 
-Contributions are welcome. Quick start:
+Contributions are welcome. Quick start (the project uses [uv](https://docs.astral.sh/uv/) for dependency management):
 
 ```bash
 git clone https://github.com/nicklambourne/slackblocks.git
 cd slackblocks
-poetry install --with dev,docs
+uv sync --all-groups
 
-poetry run pytest test/unit
-poetry run black . --check
-poetry run flake8 slackblocks
-poetry run mypy slackblocks
+uv run pytest test/unit
+uv run black . --check
+uv run flake8 slackblocks
+uv run mypy slackblocks
 ```
 
-Preview the documentation locally with `poetry run mkdocs serve`.
+Preview the documentation locally with `uv run mkdocs serve`.
 
 For the full development guide — testing conventions, validation patterns, docstring style, release process, and a PR checklist — see the [Contributing page](https://nicklambourne.github.io/slackblocks/latest/contributing/).
 

--- a/docs_src/contributing.md
+++ b/docs_src/contributing.md
@@ -1,0 +1,205 @@
+# Contributing
+
+Contributions are welcome — bug fixes, new block/element support, documentation improvements, and test coverage are all appreciated.
+
+This page covers everything you need to develop, test, and submit changes to `slackblocks` itself. If you're looking for help *using* the library, see [Troubleshooting & FAQ](usage/troubleshooting.md) instead.
+
+## Where to start
+
+- **Bugs and feature requests:** open an issue at <https://github.com/nicklambourne/slackblocks/issues>.
+- **Small fixes** (typos, docstrings, missed validation): a PR is fine; no issue needed first.
+- **Larger changes** (new block types, behaviour changes, API additions): please open an issue first to discuss the approach. Block Kit evolves and not every Slack-side feature is a clean fit.
+
+## Local development setup
+
+`slackblocks` uses [Poetry](https://python-poetry.org/) to manage dependencies and the dev environment.
+
+```bash
+git clone https://github.com/nicklambourne/slackblocks.git
+cd slackblocks
+poetry install --with dev,docs
+```
+
+This installs the library in editable mode along with the `dev` group (test, lint, type-check tooling) and the `docs` group (mkdocs and friends). All commands below should be prefixed with `poetry run ` (or invoked from inside `poetry shell`).
+
+### Python version
+
+The library targets **Python 3.8.1+** and is tested against 3.8 through 3.14 in CI. You can develop against any supported version, but check that anything you add doesn't accidentally rely on a newer Python feature (e.g. `match` statements, the `|` union syntax in annotations evaluated at runtime, `from __future__ import annotations` is OK).
+
+## Running checks
+
+The project enforces four CI gates on every PR. Run them locally before pushing:
+
+### Unit tests
+
+```bash
+poetry run pytest test/unit
+```
+
+Tests live in `test/unit/` and assert that `slackblocks` constructs valid Block Kit JSON by comparing against fixture files in `test/samples/`. When adding or modifying a block/element/object, add a corresponding test that:
+
+1. Constructs the object.
+2. Compares its `repr()` (or `_resolve()`) against a JSON fixture file.
+
+The shared helpers in `test/unit/utils.py` (`fetch_sample`, `OPTION_A`/`B`/`C`) keep tests concise.
+
+!!! note
+    `pyproject.toml` configures pytest to **turn warnings into errors** (`filterwarnings = ["error"]`). If a dependency emits a deprecation warning, the tests will fail. This applies only to this repository's CI — it doesn't affect your application.
+
+### Black formatting
+
+```bash
+poetry run black .            # format
+poetry run black . --check    # CI mode: fail if formatting changes are needed
+```
+
+CI runs `black . --check` and will fail the PR if anything is unformatted.
+
+### flake8 linting
+
+```bash
+poetry run flake8 slackblocks
+```
+
+Configuration lives in `pyproject.toml` under `[tool.flake8]`. Per-file ignores already cover the unavoidable cases (re-exports in `__init__.py`, escape sequences in regex literals).
+
+### mypy type checking
+
+```bash
+poetry run mypy slackblocks
+```
+
+`slackblocks` ships `py.typed`, so type hints are part of the public API. New public classes and functions should be fully annotated.
+
+### twine package check
+
+```bash
+poetry build
+poetry run twine check --strict dist/*
+```
+
+This validates that the package metadata and rendered README are accepted by PyPI. CI runs this on every PR — see [`.github/workflows/package-check.yml`](https://github.com/nicklambourne/slackblocks/blob/master/.github/workflows/package-check.yml).
+
+### Run everything in one go
+
+```bash
+poetry run pytest test/unit \
+  && poetry run black . --check \
+  && poetry run flake8 slackblocks \
+  && poetry run mypy slackblocks \
+  && poetry build \
+  && poetry run twine check --strict dist/*
+```
+
+## Working on the docs
+
+The documentation site uses [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) with [mkdocstrings](https://mkdocstrings.github.io/) for auto-generated API reference pages from the source docstrings.
+
+```bash
+poetry run mkdocs serve
+# visit http://127.0.0.1:8000/
+```
+
+Source files live in `docs_src/`:
+
+- `docs_src/index.md` — landing page.
+- `docs_src/usage/` — narrative guides (Installation, Using Blocks, Sending Messages, Cookbook, Troubleshooting).
+- `docs_src/reference/` — auto-generated API reference. Each page is mostly a `:::` mkdocstrings include with a short orientation intro.
+- `docs_src/img/` — images, including per-block screenshots in `docs_src/img/usage/`.
+
+Navigation order is configured in `mkdocs.yml`. If you add a new page, remember to register it under `nav:`.
+
+### Updating docstrings
+
+The reference pages render directly from the docstrings on classes and functions. `slackblocks` uses **Google-style docstrings**:
+
+```python
+def something(arg: str, optional: int = 0) -> bool:
+    """
+    Short, single-sentence summary.
+
+    Longer description if needed. Mention behaviour, edge cases, and the
+    relevant Slack API doc page (with a URL).
+
+    Args:
+        arg: what `arg` is and what valid values look like.
+        optional: defaults to `0`. Note the limit if Slack imposes one.
+
+    Throws:
+        InvalidUsageError: if `arg` exceeds the 255-character limit.
+    """
+```
+
+When linking between docs, **use relative `.md` paths** (e.g. `[Blocks](reference/blocks.md)`) rather than absolute `/slackblocks/latest/...` URLs — relative links work in local previews, on GitHub, and on the deployed site; absolute URLs only work on the deployed site.
+
+### Versioned docs
+
+The deployed docs are versioned with [mike](https://github.com/jimporter/mike). The `docs.yml` workflow runs on each release and publishes a new versioned site under `latest/`. You don't need to run `mike` manually as part of a normal contribution.
+
+## Validation in the library
+
+A core selling point of `slackblocks` is that constructing an invalid object raises `InvalidUsageError` eagerly rather than letting it fail server-side at Slack. When adding a new field or block, check Slack's reference page (linked in every docstring) for:
+
+- **Character limits** on text fields — use the helpers in `slackblocks/utils.py` (e.g. `validate_string`, `validate_action_id`) rather than duplicating limit checks.
+- **Min/max counts** on collections — validate in `__init__` and raise `InvalidUsageError` with a message that includes the actual length and the limit.
+- **Mutually exclusive arguments** — raise `InvalidUsageError` with both possibilities named.
+- **Allowed element types** in containers (e.g. `ContextBlock` only accepts `Text` and `Image`).
+
+Validation tests live in `test/unit/test_errors.py` and the per-module test files. Add a test for each new error path.
+
+## Pull request checklist
+
+Before opening a PR:
+
+- [ ] The change is covered by a unit test (or has a clear reason not to be).
+- [ ] `poetry run pytest test/unit` passes.
+- [ ] `poetry run black . --check` passes.
+- [ ] `poetry run flake8 slackblocks` passes.
+- [ ] `poetry run mypy slackblocks` passes.
+- [ ] `poetry run twine check --strict dist/*` passes (after `poetry build`).
+- [ ] If you added or modified a public class/function, its docstring is updated in Google style.
+- [ ] If you added a new block, element, or object, it's exported from `slackblocks/__init__.py`.
+- [ ] If you added a new feature surface, the relevant `docs_src/usage/` page (and possibly the [Cookbook](usage/cookbook.md)) is updated.
+
+PRs are reviewed against `master`. Keep changes focused — separate refactors from feature additions where practical.
+
+## Project layout
+
+```
+slackblocks/                    # the library
+├── __init__.py                 # public API surface (re-exports)
+├── attachments.py              # Attachment, Color, Field
+├── blocks.py                   # all *Block classes
+├── elements.py                 # all interactive elements
+├── errors.py                   # InvalidUsageError
+├── messages.py                 # Message, WebhookMessage, MessageResponse
+├── modals.py                   # Modal (legacy alias for ModalView)
+├── objects.py                  # composition objects: Text, Option, etc.
+├── rich_text/                  # rich text elements + containers
+├── utils.py                    # shared validation helpers
+└── views.py                    # ModalView, HomeTabView
+
+test/
+├── unit/                       # unit tests (run in CI)
+├── integration/                # live Slack API tests (not run in CI)
+└── samples/                    # JSON fixtures for unit tests
+
+docs_src/                       # mkdocs source
+.github/workflows/              # CI pipelines
+pyproject.toml                  # Poetry config, tool config (flake8, pytest)
+```
+
+## Releases
+
+Releases are cut by the maintainer:
+
+1. Bump `version` in `pyproject.toml`.
+2. Tag the commit (`v1.x.y`).
+3. Push the tag — `publish.yml` builds and publishes to PyPI.
+4. The GitHub release triggers `docs.yml`, which deploys the versioned docs.
+
+Contributors don't need to do anything for a release; just open PRs and the maintainer will batch them.
+
+## Questions?
+
+Open a GitHub issue or start a discussion at <https://github.com/nicklambourne/slackblocks/issues>.

--- a/docs_src/contributing.md
+++ b/docs_src/contributing.md
@@ -12,15 +12,24 @@ This page covers everything you need to develop, test, and submit changes to `sl
 
 ## Local development setup
 
-`slackblocks` uses [Poetry](https://python-poetry.org/) to manage dependencies and the dev environment.
+`slackblocks` uses [uv](https://docs.astral.sh/uv/) to manage dependencies and the dev environment. Install uv first if you don't have it:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# or: brew install uv
+```
+
+Then clone and sync:
 
 ```bash
 git clone https://github.com/nicklambourne/slackblocks.git
 cd slackblocks
-poetry install --with dev,docs
+uv sync --all-groups
 ```
 
-This installs the library in editable mode along with the `dev` group (test, lint, type-check tooling) and the `docs` group (mkdocs and friends). All commands below should be prefixed with `poetry run ` (or invoked from inside `poetry shell`).
+`uv sync --all-groups` installs the library in editable mode along with the `dev` group (test, lint, type-check tooling) and the `docs` group (mkdocs and friends). If you only need one of those groups, use `uv sync --group dev` or `uv sync --group docs`.
+
+All commands below should be prefixed with `uv run ` so they execute inside the project's virtual environment.
 
 ### Python version
 
@@ -28,12 +37,12 @@ The library targets **Python 3.8.1+** and is tested against 3.8 through 3.14 in 
 
 ## Running checks
 
-The project enforces four CI gates on every PR. Run them locally before pushing:
+The project enforces five CI gates on every PR. Run them locally before pushing:
 
 ### Unit tests
 
 ```bash
-poetry run pytest test/unit
+uv run pytest test/unit
 ```
 
 Tests live in `test/unit/` and assert that `slackblocks` constructs valid Block Kit JSON by comparing against fixture files in `test/samples/`. When adding or modifying a block/element/object, add a corresponding test that:
@@ -49,8 +58,8 @@ The shared helpers in `test/unit/utils.py` (`fetch_sample`, `OPTION_A`/`B`/`C`) 
 ### Black formatting
 
 ```bash
-poetry run black .            # format
-poetry run black . --check    # CI mode: fail if formatting changes are needed
+uv run black .            # format
+uv run black . --check    # CI mode: fail if formatting changes are needed
 ```
 
 CI runs `black . --check` and will fail the PR if anything is unformatted.
@@ -58,7 +67,7 @@ CI runs `black . --check` and will fail the PR if anything is unformatted.
 ### flake8 linting
 
 ```bash
-poetry run flake8 slackblocks
+uv run flake8 slackblocks
 ```
 
 Configuration lives in `pyproject.toml` under `[tool.flake8]`. Per-file ignores already cover the unavoidable cases (re-exports in `__init__.py`, escape sequences in regex literals).
@@ -66,7 +75,7 @@ Configuration lives in `pyproject.toml` under `[tool.flake8]`. Per-file ignores 
 ### mypy type checking
 
 ```bash
-poetry run mypy slackblocks
+uv run mypy slackblocks
 ```
 
 `slackblocks` ships `py.typed`, so type hints are part of the public API. New public classes and functions should be fully annotated.
@@ -74,8 +83,8 @@ poetry run mypy slackblocks
 ### twine package check
 
 ```bash
-poetry build
-poetry run twine check --strict dist/*
+uv build
+uv run twine check --strict dist/*
 ```
 
 This validates that the package metadata and rendered README are accepted by PyPI. CI runs this on every PR — see [`.github/workflows/package-check.yml`](https://github.com/nicklambourne/slackblocks/blob/master/.github/workflows/package-check.yml).
@@ -83,12 +92,12 @@ This validates that the package metadata and rendered README are accepted by PyP
 ### Run everything in one go
 
 ```bash
-poetry run pytest test/unit \
-  && poetry run black . --check \
-  && poetry run flake8 slackblocks \
-  && poetry run mypy slackblocks \
-  && poetry build \
-  && poetry run twine check --strict dist/*
+uv run pytest test/unit \
+  && uv run black . --check \
+  && uv run flake8 slackblocks \
+  && uv run mypy slackblocks \
+  && uv build \
+  && uv run twine check --strict dist/*
 ```
 
 ## Working on the docs
@@ -96,7 +105,7 @@ poetry run pytest test/unit \
 The documentation site uses [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) with [mkdocstrings](https://mkdocstrings.github.io/) for auto-generated API reference pages from the source docstrings.
 
 ```bash
-poetry run mkdocs serve
+uv run mkdocs serve
 # visit http://127.0.0.1:8000/
 ```
 
@@ -152,11 +161,11 @@ Validation tests live in `test/unit/test_errors.py` and the per-module test file
 Before opening a PR:
 
 - [ ] The change is covered by a unit test (or has a clear reason not to be).
-- [ ] `poetry run pytest test/unit` passes.
-- [ ] `poetry run black . --check` passes.
-- [ ] `poetry run flake8 slackblocks` passes.
-- [ ] `poetry run mypy slackblocks` passes.
-- [ ] `poetry run twine check --strict dist/*` passes (after `poetry build`).
+- [ ] `uv run pytest test/unit` passes.
+- [ ] `uv run black . --check` passes.
+- [ ] `uv run flake8 slackblocks` passes.
+- [ ] `uv run mypy slackblocks` passes.
+- [ ] `uv run twine check --strict dist/*` passes (after `uv build`).
 - [ ] If you added or modified a public class/function, its docstring is updated in Google style.
 - [ ] If you added a new block, element, or object, it's exported from `slackblocks/__init__.py`.
 - [ ] If you added a new feature surface, the relevant `docs_src/usage/` page (and possibly the [Cookbook](usage/cookbook.md)) is updated.
@@ -186,16 +195,17 @@ test/
 
 docs_src/                       # mkdocs source
 .github/workflows/              # CI pipelines
-pyproject.toml                  # Poetry config, tool config (flake8, pytest)
+pyproject.toml                  # project metadata, dep groups, tool config
+uv.lock                         # locked dependency versions
 ```
 
 ## Releases
 
 Releases are cut by the maintainer:
 
-1. Bump `version` in `pyproject.toml`.
+1. Bump `version` in `pyproject.toml` (under `[project]`).
 2. Tag the commit (`v1.x.y`).
-3. Push the tag — `publish.yml` builds and publishes to PyPI.
+3. Push the tag — `publish.yml` runs `uv build` and publishes the resulting sdist and wheel to PyPI.
 4. The GitHub release triggers `docs.yml`, which deploys the versioned docs.
 
 Contributors don't need to do anything for a release; just open PRs and the maintainer will batch them.

--- a/docs_src/index.md
+++ b/docs_src/index.md
@@ -81,3 +81,4 @@ See [Using Blocks](usage/using_blocks.md) for examples of all block types side-b
 - [Sending Messages](usage/sending_messages.md)
 - [Cookbook](usage/cookbook.md) — complete end-to-end recipes for common message patterns.
 - [Troubleshooting & FAQ](usage/troubleshooting.md)
+- [Contributing](contributing.md) — developing and contributing to `slackblocks` itself.

--- a/docs_src/index.md
+++ b/docs_src/index.md
@@ -4,56 +4,80 @@
   <img width="30%" src="./img/sb.png" />
 </p>
 
-`slackblocks` is Python package for creating complex Slack messages 
-    using the Slack [BlockKit API](https://api.slack.com/block-kit).
+`slackblocks` is a Python library for building Slack messages with the [Block Kit API](https://api.slack.com/block-kit) — without writing JSON by hand.
 
-It exists so you don't have to define block-based Slack messages by
-    hand-writing JSON.
+It exists because Block Kit JSON is verbose, easy to get subtly wrong, and unpleasant to maintain in source control. `slackblocks` gives you:
+
+- **Typed Python classes** for every block, element, and object Slack supports.
+- **Validation as you build** — character limits, required fields, mutually-exclusive options, and element-type restrictions are enforced at construction time, so you find out *before* hitting Slack's API.
+- **Drop-in compatibility** with both the official [`slack-sdk`](https://pypi.org/project/slack-sdk/) and the legacy [`slackclient`](https://pypi.org/project/slackclient/) — unpack a `Message` directly into `client.chat_postMessage(**message)`.
+- **Zero runtime dependencies.**
+
+## Quickstart
+
+```bash
+pip install slackblocks
+```
+
+```python
+from slackblocks import HeaderBlock, Message, SectionBlock, DividerBlock
+
+message = Message(
+    channel="#general",
+    blocks=[
+        HeaderBlock("Build #482 passed :white_check_mark:"),
+        SectionBlock("All 1,247 tests green in 3m 12s."),
+        DividerBlock(),
+        SectionBlock("*Author:* @nick  •  *Branch:* `main`"),
+    ],
+)
+
+print(message.json())
+```
+
+See the [installation guide](usage/installation.md) and [sending messages guide](usage/sending_messages.md) to take it from here.
 
 ## Components
 
-The [Slack BlockKit API](https://api.slack.com/block-kit) defines a number of 
-    different resource types (all defined in JSON) which work together to 
-    define Block-based messages.
-
-`slackblocks` makes using this API easier by providing a hierarchy of Python
-    classes that represent these resources.
+The [Slack Block Kit API](https://api.slack.com/block-kit) defines several resource types (all defined in JSON) that work together to build block-based messages. `slackblocks` mirrors that hierarchy with Python classes.
 
 ### Objects
-[`Objects`](/slackblocks/latest/reference/objects) (e.g. [`Text`](/slackblocks/latest/reference/objects/#objects.Text)) 
-    are the lowest level pimitives that are used to populate 
-    [`Elements`](/slackblocks/latest/reference/elements) and [`Blocks`](/slackblocks/latest/reference/blocks).
+
+[Objects](reference/objects.md) (e.g. [`Text`](reference/objects.md#objects.Text), [`Option`](reference/objects.md#objects.Option), [`Confirm`](reference/objects.md#objects.Confirm)) are the lowest-level primitives — small composable pieces that populate [Elements](reference/elements.md) and [Blocks](reference/blocks.md).
 
 ### Elements
-[`Elements`](/slackblocks/latest/reference/elements) are typically interactive UI elements that take
-    in [`Object`](/slackblocks/latest/reference/objects) to define their content. For example, the 
-    [`CheckboxGroup`](/elements/#elements.CheckboxGroup) element takes in one or
-    more [`Option`](/slackblocks/latest/reference/objects/#objects.Option) items and presents a
-    checkbox menu to the user with those options.
+
+[Elements](reference/elements.md) are typically interactive UI controls that go *inside* blocks. The [`CheckboxGroup`](reference/elements.md#elements.CheckboxGroup) element, for instance, takes one or more [`Option`](reference/objects.md#objects.Option) items and presents a checkbox menu.
 
 ### Blocks
-[`Blocks`](/slackblocks/latest/reference/blocks) are the core element of the API, with different 
-    [`Blocks`](/slackblocks/latest/reference/blocks) used to create different types of visual
-    elements. For example, the [`DividerBlock`](/slackblocks/latest/reference/blocks/#blocks.DividerBlock), 
-    when rendered, will show a visual element similar to a `<hr>` HTML element. The
-    [`RichTextBlock`](/slackblocks/latest/reference/blocks/#blocks.RichTextBlock) on the other hand
-    allows for the display of text elements with visual styling like italics,
-    block quotes, lists and code blocks. 
+
+[Blocks](reference/blocks.md) are the core visual unit of a message. Different block classes produce different UI:
+
+- [`SectionBlock`](reference/blocks.md#blocks.SectionBlock) — a chunk of markdown text, optionally with an accessory element.
+- [`HeaderBlock`](reference/blocks.md#blocks.HeaderBlock) — a large bold title.
+- [`DividerBlock`](reference/blocks.md#blocks.DividerBlock) — a visual separator (like an HTML `<hr>`).
+- [`RichTextBlock`](reference/blocks.md#blocks.RichTextBlock) — formatted text with inline styling, lists, code blocks, and quotes.
+- [`ActionsBlock`](reference/blocks.md#blocks.ActionsBlock) — a row of interactive elements like buttons or menus.
+- [`ImageBlock`](reference/blocks.md#blocks.ImageBlock), [`ContextBlock`](reference/blocks.md#blocks.ContextBlock), [`InputBlock`](reference/blocks.md#blocks.InputBlock), [`FileBlock`](reference/blocks.md#blocks.FileBlock), [`TableBlock`](reference/blocks.md#blocks.TableBlock).
+
+See [Using Blocks](usage/using_blocks.md) for examples of all block types side-by-side with their JSON output and Slack rendering.
 
 ### Messages
-[`Messages`](/slackblocks/latest/reference/messages/) are a convenience wrapper around `Blocks` that
-    can be unpacked as arguments straight into the official Slack Python SDK (or
-    its legacy `slackclient` counterpart).
+
+[Messages](reference/messages.md) are a convenience wrapper around blocks that can be unpacked directly into the Slack SDK's `chat_postMessage` (and friends).
+
+- [`Message`](reference/messages.md#messages.Message) — a normal channel message.
+- [`WebhookMessage`](reference/messages.md#messages.WebhookMessage) — for incoming webhooks.
+- [`MessageResponse`](reference/messages.md#messages.MessageResponse) — replies to slash commands and interactions.
 
 ### Views
-[`Views`](reference/views/) are an alternative usage for [`Blocks`](/slackblocks/latest/reference/blocks)
-    that allow for the creation of custom UI "surfaces" within Slack, e.g. for 
-    third-party apps.
+
+[Views](reference/views.md) are an alternative usage of blocks that build custom UI surfaces in Slack — modal dialogs and the App Home tab — typically used by interactive Slack apps.
 
 ## Guides
-In addition to a complete reference of all classes and functions provided by the 
-    `slackblocks` library, this documentation contains guides on:
 
-- [Installing `slackblocks`](usage/installation/)
-- [Using Blocks](usage/using_blocks/)
-- [Sending Block-based Messages](usage/sending_messages/)
+- [Installation](usage/installation.md)
+- [Using Blocks](usage/using_blocks.md)
+- [Sending Messages](usage/sending_messages.md)
+- [Cookbook](usage/cookbook.md) — complete end-to-end recipes for common message patterns.
+- [Troubleshooting & FAQ](usage/troubleshooting.md)

--- a/docs_src/reference/attachments.md
+++ b/docs_src/reference/attachments.md
@@ -1,10 +1,14 @@
 # Attachments
 
-!!! warning "Warning: Deprecated Feature"
+!!! warning "Deprecated by Slack"
 
-    Attachments, while still accepted by the Slack API, have long (for years now) been considered a deprecated feature.
+    Attachments, while still accepted by the Slack API, have been considered a deprecated feature for years. Prefer plain blocks where possible.
 
-    That said, there is currently no other way to achieve the vertical, colored bars next to content.
+    The one remaining reason to use attachments is the colored vertical bar to the left of the content — this styling can't currently be achieved with blocks.
+
+See the [colored-bar attachment cookbook recipe](../usage/cookbook.md#deprecated-colored-bar-attachment) for usage.
+
+Slack reference: <https://api.slack.com/reference/messaging/attachments>
 
 ::: attachments
     options:

--- a/docs_src/reference/blocks.md
+++ b/docs_src/reference/blocks.md
@@ -1,5 +1,13 @@
 # Blocks
 
+**Blocks** are the top-level visual building units of a Slack message. A `Message` is a list of blocks, rendered top-to-bottom in Slack.
+
+For a side-by-side gallery of every block type with code, JSON, and Slack screenshots, see [Using Blocks](../usage/using_blocks.md).
+
+For the elements that go *inside* blocks (buttons, menus, date pickers, etc.) see [Elements](elements.md).
+
+Slack reference: <https://api.slack.com/reference/block-kit/blocks>
+
 ::: blocks
     options:
         filters: ["!^Block"]

--- a/docs_src/reference/elements.md
+++ b/docs_src/reference/elements.md
@@ -1,5 +1,11 @@
 # Elements
 
+**Elements** are interactive UI controls that go inside blocks — buttons, select menus, date pickers, text inputs, and so on. They're typically embedded in a [`SectionBlock`](blocks.md#blocks.SectionBlock) (as an `accessory`), an [`ActionsBlock`](blocks.md#blocks.ActionsBlock) (as one of several elements), or an [`InputBlock`](blocks.md#blocks.InputBlock) (as the input control).
+
+Many elements take [`Option`](objects.md#objects.Option) or [`ConfirmationDialogue`](objects.md#objects.ConfirmationDialogue) objects as parameters — see [Objects](objects.md).
+
+Slack reference: <https://api.slack.com/reference/block-kit/block-elements>
+
 ::: elements
     options:
         filters: ["!^Element", "!^ElementType"]

--- a/docs_src/reference/messages.md
+++ b/docs_src/reference/messages.md
@@ -1,6 +1,18 @@
 # Messages
 
+**Messages** are the top-level objects you send to Slack. `slackblocks` provides several message types depending on the API surface you're targeting:
+
+| Class                | When to use it                                                                                  |
+|----------------------|-------------------------------------------------------------------------------------------------|
+| `Message`            | Posting a normal message via `chat.postMessage` (the most common case).                         |
+| `WebhookMessage`     | Sending to an [Incoming Webhook](https://api.slack.com/messaging/webhooks) URL.                 |
+| `MessageResponse`    | Replying to a slash command or an interaction `response_url`.                                   |
+
+All three implement `__getitem__`/`keys()`, so you can unpack them with `**message` straight into the Slack SDK. See [Sending Messages](../usage/sending_messages.md) for end-to-end examples.
+
+Slack reference: <https://api.slack.com/methods/chat.postMessage>
+
 ::: messages
     options:
-        filters: ["!^BaseMessage", "!^MessageResponse"]
+        filters: ["!^BaseMessage"]
         show_bases: false

--- a/docs_src/reference/modals.md
+++ b/docs_src/reference/modals.md
@@ -1,5 +1,11 @@
 # Modals
 
+A **Modal** is a pop-up dialog used to collect input from a user. Modals are opened in response to an interaction (button click, slash command) using a `trigger_id` returned by Slack.
+
+`Modal` is kept as a thin compatibility wrapper around [`ModalView`](views.md#views.ModalView) — new code can use either. See the [Confirmation modal cookbook recipe](../usage/cookbook.md#confirmation-modal) for a complete example.
+
+Slack reference: <https://api.slack.com/surfaces/modals>
+
 ::: modals
-options:
-    show_bases: false
+    options:
+        show_bases: false

--- a/docs_src/reference/objects.md
+++ b/docs_src/reference/objects.md
@@ -1,5 +1,15 @@
 # Objects
 
+**Objects** are the lowest-level composable primitives in `slackblocks`. They don't render on their own — instead, they're passed into [Elements](elements.md) and [Blocks](blocks.md) to populate them with text, choices, confirmations, and so on.
+
+The most important ones:
+
+- [`Text`](#objects.Text) — a piece of `mrkdwn` or `plain_text` content. Most fields that accept a `str` will also accept a `Text` for fine-grained control.
+- [`Option`](#objects.Option) — a single selectable choice in a select menu, checkbox, or radio group.
+- [`ConfirmationDialogue`](#objects.ConfirmationDialogue) — a "Are you sure?" prompt shown before destructive actions.
+
+Slack reference: <https://api.slack.com/reference/block-kit/composition-objects>
+
 ::: objects
     options:
         filters: ["!^CompositionObject"]

--- a/docs_src/reference/rich_text.md
+++ b/docs_src/reference/rich_text.md
@@ -1,4 +1,17 @@
 # Rich Text
+
+The **Rich Text** API lets you build inline-formatted content (bold, italic, strikethrough, code, links, mentions, lists, quotes, code blocks) without writing markdown by hand.
+
+Structure:
+
+- A [`RichTextBlock`](blocks.md#blocks.RichTextBlock) wraps one or more *containers*.
+- **Containers** group elements: [`RichTextSection`](#rich_text.objects.RichTextSection), [`RichTextList`](#rich_text.objects.RichTextList), [`RichTextQuote`](#rich_text.objects.RichTextQuote), [`RichTextCodeBlock`](#rich_text.objects.RichTextCodeBlock).
+- **Elements** are the leaf primitives: [`RichText`](#rich_text.elements.RichText) (styled text), [`RichTextLink`](#rich_text.elements.RichTextLink), [`RichTextUser`](#rich_text.elements.RichTextUser), [`RichTextChannel`](#rich_text.elements.RichTextChannel), [`RichTextEmoji`](#rich_text.elements.RichTextEmoji), [`RichTextUserGroup`](#rich_text.elements.RichTextUserGroup).
+
+See the [Rich-formatted alert cookbook recipe](../usage/cookbook.md#rich-formatted-alert) for a complete example.
+
+Slack reference: <https://api.slack.com/reference/block-kit/blocks#rich_text>
+
 ::: rich_text
 
 ## Rich Text Elements (Primitives)

--- a/docs_src/reference/utils.md
+++ b/docs_src/reference/utils.md
@@ -1,3 +1,5 @@
 # Utilities
 
+Internal helper functions used across `slackblocks` for validation and coercion. Most users won't need to call these directly, but they're documented here for completeness and for anyone extending `slackblocks` with custom block or element types.
+
 ::: utils

--- a/docs_src/reference/views.md
+++ b/docs_src/reference/views.md
@@ -1,6 +1,15 @@
 # Views
 
+**Views** are app-customised UI surfaces inside Slack — the contents of a modal dialog or the App Home tab.
+
+- `ModalView` — content of a modal opened with `views.open` / `views.update` / `views.push`.
+- `HomeTabView` — content of the App Home tab, published with `views.publish`.
+
+Pass `view.to_dict()` as the `view` argument to the Slack SDK's view methods.
+
+Slack reference: <https://api.slack.com/reference/surfaces/views>
+
 ::: views
     options:
-        filters: ["!^View"]
+        filters: ["!^View$", "!^ViewType"]
         show_bases: false

--- a/docs_src/usage/cookbook.md
+++ b/docs_src/usage/cookbook.md
@@ -1,0 +1,284 @@
+# Cookbook
+
+End-to-end recipes for common Slack messaging patterns. Each example produces a complete, valid `Message` (or `Modal`) you can pass directly to the Slack SDK.
+
+The reference docs cover *what* each class does in isolation; this page is for *how* to combine them into something useful.
+
+## Build status notification
+
+A typical CI/CD success or failure notification: header, summary fields, divider, contextual footer.
+
+```python
+from slackblocks import (
+    ContextBlock,
+    DividerBlock,
+    HeaderBlock,
+    Message,
+    SectionBlock,
+    Text,
+)
+
+
+def build_status_message(
+    *,
+    channel: str,
+    project: str,
+    branch: str,
+    commit: str,
+    author: str,
+    duration: str,
+    passed: bool,
+) -> Message:
+    icon = ":white_check_mark:" if passed else ":x:"
+    status = "passed" if passed else "failed"
+
+    return Message(
+        channel=channel,
+        text=f"Build {status} for {project}@{branch}",  # plain-text fallback
+        blocks=[
+            HeaderBlock(f"{icon} {project} build {status}"),
+            SectionBlock(
+                fields=[
+                    f"*Branch*\n`{branch}`",
+                    f"*Commit*\n`{commit[:7]}`",
+                    f"*Author*\n{author}",
+                    f"*Duration*\n{duration}",
+                ],
+            ),
+            DividerBlock(),
+            ContextBlock(
+                elements=[
+                    Text(f":calendar: Triggered by push to `{branch}`"),
+                ],
+            ),
+        ],
+    )
+```
+
+Tips:
+
+- Always pass a `text=` fallback to `Message` — Slack uses it for desktop and mobile push notifications.
+- `SectionBlock` accepts up to 10 `fields`, each up to 2,000 characters.
+
+## Approval request with action buttons
+
+A two-button approval flow. The buttons carry `value` and `action_id` so your interaction handler can identify them.
+
+```python
+from slackblocks import (
+    ActionsBlock,
+    Button,
+    ContextBlock,
+    HeaderBlock,
+    Message,
+    SectionBlock,
+    Text,
+)
+
+
+def approval_request(*, channel: str, request_id: str, requester: str, summary: str) -> Message:
+    return Message(
+        channel=channel,
+        text=f"Approval requested by {requester}",
+        blocks=[
+            HeaderBlock(":hand: Approval needed"),
+            SectionBlock(text=f"*Requested by:* {requester}\n\n{summary}"),
+            ActionsBlock(
+                block_id=f"approval:{request_id}",
+                elements=[
+                    Button(
+                        text="Approve",
+                        action_id="approve",
+                        value=request_id,
+                        style="primary",
+                    ),
+                    Button(
+                        text="Reject",
+                        action_id="reject",
+                        value=request_id,
+                        style="danger",
+                    ),
+                    Button(
+                        text="View details",
+                        action_id="details",
+                        url=f"https://approvals.example.com/{request_id}",
+                    ),
+                ],
+            ),
+            ContextBlock(
+                elements=[Text(f"Request ID: `{request_id}`")],
+            ),
+        ],
+    )
+```
+
+When the user clicks a button, Slack will POST an interaction payload to your app. Match on `action_id` (`approve` / `reject` / `details`) and pull the request ID from `block_id` or the button's `value`.
+
+## Rich-formatted alert
+
+Use `RichTextBlock` when you want inline bold/italic/code styling without writing markdown by hand.
+
+```python
+from slackblocks import (
+    Message,
+    RichText,
+    RichTextBlock,
+    RichTextLink,
+    RichTextSection,
+)
+
+
+def deploy_alert(*, channel: str, service: str, version: str, dashboard_url: str) -> Message:
+    return Message(
+        channel=channel,
+        text=f"Deployed {service} {version}",
+        blocks=[
+            RichTextBlock(
+                RichTextSection(
+                    elements=[
+                        RichText(text="Deployed "),
+                        RichText(text=service, bold=True),
+                        RichText(text=" version "),
+                        RichText(text=version, code=True),
+                        RichText(text=". "),
+                        RichTextLink(url=dashboard_url, text="View dashboard"),
+                        RichText(text="."),
+                    ],
+                ),
+            ),
+        ],
+    )
+```
+
+## Confirmation modal
+
+A modal is opened in response to an interaction `trigger_id` from Slack.
+
+```python
+from slack_sdk import WebClient
+from slackblocks import (
+    InputBlock,
+    Modal,
+    PlainTextInput,
+    SectionBlock,
+)
+
+
+def open_confirmation_modal(client: WebClient, trigger_id: str, target: str) -> None:
+    modal = Modal(
+        title="Confirm deletion",
+        submit="Delete",
+        close="Cancel",
+        callback_id="confirm_delete",
+        private_metadata=target,  # round-tripped back to your handler on submit
+        blocks=[
+            SectionBlock(f":warning: This will permanently delete *{target}*."),
+            InputBlock(
+                label="Type the name to confirm",
+                element=PlainTextInput(
+                    action_id="confirmation_text",
+                    placeholder=target,
+                ),
+                block_id="confirmation",
+            ),
+        ],
+    )
+
+    client.views_open(trigger_id=trigger_id, view=modal.to_dict())
+```
+
+When the user submits, your `view_submission` handler will receive the input under `state.values["confirmation"]["confirmation_text"]`.
+
+## Threaded reply
+
+Pass `thread_ts` (the timestamp of the parent message) to reply in-thread.
+
+```python
+from slackblocks import Message, SectionBlock
+
+reply = Message(
+    channel="#general",
+    thread_ts="1700000000.000100",
+    blocks=SectionBlock("Reticulating splines... 30% complete."),
+)
+```
+
+## Ephemeral slash-command response
+
+Reply to a slash command with a message only the invoking user sees:
+
+```python
+from slackblocks import MessageResponse, SectionBlock
+
+body = MessageResponse(
+    blocks=SectionBlock(":mag: Searching... I'll DM you when I'm done."),
+    ephemeral=True,
+).json()
+# return `body` as the JSON response to Slack's slash-command webhook
+```
+
+## Multi-column status report (table)
+
+`TableBlock` is useful for compact tabular output.
+
+```python
+from slackblocks import (
+    ColumnSettings,
+    Message,
+    RawText,
+    RichText,
+    RichTextSection,
+    TableBlock,
+)
+
+
+def header_cell(text: str) -> RichTextSection:
+    return RichTextSection(elements=[RichText(text=text, bold=True)])
+
+
+report = Message(
+    channel="#ops",
+    text="Daily service report",
+    blocks=[
+        TableBlock(
+            column_settings=[
+                ColumnSettings(align="left"),
+                ColumnSettings(align="right"),
+                ColumnSettings(align="right"),
+            ],
+            rows=[
+                [header_cell("Service"), header_cell("p99 (ms)"), header_cell("Errors")],
+                [RawText("api"),     RawText("142"), RawText("3")],
+                [RawText("worker"),  RawText("89"),  RawText("0")],
+                [RawText("billing"), RawText("310"), RawText("12")],
+            ],
+        ),
+    ],
+)
+```
+
+## Deprecated: colored-bar attachment
+
+Slack has long deprecated message attachments, but they're still the only way to get the colored vertical bar on the left of a message. `slackblocks` supports them when you really need that styling:
+
+```python
+from slackblocks import (
+    Attachment,
+    Color,
+    Message,
+    SectionBlock,
+)
+
+msg = Message(
+    channel="#alerts",
+    text="Disk usage warning",
+    attachments=[
+        Attachment(
+            color=Color.YELLOW,
+            blocks=[SectionBlock(":warning: `/var` is at 87% capacity on `prod-db-1`.")],
+        ),
+    ],
+)
+```
+
+Prefer plain blocks where possible — Slack may drop attachment support in the future.

--- a/docs_src/usage/installation.md
+++ b/docs_src/usage/installation.md
@@ -1,4 +1,5 @@
-## Installing `slackblocks`
+# Installation
+
 You can install `slackblocks` using any Python package manager with access to PyPI. Installation commands for some of the more popular ones are included below.
 
 === "pip"
@@ -12,16 +13,47 @@ You can install `slackblocks` using any Python package manager with access to Py
     ```
 
 === "Pipenv"
-    ```
+    ```bash
     pipenv install slackblocks
     ```
 
-`slackblocks` is a pure Python package and is published automatically to [PyPI](https://pypi.org/project/slackblocks/) as Python wheels whenever a new version is released.
+=== "uv"
+    ```bash
+    uv add slackblocks
+    ```
 
-As of version `v0.1.0`` it has no dependencies outside of the Python standard library.
+`slackblocks` is a pure Python package and is published to [PyPI](https://pypi.org/project/slackblocks/) as a wheel on every release. As of `v0.1.0` it has no dependencies outside of the Python standard library.
 
-## Uninstalling `slackblocks`
-If, for whatever reason, you need to remove `slackblocks` from your environment you can do so with the following commands:
+## Requirements
+
+- Python 3.8.1 or newer.
+- No runtime dependencies.
+
+## Verifying your installation
+
+```python
+from slackblocks import Message, SectionBlock
+
+print(Message(channel="#general", blocks=SectionBlock("Hello, world!")).json())
+```
+
+If this prints a formatted JSON object describing a message, you're ready to go.
+
+## Version pinning
+
+`slackblocks` follows semantic versioning. Pinning to a major version is recommended:
+
+=== "pip (`requirements.txt`)"
+    ```
+    slackblocks~=1.2
+    ```
+
+=== "poetry (`pyproject.toml`)"
+    ```toml
+    slackblocks = "^1.2"
+    ```
+
+## Uninstalling
 
 === "pip"
     ```bash
@@ -34,6 +66,11 @@ If, for whatever reason, you need to remove `slackblocks` from your environment 
     ```
 
 === "Pipenv"
-    ```
+    ```bash
     pipenv uninstall slackblocks
+    ```
+
+=== "uv"
+    ```bash
+    uv remove slackblocks
     ```

--- a/docs_src/usage/sending_messages.md
+++ b/docs_src/usage/sending_messages.md
@@ -1,10 +1,11 @@
-`slackblocks` is designed primarily for use with either the [`slack-sdk`](https://pypi.org/project/slack-sdk/) or (legacy) [`slackclient`](https://pypi.org/project/slackclient/) Python packages. Usage of `slackblocks` remains identical regardless of which Slack client library you're using.
+# Sending Messages
 
-While there's nothing stopping you from sending the rendered messages directly with `curl` or `requests`, we recommend using the `**` (dictionary unpacking)operator to unpack `slackblocks` `Messages` directly into the Slack `client`'s `chat_postMessage` function.
+`slackblocks` produces the JSON payloads that the Slack APIs accept; it does **not** make HTTP calls itself. You're free to send the rendered messages with any HTTP client (`curl`, `requests`, `httpx`), but the recommended path is to combine `slackblocks` with the official [`slack-sdk`](https://pypi.org/project/slack-sdk/) (or its legacy [`slackclient`](https://pypi.org/project/slackclient/) predecessor).
 
-An example of this is provided below along with the JSON result of rendering the message, an equivalent `curl` command, and finally the result of the message as it appears in the Slack user interface.
+The trick is the `**` operator: a `slackblocks.Message` is a mapping, so you can unpack it directly into `client.chat_postMessage(...)`.
 
-### Sending a Message with the (Modern) `slack-sdk` Library
+## With the modern `slack-sdk`
+
 === "Python (`slackblocks`)"
     ```python
     from os import environ
@@ -36,61 +37,107 @@ An example of this is provided below along with the JSON result of rendering the
         ]
     }
     ```
-    * Note that the `block_id` field is a pseudorandomly generated UUID. You can pass a value to `Block` constructors should you desire deterministic `Blocks`.
+    Note: the `block_id` field is a pseudorandomly generated UUID. Pass an explicit `block_id` to any block constructor if you need deterministic IDs (e.g. for testing or interaction handling).
 
-=== "Equivalent `curl` Command"
+=== "Equivalent `curl`"
     ```bash
     curl -H "Content-type: application/json" \
-    --data '{"channel":"#general","blocks":[{"type":"section", "block_id": "992ceb6b-9ad4-496b-b8e6-1bd8a632e8b3", "text":{"type":"mrkdwn","text":"Hello, world"}}]}' \
-    -H "Authorization: Bearer ${SLACK_API_TOKEN}" \
-    -X POST https://slack.com/api/chat.postMessage
+      --data '{"channel":"#general","blocks":[{"type":"section","block_id":"992ceb6b-9ad4-496b-b8e6-1bd8a632e8b3","text":{"type":"mrkdwn","text":"Hello, world!"}}]}' \
+      -H "Authorization: Bearer ${SLACK_API_TOKEN}" \
+      -X POST https://slack.com/api/chat.postMessage
     ```
 
-=== "Slack UI Output"
-    ![Hello World Slack Image](../img/hello_world.png)
+=== "Slack UI"
+    ![Hello World rendered in Slack](../img/hello_world.png)
+
+## With the legacy `slackclient`
+
+The API is identical — only the import path changes:
+
+```python
+from os import environ
+from slack import WebClient   # legacy slackclient package
+from slackblocks import Message, SectionBlock
 
 
-### Sending a Message with the (Legacy) `slackclient` Library
-=== "Python (`slackblocks`)"
-    ```python
-    from os import environ
-    from slack import WebClient
-    from slackblocks import Message, SectionBlock
+client = WebClient(token=environ["SLACK_API_TOKEN"])
+message = Message(channel="#general", blocks=SectionBlock("Hello, world!"))
 
+response = client.chat_postMessage(**message)
+```
 
-    client = WebClient(token=environ["SLACK_API_TOKEN"])
-    block = SectionBlock("Hello, world!")
-    message = Message(channel="#general", blocks=block)
+## Other delivery surfaces
 
-    response = client.chat_postMessage(**message)
-    ```
+`slackblocks` provides specialized message classes for each Slack delivery surface. They all unpack the same way as `Message`.
 
-=== "JSON Message"
-    ```json
-    {
-        "channel": "#general",
-        "mrkdwn": true,
-        "blocks": [
-            {
-                "type": "section",
-                "block_id": "992ceb6b-9ad4-496b-b8e6-1bd8a632e8b3",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "Hello, world!"
-                }
-            }
-        ]
-    }
-    ```
-    * Note that the `block_id` field is a pseudorandomly generated UUID. You can pass a value to `Block` constructors should you desire deterministic `Blocks`.
+### Incoming webhooks
 
-=== "Equivalent `curl` Command"
-    ```bash
-    curl -H "Content-type: application/json" \
-    --data '{"channel":"#general","blocks":[{"type":"section", "block_id": "992ceb6b-9ad4-496b-b8e6-1bd8a632e8b3", "text":{"type":"mrkdwn","text":"Hello, world"}}]}' \
-    -H "Authorization: Bearer ${SLACK_API_TOKEN}" \
-    -X POST https://slack.com/api/chat.postMessage
-    ```
+```python
+from slack_sdk.webhook import WebhookClient
+from slackblocks import WebhookMessage, SectionBlock
 
-=== "Slack UI Output"
-    ![Hello World Slack Image](../img/hello_world.png)
+webhook = WebhookClient(url="https://hooks.slack.com/services/...")
+message = WebhookMessage(blocks=SectionBlock("Build complete :white_check_mark:"))
+
+webhook.send(**message)
+```
+
+`WebhookMessage` supports webhook-only options like `response_type`, `replace_original`, and `delete_original`.
+
+### Slash command / interaction responses
+
+When responding to a slash command or interactive payload, use `MessageResponse`:
+
+```python
+from slackblocks import MessageResponse, SectionBlock
+
+response_body = MessageResponse(
+    blocks=SectionBlock("Got it! Working on that now..."),
+    ephemeral=True,        # only visible to the invoking user
+).json()
+```
+
+### Modals & home tabs
+
+For modals and home tab views, build a `Modal` (or `HomeTabView`) and pass it to `views_open` / `views_publish`:
+
+```python
+from slack_sdk import WebClient
+from slackblocks import Modal, SectionBlock
+
+client = WebClient(token=environ["SLACK_API_TOKEN"])
+modal = Modal(
+    title="Confirm action",
+    blocks=[SectionBlock("Are you sure?")],
+    submit="Yes",
+    close="Cancel",
+)
+
+client.views_open(trigger_id=trigger_id, view=modal.to_dict())
+```
+
+See [Modals reference](../reference/modals.md) and [Views reference](../reference/views.md) for the full surface.
+
+## Sending without an SDK
+
+Because `Message` renders to a plain dict, you can also send it directly:
+
+```python
+import json
+import os
+import urllib.request
+
+from slackblocks import Message, SectionBlock
+
+message = Message(channel="#general", blocks=SectionBlock("Hello, world!"))
+
+req = urllib.request.Request(
+    "https://slack.com/api/chat.postMessage",
+    data=message.json().encode("utf-8"),
+    headers={
+        "Content-Type": "application/json; charset=utf-8",
+        "Authorization": f"Bearer {os.environ['SLACK_API_TOKEN']}",
+    },
+)
+urllib.request.urlopen(req)
+```

--- a/docs_src/usage/troubleshooting.md
+++ b/docs_src/usage/troubleshooting.md
@@ -1,0 +1,143 @@
+# Troubleshooting & FAQ
+
+Common questions, gotchas, and error messages.
+
+## Why is my message body coming through with literal `*asterisks*` instead of bold?
+
+Slack supports two text types: `mrkdwn` (a Slack-flavoured markdown) and `plain_text`. `slackblocks` uses `mrkdwn` by default for `SectionBlock` text, but **`HeaderBlock`, button labels, modal titles, input labels, and tab/option labels are forced to `plain_text` by Slack** — markdown syntax in those fields is rendered literally.
+
+If you need bold/italic styling in those places, you can't get it. If you need it elsewhere and aren't getting it, double-check you're not accidentally constructing a `Text(type_=TextType.PLAINTEXT, ...)`.
+
+## Why does my message say `text` is required?
+
+Slack will warn (or in some cases reject) messages that have `blocks` but no `text` fallback. The `text` field is used for:
+
+- Desktop and mobile **push notifications**.
+- Accessibility readers.
+- Clients that don't render Block Kit (rare, but they exist).
+
+Always pass a short `text=` summary alongside `blocks=`:
+
+```python
+Message(
+    channel="#general",
+    text="Build #482 passed",        # fallback
+    blocks=[HeaderBlock("Build #482 passed :white_check_mark:"), ...],
+)
+```
+
+## What is `block_id` for? Should I set it?
+
+`block_id` is a stable identifier for a block. Slack echoes it back to you in interaction payloads (button clicks, modal submits) so you can correlate which block produced the event.
+
+- For **non-interactive** messages, you can leave it unset — `slackblocks` generates a random UUID.
+- For **interactive** messages and modals, set explicit `block_id`s so your handlers can look up state reliably:
+
+  ```python
+  ActionsBlock(
+      block_id="approval:req-123",
+      elements=[Button(text="Approve", action_id="approve", value="req-123")],
+  )
+  ```
+
+The same applies to `action_id` for elements.
+
+## What does `InvalidUsageError: ... exceeds limit of N characters` mean?
+
+Slack imposes hard character limits on most fields. `slackblocks` validates these at construction time so you find out before hitting Slack. Common limits:
+
+| Field                              | Limit (chars) |
+|------------------------------------|---------------|
+| `SectionBlock.text`                | 3,000         |
+| `SectionBlock.fields[i]`           | 2,000         |
+| `HeaderBlock.text` (`plain_text`)  | 150           |
+| `Button.text`                      | 75            |
+| `Button.value`                     | 2,000         |
+| `Button.url`                       | 3,000         |
+| `Modal.title` / `submit` / `close` | 24            |
+| `action_id`                        | 255           |
+| `private_metadata`                 | 3,000         |
+| `Option.url`                       | 3,000         |
+
+If a field exceeds its limit, truncate or split the content.
+
+## How many blocks can a single message have?
+
+- Channel messages: **50 blocks** (Slack-side limit).
+- Modals and home tabs: **100 blocks**.
+- `ContextBlock`: max **10 elements**.
+- `ActionsBlock`: max **25 elements**.
+- `SectionBlock.fields`: max **10 items**.
+- `TableBlock`: max **100 rows × 20 columns**.
+
+## My buttons / selects don't do anything when clicked.
+
+`slackblocks` only constructs the *outgoing* payload. Handling button clicks, menu selections, and modal submissions requires:
+
+1. A public HTTPS endpoint registered as your app's **Interactivity & Shortcuts** URL.
+2. An interaction handler that parses the payload Slack POSTs to that URL.
+
+The [`slack-bolt`](https://slack.dev/bolt-python/) framework is the easiest way to wire this up.
+
+## Why doesn't markdown work inside a `HeaderBlock`?
+
+By design — Slack only allows `plain_text` in headers. Use a `SectionBlock` (which supports `mrkdwn`) followed by a `DividerBlock` if you want bold or styled text as a heading.
+
+## How do I preview a message without actually sending it?
+
+Use Slack's [Block Kit Builder](https://app.slack.com/block-kit-builder) and paste the JSON output from `message.json()`:
+
+```python
+print(message.json())
+```
+
+## How do I send a `slackblocks.Message` with `requests`?
+
+`Message` renders to a dict, so:
+
+```python
+import os
+import requests
+
+from slackblocks import Message, SectionBlock
+
+message = Message(channel="#general", blocks=SectionBlock("Hi!"))
+
+requests.post(
+    "https://slack.com/api/chat.postMessage",
+    json=message.to_dict(),
+    headers={"Authorization": f"Bearer {os.environ['SLACK_API_TOKEN']}"},
+).raise_for_status()
+```
+
+## Can I use `slackblocks` with async code?
+
+Yes — `slackblocks` itself is synchronous and side-effect-free, so `Message(...)` construction works identically inside `async def` functions. Use the async `WebClient` from `slack_sdk.web.async_client` to actually send:
+
+```python
+from slack_sdk.web.async_client import AsyncWebClient
+from slackblocks import Message, SectionBlock
+
+async def notify():
+    client = AsyncWebClient(token=...)
+    message = Message(channel="#general", blocks=SectionBlock("Hi!"))
+    await client.chat_postMessage(**message)
+```
+
+## How does `slackblocks` compare to the block classes in `slack-sdk`?
+
+`slack-sdk` ships its own `Block` / `SectionBlock` / etc. classes. `slackblocks` predates them and offers:
+
+- A more concise API (e.g. `SectionBlock("Hi!")` vs `SectionBlock(text=MarkdownTextObject(text="Hi!"))`).
+- Stricter up-front validation with informative `InvalidUsageError` messages.
+- Independent release cadence — usable with the legacy `slackclient` or no SDK at all.
+
+Use whichever you find more ergonomic; they produce equivalent JSON.
+
+## I'm getting a `pytest` `error` from a Python `DeprecationWarning`.
+
+`slackblocks`' own test suite turns warnings into errors via `pyproject.toml`. That setting only affects this project's CI — it doesn't propagate to your application. If you're seeing it, it's because you're running the `slackblocks` test suite as part of contributing.
+
+## Where do I report bugs / request features?
+
+GitHub Issues: <https://github.com/nicklambourne/slackblocks/issues>

--- a/docs_src/usage/using_blocks.md
+++ b/docs_src/usage/using_blocks.md
@@ -1,3 +1,15 @@
+# Using Blocks
+
+Blocks are the fundamental visual units of a Slack message. Each block type renders as a different UI component (a section of text, a header, a divider, an image, a row of buttons, and so on). A `Message` is composed of one or more blocks, rendered top-to-bottom.
+
+This page lists every block type supported by `slackblocks`, with:
+
+- A short description of what the block is for.
+- The `slackblocks` Python code to construct it.
+- The JSON payload that's produced.
+- A screenshot of how it looks in Slack.
+
+For the reverse mapping — looking up a class by name — see the [Blocks reference](../reference/blocks.md). For interactive UI bits (buttons, menus, date pickers) that go *inside* blocks, see [Elements](../reference/elements.md).
 
 ## Section Block
 :::blocks.SectionBlock
@@ -9,11 +21,11 @@
 === "`slackblocks`"
     
     ```python
-    from slackblocks import Checkboxes, Option, SectionBlock
+    from slackblocks import CheckboxGroup, Option, SectionBlock
 
     SectionBlock(
-        text="This is a section block with a checkbox accessory.", 
-        block_id="fake_block_id"
+        text="This is a section block with a checkbox accessory.",
+        block_id="fake_block_id",
         accessory=CheckboxGroup(
             action_id="checkboxes-action",
             options=[
@@ -64,7 +76,7 @@
 
 === "`slackblocks`"
     ```python
-    from slackblock import RichTextBlock, RichTextSection, RichText
+    from slackblocks import RichTextBlock, RichTextSection, RichText
 
     RichTextBlock(
         RichTextSection(
@@ -334,7 +346,7 @@
     ```
 
 === "Slack UI"
-    ![An example of the UI output of an Context Block](../img/usage/divider.png)
+    ![An example of the UI output of a Context Block](../img/usage/context.png)
 
 ## Actions Block
 :::blocks.ActionsBlock
@@ -344,6 +356,8 @@
 
 === "`slackblocks`"
     ```python
+    from slackblocks import ActionsBlock, CheckboxGroup, Option
+
     ActionsBlock(
         block_id="fake_block_id",
         elements=CheckboxGroup(
@@ -417,6 +431,15 @@
 
 === "`slackblocks`"
     ```python
+    from slackblocks import (
+        ColumnSettings,
+        RawText,
+        RichText,
+        RichTextLink,
+        RichTextSection,
+        TableBlock,
+    )
+
     TableBlock(
         column_settings=[
             ColumnSettings(align="right", is_wrapped=True),
@@ -425,25 +448,21 @@
         rows=[
             [
                 RichTextSection(
-                    elements=RichText(
-                        text="Header 1",
-                        bold=True,
-                    )
+                    elements=[RichText(text="Header 1", bold=True)],
                 ),
                 RichTextSection(
-                    elements=RichTextLink(
-                        text="Header 2",
-                        bold=True,
-                    )
+                    elements=[RichText(text="Header 2", bold=True)],
                 ),
             ],
             [
                 RawText(text="Datum 1"),
                 RichTextSection(
-                    elements=RichTextLink(
-                        url="https://slack.com",
-                        text="Datum 2",
-                    )
+                    elements=[
+                        RichTextLink(
+                            url="https://slack.com",
+                            text="Datum 2",
+                        )
+                    ],
                 ),
             ],
         ],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
     - Rich Text: reference/rich_text.md
     - Views: reference/views.md
     - Utilities: reference/utils.md
+  - Contributing: contributing.md
 
 extra:
   version:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,8 @@ nav:
     - Installation: usage/installation.md
     - Using Blocks: usage/using_blocks.md
     - Sending Messages: usage/sending_messages.md
+    - Cookbook: usage/cookbook.md
+    - Troubleshooting & FAQ: usage/troubleshooting.md
   - Reference:
     - Attachments: reference/attachments.md
     - Blocks: reference/blocks.md

--- a/slackblocks/messages.py
+++ b/slackblocks/messages.py
@@ -196,17 +196,17 @@ class WebhookMessage:
         response_type: one of `ResponseType.EPHEMERAL` or `ResponseType.IN_CHANNEL`.
             Ephemeral messages are shown only to the requesting user whereas
             "in-channel" messages are shown to all channel participants.
-        replace_orginal: when `True`, the message triggering this response will be
-            replaced by this messaage. Mutually exclusive with `delete_original`.
+        replace_original: when `True`, the message triggering this response will be
+            replaced by this message. Mutually exclusive with `delete_original`.
         delete_original: when `True`, the original message triggering this response
             will be deleted, and any content of this message will be posted as a
-            new message. Mutually exclusive with `replace_orginal`.
+            new message. Mutually exclusive with `replace_original`.
         unfurl_links: if `True`, links in the message will be automatically
             unfurled.
         unfurl_media: if `True`, media from links (e.g. images) will
             automatically unfurl.
         metadata: additional metadata to attach to the message.
-        headres: HTTP request headers to include with the message.
+        headers: HTTP request headers to include with the message.
 
     Throws:
         InvalidUsageError: when any of the passed fields fail validation.

--- a/slackblocks/rich_text/elements.py
+++ b/slackblocks/rich_text/elements.py
@@ -22,7 +22,7 @@ class RichTextElementType(Enum):
     LINK = "link"
     TEXT = "text"
     USER = "user"
-    USER_GROUP = "user_group"
+    USER_GROUP = "usergroup"
 
 
 class RichTextElement(ABC):
@@ -333,7 +333,7 @@ class RichTextUserGroup(RichTextElement):
 
     def _resolve(self) -> Dict[str, Any]:
         user_group = super()._resolve()
-        user_group["user_group_id"] = self.user_group_id
+        user_group["usergroup_id"] = self.user_group_id
         style = {}
         if self.bold is not None:
             style["bold"] = self.bold

--- a/test/samples/rich_text/rich_text_user_group_basic.json
+++ b/test/samples/rich_text/rich_text_user_group_basic.json
@@ -1,6 +1,6 @@
 {
-    "type": "user_group",
-    "user_group_id": "C01RGRU0RUK",
+    "type": "usergroup",
+    "usergroup_id": "C01RGRU0RUK",
     "style": {
         "bold": true,
         "italic": false,


### PR DESCRIPTION
## Summary

A docs and README overhaul focused on first-time-user experience, plus a new Contributing guide, a CI gate to validate the README on PyPI, and source fixes that eliminate all griffe warnings during the docs build. Every example in the docs was executed against the source to confirm it produces valid Block Kit JSON.

### Fixes to existing docs

- **`docs_src/usage/using_blocks.md`** — fixed several broken code samples that wouldn't run: wrong import (`Checkboxes` → `CheckboxGroup`), missing comma in `SectionBlock` example, `slackblock` → `slackblocks` typo, missing imports in `ActionsBlock` example, invalid `RichTextLink` usage in `TableBlock` example (no `url`, single-element where list expected), and a broken Context block screenshot reference (`divider.png` → `context.png`).
- **`docs_src/index.md` and reference pages** — replaced absolute `/slackblocks/latest/...` links (which only worked on the deployed site) with relative `.md` links that work in local previews, on GitHub, and on PyPI.
- **`docs_src/usage/installation.md`** — removed stray backtick in `` `v0.1.0`` `` , added uv, version-pinning guidance, and a working verification snippet (the previous one called `.json()` on a `SectionBlock`, which doesn't expose that method).
- **`docs_src/usage/sending_messages.md`** — collapsed the two near-identical `slack-sdk` / `slackclient` walkthroughs into one and added webhooks, slash-command responses, modals, and a no-SDK fallback.

### New docs pages

- **Cookbook** (`docs_src/usage/cookbook.md`) — 8 end-to-end recipes: build status notification, approval flow with action buttons, rich-text alert, confirmation modal, threaded reply, ephemeral slash-command response, multi-column table report, deprecated colored-bar attachment.
- **Troubleshooting & FAQ** (`docs_src/usage/troubleshooting.md`) — covers `mrkdwn` vs `plain_text`, the `text` fallback requirement, `block_id`/`action_id` semantics, character + block-count limits, async usage, and a comparison with `slack-sdk`'s built-in block classes.
- **Contributing** (`docs_src/contributing.md`) — full development guide: setup with `uv sync --all-groups`, all five CI gates (pytest, black, flake8, mypy, twine), docstring style, working on the docs, validation patterns, a PR checklist, project layout, and the release process. Linked from the home page and surfaced in the mkdocs nav.
- Added orientation intros + Slack API reference links to every page in `docs_src/reference/`.

### README rewrite

- New tagline and "Why slackblocks?" rationale.
- Richer multi-block quickstart (header + fields + divider + buttons) followed by a screenshot of the rendered message.
- "What's supported" feature matrix covering blocks, elements, objects, rich text, modals, messages, and attachments.
- Side-by-side comparison with `slack-sdk`'s block classes.
- Explanation of the dual MIT / BSD-3-Clause licensing (with absolute URLs so the links resolve on PyPI as well as on GitHub).
- Trimmed Contributing section that links out to the new Contributing docs page; uses `uv` commands consistent with the project's tooling.

### CI: PyPI README validation

Added `.github/workflows/package-check.yml` — a new `Package Check` job that runs on every push and PR to master:

1. `uv sync`
2. `uv build` (produces sdist + wheel)
3. `uv run twine check --strict dist/*` (the same validation PyPI applies on upload)

This catches README rendering issues, broken markdown, unsupported HTML, and missing package metadata **before** they reach PyPI. Previously the only validation was the `publish.yml` workflow, which runs on tag push — so a broken README would silently make it to PyPI before anyone noticed. Runs in ~9s thanks to uv's caching.

### Source fixes (typos in `slackblocks/messages.py`)

Fixed three typos in the `WebhookMessage` docstring that were producing griffe warnings on every docs build:

- `replace_orginal` → `replace_original` (matches the actual parameter name; appeared twice)
- `messaage` → `message`
- `headres` → `headers` (matches the actual parameter name)

Docstring-only change. With these fixes the docs now build with **zero** griffe warnings.

### Reconciliation with uv migration on master

Master migrated from poetry to uv in #119 while this PR was open. Reconciled cleanly:

- `package-check.yml` rewritten to use uv (`uv sync` / `uv build` / `uv run twine check`) and the same action versions as master's other workflows (`actions/checkout@v5`, `astral-sh/setup-uv@v4`, `enable-cache: true`).
- `docs_src/contributing.md` and the README's Contributing section converted from `poetry install --with dev,docs` / `poetry run ...` to `uv sync --all-groups` / `uv run ...`. The release-process notes now describe `uv build`. Project layout updated to mention `uv.lock`.
- Poetry references **intentionally retained** in `docs_src/usage/installation.md`, which documents installing slackblocks as a dependency in a downstream project — poetry remains a valid choice there alongside pip, pipenv, and uv.

### Validation

- Every code sample in the docs was executed against the source — 16+ examples in total, all producing valid Block Kit JSON.
- `uv build && uv run twine check --strict dist/*` passes for both sdist and wheel.
- `uv run mkdocs build` succeeds with no project-originating warnings.
- All 25 CI gates pass on this PR (unit tests across 3 OSes × 7 Python versions, plus formatting, linting, type checking, and the new package check).