### PR TITLE
style: apply black formatting to test_elements.py

### DIFF
--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -291,9 +291,7 @@ def test_static_multi_select_with_option_groups_validates_text() -> None:
                 OptionGroup(
                     label="Group 2",
                     options=[
-                        Option(
-                            text=Text("Bad", type_=TextType.MARKDOWN), value="bad"
-                        )
+                        Option(text=Text("Bad", type_=TextType.MARKDOWN), value="bad")
                     ],
                 ),
             ],


### PR DESCRIPTION
Closes #159

## Summary
`test/unit/test_elements.py` had been failing the `Black Formatting` workflow on master since PR #149 (the merge bypassed it with `--admin`). Black wanted to collapse a multi-line `Option(...)` invocation onto a single line.

## Changes
- Ran `uv run black test/unit/test_elements.py`.
- Verified locally: `black . --check`, `mypy slackblocks`, `flake8 slackblocks`, and `pytest test/unit` all clean.