### PR TITLE
fix: DatePicker resolves nested confirm and handles missing initial_date

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -253,6 +253,8 @@ class DatePicker(Element):
             self.initial_date = datetime.strptime(initial_date, "%Y-%m-%d").strftime(
                 "%Y-%m-%d"
             )
+        else:
+            self.initial_date = None
         self.confirm = confirm
         self.focus_on_load = focus_on_load
         self.placeholder = Text.to_text(
@@ -265,7 +267,7 @@ class DatePicker(Element):
         if self.initial_date is not None:
             date_picker["initial_date"] = self.initial_date
         if self.confirm:
-            date_picker["confirm"] = self.confirm
+            date_picker["confirm"] = self.confirm._resolve()
         if self.focus_on_load:
             date_picker["focus_on_load"] = self.focus_on_load
         if self.placeholder:

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -85,6 +85,36 @@ def test_datepicker_basic() -> None:
     )
 
 
+def test_datepicker_without_initial_date() -> None:
+    """Regression test for #135: DatePicker without ``initial_date`` must not
+    raise AttributeError on ``_resolve``."""
+    from json import dumps
+
+    datepicker = DatePicker(action_id="datepicker")
+    resolved = datepicker._resolve()
+    dumps(resolved)  # Must not raise.
+    assert "initial_date" not in resolved
+
+
+def test_datepicker_with_confirm_resolves() -> None:
+    """Regression test for #135: DatePicker must call ``_resolve()`` on its
+    nested ``confirm`` so the result is JSON-serializable."""
+    from json import dumps
+
+    datepicker = DatePicker(
+        action_id="datepicker",
+        confirm=ConfirmationDialogue(
+            title=Text("Sure?", type_=TextType.PLAINTEXT),
+            text=Text("Pick this date?", type_=TextType.PLAINTEXT),
+            confirm=Text("Yes", type_=TextType.PLAINTEXT),
+            deny=Text("No", type_=TextType.PLAINTEXT),
+        ),
+    )
+    resolved = datepicker._resolve()
+    dumps(resolved)
+    assert resolved["confirm"]["title"]["text"] == "Sure?"
+
+
 def test_datetime_picker_basic() -> None:
     datetime_picker = DateTimePicker(
         action_id="datetime_picker", initial_datetime=1628633830


### PR DESCRIPTION
Closes #135

## Summary
Two bugs in `DatePicker`:
1. `_resolve` did not call `._resolve()` on `confirm`, causing `json.dumps` to raise `TypeError`.
2. `__init__` only set `self.initial_date` when the argument was provided, so omitting it made `_resolve` raise `AttributeError`.

## Changes
- Always initialize `self.initial_date` (`None` when not provided).
- Call `._resolve()` on `self.confirm` in `_resolve`.
- Add regression tests for both paths.