### PR TITLE
perf: replace quadratic sum([list], []) flatten with itertools.chain

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -7,6 +7,7 @@ See: <https://api.slack.com/reference/block-kit/block-elements>
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
+from itertools import chain
 from json import dumps
 from typing import Any, Dict, List, Optional, Union
 
@@ -552,8 +553,10 @@ class StaticMultiSelectMenu(Element):
         if self.options:
             options_to_validate = self.options
         if self.option_groups:
-            options_to_validate = sum(
-                [option_group.options for option_group in self.option_groups], []
+            options_to_validate = list(
+                chain.from_iterable(
+                    option_group.options for option_group in self.option_groups
+                )
             )
         for option in options_to_validate:
             if option.text.text_type == TextType.MARKDOWN:
@@ -1207,8 +1210,10 @@ class StaticSelectMenu(Element):
         if self.options:
             options_to_validate = self.options
         if self.option_groups:
-            options_to_validate = sum(
-                [option_group.options for option_group in self.option_groups], []
+            options_to_validate = list(
+                chain.from_iterable(
+                    option_group.options for option_group in self.option_groups
+                )
             )
         for option in options_to_validate:
             if option.text.text_type == TextType.MARKDOWN:

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -34,6 +34,7 @@ from slackblocks.objects import (
     DispatchActionConfiguration,
     InputParameter,
     Option,
+    OptionGroup,
     SlackFile,
     Text,
     TextType,
@@ -246,6 +247,40 @@ def test_multi_select_static_invalid_option() -> None:
             placeholder=Text("Select one or more", type_=TextType.PLAINTEXT),
             options=TWO_OPTIONS
             + [Option(text=Text("C", type_=TextType.MARKDOWN), value="X")],
+        )
+
+
+def test_static_multi_select_with_option_groups_validates_text() -> None:
+    """Regression test for #148: option_groups flattening must continue to
+    visit every option for plaintext validation after the migration from
+    sum([list], []) to itertools.chain."""
+    valid = StaticMultiSelectMenu(
+        action_id="multi_static_select",
+        placeholder="Pick",
+        options=None,
+        option_groups=[
+            OptionGroup(label="Group 1", options=TWO_OPTIONS),
+            OptionGroup(label="Group 2", options=TWO_OPTIONS),
+        ],
+    )
+    assert "option_groups" in valid._resolve()
+    # Markdown-typed option in a later group still raises.
+    with pytest.raises(InvalidUsageError):
+        StaticMultiSelectMenu(
+            action_id="multi_static_select",
+            placeholder="Pick",
+            options=None,
+            option_groups=[
+                OptionGroup(label="Group 1", options=TWO_OPTIONS),
+                OptionGroup(
+                    label="Group 2",
+                    options=[
+                        Option(
+                            text=Text("Bad", type_=TextType.MARKDOWN), value="bad"
+                        )
+                    ],
+                ),
+            ],
         )
 
 


### PR DESCRIPTION
Closes #148

## Summary
Both `StaticSelectMenu` and `StaticMultiSelectMenu` flattened `option_groups.options` using `sum([list], [])`, which is O(n^2). Replaced with the standard `list(chain.from_iterable(...))` idiom for O(n) behavior.

## Changes
- Add `from itertools import chain` import.
- Replace both flatten sites with `chain.from_iterable`.
- Add regression test covering the option_groups validation path.