### PR TITLE
fix: resolve nested filter in ConversationSelectMenu JSON output

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -1432,7 +1432,7 @@ class ConversationSelectMenu(Element):
         if self.response_url_enabled:
             conversation_select_menu["response_url_enabled"] = self.response_url_enabled
         if self.filter:
-            conversation_select_menu["filter"] = self.filter
+            conversation_select_menu["filter"] = self.filter._resolve()
         if self.focus_on_load:
             conversation_select_menu["focus_on_load"] = self.focus_on_load
         if self.placeholder:

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -30,6 +30,7 @@ from slackblocks.elements import (
 from slackblocks.errors import InvalidUsageError
 from slackblocks.objects import (
     ConfirmationDialogue,
+    ConversationFilter,
     InputParameter,
     Option,
     SlackFile,
@@ -302,6 +303,24 @@ def test_select_menu_conversation() -> None:
     assert fetch_sample(
         path="test/samples/elements/select_menu_conversation.json"
     ) == repr(select_menu_conversation)
+
+
+def test_conversation_select_menu_with_filter_resolves() -> None:
+    """Regression test for #140: ConversationSelectMenu must call
+    ``_resolve()`` on its nested ``filter`` so the result is JSON-serializable."""
+    from json import dumps
+
+    select_menu = ConversationSelectMenu(
+        action_id="conversations_select",
+        placeholder="Pick a conversation",
+        filter=ConversationFilter(include=["public"], exclude_bot_users=True),
+    )
+    resolved = select_menu._resolve()
+    dumps(resolved)
+    assert resolved["filter"] == {
+        "include": ["public"],
+        "exclude_bot_users": True,
+    }
 
 
 def test_select_menu_external() -> None:


### PR DESCRIPTION
Closes #140

## Summary
`ConversationSelectMenu._resolve` did not call `._resolve()` on its `ConversationFilter`, causing `json.dumps` of the payload to raise `TypeError`.

## Changes
- Call `._resolve()` on `self.filter`.
- Add regression test verifying JSON serializability and structure.