### PR TITLE
fix: prevent UnboundLocalError in static (multi) select menus

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -550,6 +550,7 @@ class StaticMultiSelectMenu(Element):
             )
 
         # Check that Option Text is all TextType.PLAINTEXT
+        options_to_validate: List[Option] = []
         if self.options:
             options_to_validate = self.options
         if self.option_groups:
@@ -1207,6 +1208,7 @@ class StaticSelectMenu(Element):
             )
 
         # Check that Option Text is all TextType.PLAINTEXT
+        options_to_validate: List[Option] = []
         if self.options:
             options_to_validate = self.options
         if self.option_groups:

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -250,6 +250,22 @@ def test_multi_select_static_invalid_option() -> None:
         )
 
 
+def test_static_select_menu_without_options_or_groups_does_not_raise() -> None:
+    """Regression test for #150: StaticSelectMenu must not raise
+    UnboundLocalError when neither ``options`` nor ``option_groups`` is set."""
+    menu = StaticSelectMenu(action_id="action", placeholder="Select")
+    resolved = menu._resolve()
+    assert resolved["type"] == "static_select"
+
+
+def test_static_multi_select_menu_without_options_or_groups_does_not_raise() -> None:
+    """Regression test for #150: StaticMultiSelectMenu must not raise
+    UnboundLocalError when ``options`` is None and ``option_groups`` is unset."""
+    menu = StaticMultiSelectMenu(action_id="action", placeholder="Select", options=None)
+    resolved = menu._resolve()
+    assert resolved["type"] == "multi_static_select"
+
+
 def test_static_multi_select_with_option_groups_validates_text() -> None:
     """Regression test for #148: option_groups flattening must continue to
     visit every option for plaintext validation after the migration from


### PR DESCRIPTION
Closes #150

## Summary
`StaticSelectMenu` and `StaticMultiSelectMenu` set `options_to_validate` only inside the `if self.options:` and `if self.option_groups:` branches. When neither argument was provided (or both were empty/None), the variable was unbound and the constructor raised `UnboundLocalError` before any user-facing validation could occur.

## Changes
- Initialize `options_to_validate: List[Option] = []` before the branches in both classes.
- Add regression tests for both `StaticSelectMenu` and `StaticMultiSelectMenu` constructors with no options/groups.