### PR TITLE
fix: annotate DatePicker.initial_date as Optional[str] for mypy

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -250,12 +250,11 @@ class DatePicker(Element):
     ) -> None:
         super().__init__(type_=ElementType.DATE_PICKER)
         self.action_id = validate_action_id(action_id)
+        self.initial_date: Optional[str] = None
         if initial_date:
             self.initial_date = datetime.strptime(initial_date, "%Y-%m-%d").strftime(
                 "%Y-%m-%d"
             )
-        else:
-            self.initial_date = None
         self.confirm = confirm
         self.focus_on_load = focus_on_load
         self.placeholder = Text.to_text(


### PR DESCRIPTION
Closes #158

## Summary
The DatePicker fix from #135 left mypy with an inference conflict: `self.initial_date` was assigned a `str` in the `if` branch (so mypy inferred type `str`) and `None` in the `else` branch (incompatible). The previous PR was merged with `--admin` despite failing the (non-required) `Type Checking` workflow, leaving master red.

## Changes
- Explicitly annotate `self.initial_date: Optional[str] = None` before the conditional assignment.
- Verified locally: `mypy slackblocks` reports "no issues found".