### PR TITLE
fix: properly delegate Confirm.__init__ to parent class

### DIFF
--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -258,7 +258,7 @@ class Confirm(ConfirmationDialogue):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        super(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class Option(CompositionObject):

--- a/test/unit/test_objects.py
+++ b/test/unit/test_objects.py
@@ -2,6 +2,7 @@ import pytest
 
 from slackblocks.errors import InvalidUsageError
 from slackblocks.objects import (
+    Confirm,
     ConfirmationDialogue,
     ConversationFilter,
     DispatchActionConfiguration,
@@ -90,6 +91,21 @@ def test_confirmation_dialogue_basic() -> None:
     assert fetch_sample(
         path="test/samples/objects/confirmation_dialogue_basic.json"
     ) == repr(confirmation_dialogue)
+
+
+def test_confirm_alias_equivalent_to_confirmation_dialogue() -> None:
+    """Regression test for #126: the ``Confirm`` backwards-compat alias must
+    forward all arguments to ``ConfirmationDialogue.__init__`` and produce
+    the same JSON output."""
+    confirm = Confirm(
+        title=Text("Maybe?", type_=TextType.PLAINTEXT),
+        text=Text("Would you like to play checkers?", type_=TextType.PLAINTEXT),
+        confirm=Text("Yes", type_=TextType.PLAINTEXT),
+        deny=Text("Nope!", type_=TextType.PLAINTEXT),
+    )
+    assert fetch_sample(
+        path="test/samples/objects/confirmation_dialogue_basic.json"
+    ) == repr(confirm)
 
 
 def test_conversation_filter_basic() -> None:


### PR DESCRIPTION
Closes #126

## Summary
`Confirm.__init__` had a broken super call (`super(*args, **kwargs)` instead of `super().__init__(*args, **kwargs)`), causing every `Confirm(...)` invocation to raise `TypeError`. The backwards-compat alias was non-functional.

## Changes
- Replace `super(*args, **kwargs)` with `super().__init__(*args, **kwargs)`.
- Add regression test confirming `Confirm` produces identical JSON to `ConfirmationDialogue` for the same inputs.