### PR TITLE
Bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,12 +10,12 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Check Out Source Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
             fetch-depth: 0
 
         - name: Set Up Python Environment
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@v6
           with:
             python-version: "3.12"
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -15,10 +15,10 @@ jobs:
     name: black Formatting
     steps:
       - name: Check Out Source Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set Up Python Environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Load Cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,10 +15,10 @@ jobs:
     name: flake8 Linting
     steps:
       - name: Check Out Source Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set Up Python Environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Load Cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Publish Package
         uses: celsiusnarhwal/poetry-publish@v2

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -15,10 +15,10 @@ jobs:
     name: mypy Type Checking
     steps:
       - name: Check Out Source Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set Up Python Environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Load Cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,11 +24,11 @@ jobs:
 
     steps:
       - name: Check Out Source Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set Up Python ${{ matrix.python-version }}
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Load Cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
## Summary
Bumps GitHub Actions to their latest major versions, all of which run on Node.js 24:

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`
- `actions/cache@v4` → `@v5`

## Why
The v1.2.4 publish run surfaced this deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

The new majors are pure Node.js 24 runtime upgrades — no functional/breaking changes per the upstream release notes.

## Notes
- `publish.yml` also relies on `celsiusnarhwal/poetry-publish@v2`, which internally pins an older `actions/setup-python@v4`. That can't be fixed from this repo; it would require either upstream action updates or replacing that step with explicit poetry/twine commands. Out of scope for this PR.