### PR TITLE
fix: properly resolve nested objects and coerce placeholder in RichTextInput

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -1724,7 +1724,12 @@ class RichTextInput(Element):
         self.initial_value = initial_value
         self.dispatch_action_config = dispatch_action_config
         self.focus_on_load = focus_on_load
-        self.placeholder = placeholder
+        self.placeholder = Text.to_text(
+            placeholder,
+            force_plaintext=True,
+            max_length=150,
+            allow_none=True,
+        )
 
     def _resolve(self) -> Dict[str, Any]:
         rich_text_input = super()._attributes()
@@ -1732,9 +1737,11 @@ class RichTextInput(Element):
         if self.initial_value is not None:
             rich_text_input["initial_value"] = self.initial_value._resolve()
         if self.dispatch_action_config is not None:
-            rich_text_input["dispatch_action_config"] = self.dispatch_action_config
+            rich_text_input["dispatch_action_config"] = (
+                self.dispatch_action_config._resolve()
+            )
         if self.focus_on_load is not None:
             rich_text_input["focus_on_load"] = self.focus_on_load
         if self.placeholder is not None:
-            rich_text_input["placeholder"] = self.placeholder
+            rich_text_input["placeholder"] = self.placeholder._resolve()
         return rich_text_input

--- a/test/samples/elements/rich_text_input_basic.json
+++ b/test/samples/elements/rich_text_input_basic.json
@@ -6,5 +6,8 @@
         "text": "I'm rich"
     },
     "focus_on_load": false,
-    "placeholder": "Hello"
+    "placeholder": {
+        "type": "plain_text",
+        "text": "Hello"
+    }
 }

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -31,6 +31,7 @@ from slackblocks.errors import InvalidUsageError
 from slackblocks.objects import (
     ConfirmationDialogue,
     ConversationFilter,
+    DispatchActionConfiguration,
     InputParameter,
     Option,
     SlackFile,
@@ -444,3 +445,24 @@ def test_rich_text_input_basic() -> None:
             placeholder="Hello",
         )
     )
+
+
+def test_rich_text_input_dispatch_action_config_resolves() -> None:
+    """Regression test for #142: RichTextInput must call ``_resolve()`` on
+    its nested ``dispatch_action_config`` and coerce a ``placeholder`` string
+    to a ``Text`` object so the result is JSON-serializable."""
+    from json import dumps
+
+    rich_text_input = RichTextInput(
+        action_id="rt",
+        placeholder="Type something",
+        dispatch_action_config=DispatchActionConfiguration(
+            trigger_actions_on=["on_enter_pressed"]
+        ),
+    )
+    resolved = rich_text_input._resolve()
+    dumps(resolved)
+    assert resolved["dispatch_action_config"] == {
+        "trigger_actions_on": ["on_enter_pressed"]
+    }
+    assert resolved["placeholder"] == {"type": "plain_text", "text": "Type something"}


### PR DESCRIPTION
Closes #142

## Summary
`RichTextInput` had three problems:
1. `__init__` stored `placeholder` raw instead of coercing through `Text.to_text(...)`, so a string placeholder would be left as a `str`.
2. `_resolve` did not call `._resolve()` on `dispatch_action_config`.
3. `_resolve` did not call `._resolve()` on `placeholder`.

Together these meant any `RichTextInput` carrying a `placeholder` or `dispatch_action_config` produced an invalid payload (and a `TypeError` from `json.dumps` for the latter).

## Changes
- Coerce `placeholder` via `Text.to_text(force_plaintext=True, max_length=150, allow_none=True)` in `__init__`.
- Call `._resolve()` on both `dispatch_action_config` and `placeholder` in `_resolve`.
- Update `test/samples/elements/rich_text_input_basic.json` so the sample reflects the now-correct `Text` placeholder rendering instead of a bare string.
- Add regression test for `dispatch_action_config` and the coerced placeholder.