### PR TITLE
fix: call super().__init__ in DispatchActionConfiguration

### DIFF
--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -368,6 +368,7 @@ class DispatchActionConfiguration(CompositionObject):
     def __init__(
         self, trigger_actions_on: Optional[Union[str, List[str]]] = None
     ) -> None:
+        super().__init__(type_=CompositionObjectType.DISPATCH)
         trigger_actions_on = trigger_actions_on or []
         self.trigger_actions_on = list(
             set(coerce_to_list_nonnull(trigger_actions_on, str, min_size=1, max_size=2))

--- a/test/unit/test_objects.py
+++ b/test/unit/test_objects.py
@@ -130,6 +130,16 @@ def test_dispatch_action_config_basic() -> None:
     ) == repr(dispatch_action_config)
 
 
+def test_dispatch_action_config_has_type_attribute() -> None:
+    """Regression test for #128: DispatchActionConfiguration must call
+    super().__init__ so that the inherited ``type`` attribute is set."""
+    dispatch_action_config = DispatchActionConfiguration(
+        trigger_actions_on=["on_character_entered"]
+    )
+    assert hasattr(dispatch_action_config, "type")
+    assert dispatch_action_config.type.value == "dispatch"
+
+
 def test_input_parameter_basic() -> None:
     input_parameter = InputParameter(
         name="name",


### PR DESCRIPTION
Closes #128

## Summary
`DispatchActionConfiguration` inherits from `CompositionObject` but did not call `super().__init__()`, leaving the `type` attribute unset. Any downstream code that read `.type` (e.g. `ContextBlock` element-type validation) would raise `AttributeError`.

## Changes
- Add `super().__init__(type_=CompositionObjectType.DISPATCH)` at the start of `__init__`.
- Add regression test asserting the `type` attribute is set.
- The rendered JSON is unchanged because `_resolve` continues to omit the type key (intentional, per existing comment).