### PR TITLE
fix: honor min_length=0 and max_length=0 in validate_string_nonnull

### DIFF
--- a/slackblocks/utils.py
+++ b/slackblocks/utils.py
@@ -183,12 +183,12 @@ def validate_string_nonnull(
     field_name: str = "string",
 ) -> str:
     length = len(string)
-    if min_length and length < min_length:
+    if min_length is not None and length < min_length:
         raise InvalidUsageError(
             f"Argument to field `{field_name}` ({length} characters) "
             f"is less than minimum length of {min_length} characters"
         )
-    if max_length and length > max_length:
+    if max_length is not None and length > max_length:
         raise InvalidUsageError(
             f"Argument to field `{field_name}` ({length} characters) "
             f"exceeds length limit of {max_length} characters"

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -103,3 +103,18 @@ def test_validate_int_max_value_error_message() -> None:
     maximum violation, not the minimum."""
     with pytest.raises(InvalidUsageError, match="exceeds the maximum"):
         validate_int(10, max_value=5)
+
+
+def test_validate_string_zero_max_length_enforced() -> None:
+    """Regression test for #122: max_length=0 must be honored (only empty
+    string is valid), not silently ignored as a falsy value."""
+    with pytest.raises(InvalidUsageError):
+        validate_string("a", field_name="field", max_length=0)
+    # Empty string should pass (length 0 is not > 0).
+    assert validate_string("", field_name="field", max_length=0) == ""
+
+
+def test_validate_string_zero_min_length_passes() -> None:
+    """Regression test for #122: min_length=0 must be honored explicitly."""
+    assert validate_string("", field_name="field", min_length=0) == ""
+    assert validate_string("abc", field_name="field", min_length=0) == "abc"


### PR DESCRIPTION
Closes #122

## Summary
`validate_string_nonnull` used truthy checks (`if min_length` / `if max_length`) instead of `is not None`, silently ignoring `max_length=0` (a legitimate constraint that allows only empty strings) and `min_length=0`.

## Changes
- Replace truthy checks with `is not None` so explicit `0` values are honored.
- Add regression tests for both `min_length=0` and `max_length=0` paths.