### PR TITLE
fix: resolve nested slack_file in Image element JSON output

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -461,7 +461,7 @@ class Image(Element):
             image["image_url"] = self.image_url
         image["alt_text"] = self.alt_text
         if self.slack_file is not None:
-            image["slack_file"] = self.slack_file
+            image["slack_file"] = self.slack_file._resolve()
         return image
 
 

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -31,6 +31,7 @@ from slackblocks.errors import InvalidUsageError
 from slackblocks.objects import (
     InputParameter,
     Option,
+    SlackFile,
     Text,
     TextType,
     Trigger,
@@ -102,6 +103,21 @@ def test_email_input_basic() -> None:
 def test_image_basic() -> None:
     image = Image(image_url="https://ndl.im/img/logo.png", alt_text="Logo for ndl.im")
     assert fetch_sample(path="test/samples/elements/image_basic.json") == repr(image)
+
+
+def test_image_with_slack_file_resolves() -> None:
+    """Regression test for #130: Image element must call ``_resolve()`` on
+    its nested ``slack_file`` so the result is JSON-serializable."""
+    from json import dumps
+
+    image = Image(
+        alt_text="alt",
+        slack_file=SlackFile(url="https://example.com/img.png", id=None),
+    )
+    resolved = image._resolve()
+    # Should not raise.
+    dumps(resolved)
+    assert resolved["slack_file"] == {"url": "https://example.com/img.png"}
 
 
 def test_multi_select_channel() -> None:


### PR DESCRIPTION
Closes #130

## Summary
`Image._resolve` assigned the raw `SlackFile` instance to the JSON dict instead of calling `._resolve()` on it, causing `json.dumps` of the resulting payload to raise `TypeError`.

## Changes
- Call `._resolve()` on `self.slack_file` before placing it in the output dict.
- Add regression test asserting the JSON output is serializable and structurally correct.