### PR TITLE
fix: correct 'intial_conversations' typo in ConversationMultiSelectMenu

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -788,7 +788,7 @@ class ConversationMultiSelectMenu(Element):
         conversation_multi_select = self._attributes()
         conversation_multi_select["action_id"] = self.action_id
         if self.initial_conversations:
-            conversation_multi_select["intial_conversations"] = (
+            conversation_multi_select["initial_conversations"] = (
                 self.initial_conversations
             )
         if self.default_to_current_conversation:

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -203,6 +203,20 @@ def test_multi_select_conversation() -> None:
     ) == repr(multi_select_conversation)
 
 
+def test_multi_select_conversation_initial_conversations_key() -> None:
+    """Regression test for #144: ConversationMultiSelectMenu must emit the
+    correctly-spelled ``initial_conversations`` JSON key (Slack silently
+    ignores the previous typo'd ``intial_conversations``)."""
+    multi_select = ConversationMultiSelectMenu(
+        action_id="multi_conversations_select",
+        initial_conversations=["C123", "C456"],
+    )
+    resolved = multi_select._resolve()
+    assert "initial_conversations" in resolved
+    assert resolved["initial_conversations"] == ["C123", "C456"]
+    assert "intial_conversations" not in resolved
+
+
 def test_multi_select_external() -> None:
     multi_select_external = ExternalMultiSelectMenu(
         action_id="multi_external_select",


### PR DESCRIPTION
Closes #144

## Summary
`ConversationMultiSelectMenu._resolve` emitted the JSON key `intial_conversations` (missing the second 'i') instead of `initial_conversations`. Slack silently ignored the field, so any user-provided initial conversations were never sent.

## Changes
- Correct the JSON key spelling.
- Add regression test asserting the new key is present and the typo is gone.