### PR TITLE
fix: correct max_value error message in validate_int

### DIFF
--- a/slackblocks/utils.py
+++ b/slackblocks/utils.py
@@ -224,5 +224,5 @@ def validate_int(
         if min_value is not None and num < min_value:
             raise InvalidUsageError(f"{num} is less than the minimum {min_value}")
         if max_value is not None and num > max_value:
-            raise InvalidUsageError(f"{num} is less than the minimum {max_value}")
+            raise InvalidUsageError(f"{num} exceeds the maximum {max_value}")
     return num

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -5,6 +5,7 @@ from slackblocks.utils import (
     coerce_to_list,
     is_hex,
     validate_action_id,
+    validate_int,
     validate_string,
 )
 
@@ -90,3 +91,15 @@ def test_validate_string_disallow_none() -> None:
 def test_validate_string_exceed_max_length() -> None:
     with pytest.raises(InvalidUsageError):
         assert validate_string("a" * 5, field_name="field", max_length=4)
+
+
+def test_validate_int_min_value_error_message() -> None:
+    with pytest.raises(InvalidUsageError, match="is less than the minimum"):
+        validate_int(1, min_value=5)
+
+
+def test_validate_int_max_value_error_message() -> None:
+    """Regression test for #120: max-value error message must reflect the
+    maximum violation, not the minimum."""
+    with pytest.raises(InvalidUsageError, match="exceeds the maximum"):
+        validate_int(10, max_value=5)

--- a/uv.lock
+++ b/uv.lock
@@ -3554,7 +3554,7 @@ wheels = [
 
 [[package]]
 name = "slackblocks"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #120

## Summary
The `validate_int` function in `slackblocks/utils.py` raised an error message saying "is less than the minimum" when a value actually *exceeded* the maximum. This was a copy-paste error from the min-value branch.

## Changes
- Corrected the error message to "exceeds the maximum" when `num > max_value`
- Added regression tests for both the min-value and max-value error messages