### PR TITLE
fix: resolve nested confirm in TimePicker JSON output

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -1551,7 +1551,7 @@ class TimePicker(Element):
         if self.initial_time:
             time_picker["initial_time"] = self.initial_time
         if self.confirm:
-            time_picker["confirm"] = self.confirm
+            time_picker["confirm"] = self.confirm._resolve()
         if self.focus_on_load:
             time_picker["focus_on_load"] = self.focus_on_load
         if self.placeholder:

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -29,6 +29,7 @@ from slackblocks.elements import (
 )
 from slackblocks.errors import InvalidUsageError
 from slackblocks.objects import (
+    ConfirmationDialogue,
     InputParameter,
     Option,
     SlackFile,
@@ -290,6 +291,25 @@ def test_timepicker_basic() -> None:
     assert fetch_sample(path="test/samples/elements/timepicker_basic.json") == repr(
         timepicker
     )
+
+
+def test_timepicker_with_confirm_resolves() -> None:
+    """Regression test for #134: TimePicker must call ``_resolve()`` on its
+    nested ``confirm`` so the result is JSON-serializable."""
+    from json import dumps
+
+    timepicker = TimePicker(
+        action_id="timepicker",
+        confirm=ConfirmationDialogue(
+            title=Text("Sure?", type_=TextType.PLAINTEXT),
+            text=Text("Pick a time?", type_=TextType.PLAINTEXT),
+            confirm=Text("Yes", type_=TextType.PLAINTEXT),
+            deny=Text("No", type_=TextType.PLAINTEXT),
+        ),
+    )
+    resolved = timepicker._resolve()
+    dumps(resolved)  # Must not raise.
+    assert resolved["confirm"]["title"]["text"] == "Sure?"
 
 
 def test_url_input_basic() -> None:


### PR DESCRIPTION
Closes #134

## Summary
`TimePicker._resolve` did not call `._resolve()` on its `ConfirmationDialogue`, causing `json.dumps` to raise `TypeError`.

## Changes
- Call `._resolve()` on `self.confirm`.
- Add regression test verifying JSON serializability.