### PR TITLE
fix: resolve nested placeholder in URLInput JSON output

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -1613,7 +1613,7 @@ class URLInput(Element):
         if self.focus_on_load:
             url_input["focus_on_load"] = self.focus_on_load
         if self.placeholder:
-            url_input["placeholder"] = self.placeholder
+            url_input["placeholder"] = self.placeholder._resolve()
         return url_input
 
 

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -299,6 +299,17 @@ def test_url_input_basic() -> None:
     )
 
 
+def test_url_input_with_placeholder_resolves() -> None:
+    """Regression test for #132: URLInput must call ``_resolve()`` on its
+    nested ``placeholder`` so the result is JSON-serializable."""
+    from json import dumps
+
+    url_input = URLInput(action_id="url_text_input", placeholder="Enter a URL")
+    resolved = url_input._resolve()
+    dumps(resolved)  # Must not raise.
+    assert resolved["placeholder"] == {"type": "plain_text", "text": "Enter a URL"}
+
+
 def test_workflow_button_basic() -> None:
     workflow_button = WorkflowButton(
         text=Text("Run Your Workflow", type_=TextType.PLAINTEXT),


### PR DESCRIPTION
Closes #132

## Summary
`URLInput._resolve` did not call `._resolve()` on its `Text` placeholder, causing `json.dumps` of the payload to raise `TypeError`.

## Changes
- Call `._resolve()` on `self.placeholder` before placing it in the output dict.
- Add regression test verifying JSON serializability and structural correctness.