### PR TITLE
fix: align validate_string_nonnull arg order with validate_string

### DIFF
--- a/slackblocks/utils.py
+++ b/slackblocks/utils.py
@@ -173,14 +173,16 @@ def validate_string(
                 f"Expecting string for field `{field_name}`, cannot be None."
             )
         return None
-    return validate_string_nonnull(string, max_length, min_length, field_name)
+    return validate_string_nonnull(
+        string, field_name=field_name, max_length=max_length, min_length=min_length
+    )
 
 
 def validate_string_nonnull(
     string: str,
+    field_name: str = "string",
     max_length: Optional[int] = None,
     min_length: Optional[int] = None,
-    field_name: str = "string",
 ) -> str:
     length = len(string)
     if min_length is not None and length < min_length:

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -7,6 +7,7 @@ from slackblocks.utils import (
     validate_action_id,
     validate_int,
     validate_string,
+    validate_string_nonnull,
 )
 
 
@@ -118,3 +119,20 @@ def test_validate_string_zero_min_length_passes() -> None:
     """Regression test for #122: min_length=0 must be honored explicitly."""
     assert validate_string("", field_name="field", min_length=0) == ""
     assert validate_string("abc", field_name="field", min_length=0) == "abc"
+
+
+def test_validate_string_nonnull_positional_arg_order() -> None:
+    """Regression test for #124: validate_string_nonnull must accept
+    (string, field_name, max_length, min_length) in that positional order,
+    matching validate_string."""
+    assert validate_string_nonnull("hi", "field", 10, 1) == "hi"
+    with pytest.raises(InvalidUsageError, match="field"):
+        validate_string_nonnull("toolong", "field", 3)
+
+
+def test_validate_string_nonnull_keyword_args() -> None:
+    """validate_string_nonnull continues to accept keyword arguments."""
+    assert (
+        validate_string_nonnull("ok", field_name="x", max_length=10, min_length=1)
+        == "ok"
+    )


### PR DESCRIPTION
Closes #124

## Summary
`validate_string` and `validate_string_nonnull` accepted parameters in inconsistent positional order (`field_name` was 2nd in one and 4th in the other). All current callers used keyword arguments, so reordering is safe.

## Changes
- Reorder `validate_string_nonnull` signature to `(string, field_name, max_length, min_length)` to match `validate_string`.
- Update the internal call from `validate_string` to use keyword arguments.
- Add regression tests for both positional and keyword call styles.