### PR TITLE
fix: NumberInput honors zero values and corrects error message

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -925,11 +925,11 @@ class NumberInput(Element):
                         f"`max_value` ({max_value}) cannot be a float when "
                         "`is_decimal_allowed` is `False`"
                     )
-        if (min_value or min_value == 0) and (max_value or max_value == 0):
+        if min_value is not None and max_value is not None:
             if min_value > max_value:
                 raise InvalidUsageError(
                     f"`min_value` ({min_value}) cannot be greater than "
-                    "`max_value` ({min_value})"
+                    f"`max_value` ({max_value})"
                 )
         self.dispatch_action_config = dispatch_action_config
         self.focus_on_load = focus_on_load
@@ -944,9 +944,9 @@ class NumberInput(Element):
             number_input["action_id"] = self.action_id
         if self.initial_value:
             number_input["initial_value"] = self.initial_value
-        if self.min_value:
+        if self.min_value is not None:
             number_input["min_value"] = self.min_value
-        if self.max_value:
+        if self.max_value is not None:
             number_input["max_value"] = self.max_value
         if self.dispatch_action_config:
             number_input["dispatch_action_config"] = (

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -277,6 +277,34 @@ def test_number_input_basic() -> None:
     )
 
 
+def test_number_input_zero_min_value_emitted() -> None:
+    """Regression test for #146: NumberInput must emit ``min_value=0`` and
+    ``max_value=0`` (legitimate constraints), not silently drop them."""
+    number_input = NumberInput(
+        is_decimal_allowed=False,
+        action_id="number_input",
+        min_value=0,
+        max_value=0,
+    )
+    resolved = number_input._resolve()
+    assert resolved["min_value"] == 0
+    assert resolved["max_value"] == 0
+
+
+def test_number_input_min_greater_than_max_error_message() -> None:
+    """Regression test for #146: cross-validation error message must include
+    both min_value and max_value (previously interpolated min_value twice)."""
+    with pytest.raises(InvalidUsageError) as excinfo:
+        NumberInput(
+            is_decimal_allowed=False,
+            action_id="number_input",
+            min_value=10,
+            max_value=5,
+        )
+    msg = str(excinfo.value)
+    assert "10" in msg and "5" in msg
+
+
 def test_overflow_menu_basic() -> None:
     overflow_menu = OverflowMenu(options=THREE_OPTIONS, action_id="overflow")
     assert fetch_sample(path="test/samples/elements/overflow_menu_basic.json") == repr(


### PR DESCRIPTION
Closes #146

## Summary
`NumberInput` had two bugs:

1. `_resolve` used truthy checks (`if self.min_value`) so legitimate `min_value=0` / `max_value=0` values were silently dropped from the JSON payload.
2. The cross-validation error in `__init__` for `min_value > max_value` formatted `min_value` twice in its message; the second placeholder was also missing the f-prefix so it appeared literally.

## Changes
- Replace truthy checks with `is not None` in both `__init__` cross-validation and `_resolve`.
- Correct the f-string so `max_value` is properly interpolated.
- Add regression tests for both behaviors.