### PR TITLE
fix: DateTimePicker resolves nested confirm and handles missing initial_datetime

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -304,8 +304,7 @@ class DateTimePicker(Element):
     ) -> None:
         super().__init__(type_=ElementType.DATETIME_PICKER)
         self.action_id = validate_action_id(action_id)
-        if initial_datetime:
-            self.initial_datetime = initial_datetime
+        self.initial_datetime = initial_datetime
         self.confirm = confirm
         self.focus_on_load = focus_on_load
 
@@ -315,7 +314,7 @@ class DateTimePicker(Element):
         if self.initial_datetime:
             datetime_picker["initial_date_time"] = self.initial_datetime
         if self.confirm:
-            datetime_picker["confirm"] = self.confirm
+            datetime_picker["confirm"] = self.confirm._resolve()
         if self.focus_on_load:
             datetime_picker["focus_on_load"] = self.focus_on_load
         return datetime_picker

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -124,6 +124,36 @@ def test_datetime_picker_basic() -> None:
     ) == repr(datetime_picker)
 
 
+def test_datetime_picker_without_initial_datetime() -> None:
+    """Regression test for #136: DateTimePicker without ``initial_datetime``
+    must not raise AttributeError on ``_resolve``."""
+    from json import dumps
+
+    datetime_picker = DateTimePicker(action_id="datetime_picker")
+    resolved = datetime_picker._resolve()
+    dumps(resolved)
+    assert "initial_date_time" not in resolved
+
+
+def test_datetime_picker_with_confirm_resolves() -> None:
+    """Regression test for #136: DateTimePicker must call ``_resolve()`` on
+    its nested ``confirm`` so the result is JSON-serializable."""
+    from json import dumps
+
+    datetime_picker = DateTimePicker(
+        action_id="datetime_picker",
+        confirm=ConfirmationDialogue(
+            title=Text("Sure?", type_=TextType.PLAINTEXT),
+            text=Text("Pick this datetime?", type_=TextType.PLAINTEXT),
+            confirm=Text("Yes", type_=TextType.PLAINTEXT),
+            deny=Text("No", type_=TextType.PLAINTEXT),
+        ),
+    )
+    resolved = datetime_picker._resolve()
+    dumps(resolved)
+    assert resolved["confirm"]["title"]["text"] == "Sure?"
+
+
 def test_email_input_basic() -> None:
     email_input = EmailInput(action_id="email_input", placeholder="Enter your email")
     assert fetch_sample(path="test/samples/elements/email_input_basic.json") == repr(


### PR DESCRIPTION
Closes #136

## Summary
Two bugs in `DateTimePicker`:
1. `_resolve` did not call `._resolve()` on `confirm`, causing `json.dumps` to raise `TypeError`.
2. `__init__` only set `self.initial_datetime` when the argument was truthy, so omitting it made `_resolve` raise `AttributeError`.

## Changes
- Always initialize `self.initial_datetime` (`None` when not provided).
- Call `._resolve()` on `self.confirm` in `_resolve`.
- Add regression tests for both paths.