### PR TITLE
chore: replace black + flake8 with ruff

### DIFF
--- a/.github/workflows/ruff-format.yml
+++ b/.github/workflows/ruff-format.yml
@@ -1,4 +1,4 @@
-name: Black Formatting
+name: Ruff Format
 on:
   push:
     branches: [master]
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   formatting:
     runs-on: ubuntu-latest
-    name: black Formatting
+    name: Ruff Format
     steps:
       - name: Check Out Source Repository
         uses: actions/checkout@v5
@@ -26,4 +26,4 @@ jobs:
         run: uv sync
 
       - name: Formatting
-        run: uv run black . --check
+        run: uv run ruff format --check .

--- a/.github/workflows/ruff-lint.yml
+++ b/.github/workflows/ruff-lint.yml
@@ -1,4 +1,4 @@
-name: Flake8 Linting
+name: Ruff Lint
 on:
   push:
     branches: [master]
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   linting:
     runs-on: ubuntu-latest
-    name: flake8 Linting
+    name: Ruff Lint
     steps:
       - name: Check Out Source Repository
         uses: actions/checkout@v5
@@ -26,6 +26,4 @@ jobs:
         run: uv sync
 
       - name: Linting
-        uses: py-actions/flake8@v2
-        with:
-          plugins: "flake8-black Flake8-pyproject"
+        run: uv run ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,9 @@ exclude = ["test/**", "docs/**"]
 [dependency-groups]
 dev = [
     "aiohttp>=3.10.11,<4.0.0",
-    "black>=24.8.0,<25.0.0",
-    "flake8>=6.1.0,<7.0.0",
-    "flake8-pyproject>=1.2.3,<2.0.0",
     "mypy>=1.14.1,<1.15.0",
     "pytest>=8.3.4,<9.0.0",
+    "ruff>=0.8.0,<1.0.0",
     "slack-sdk>=3.33.4,<4.0.0",
     "twine>=6.0.1,<7.0.0",
     "wheel>=0.45.1,<1.0.0",
@@ -61,17 +59,27 @@ docs = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.flake8]
-exclude = [".venv", "./build", "./dist", ".eggs", ".git"]
-max-line-length = 100
-extend-ignore = """
-    BLK100
-"""
-per-file-ignores = [
-    "slackblocks/__init__.py:F401",
-    "slackblocks/rich_text/__init__.py:F401",
-    "slackblocks/rich_text/objects.py:W605",
-]
+[tool.ruff]
+line-length = 100
+exclude = [".venv", "build", "dist", ".eggs", ".git"]
+
+[tool.ruff.lint]
+# Mirror the previous flake8 + flake8-black behavior. Start conservatively:
+# pycodestyle (E,W) + pyflakes (F). Additional rule families (UP, B, SIM, I, TCH)
+# can be enabled in a follow-up PR with their own targeted code changes.
+select = ["E", "F", "W"]
+# E501 (line-too-long) is handled by the formatter; don't lint it. Long lines
+# in docstrings (e.g. Slack API URLs) can't be wrapped without breaking
+# Markdown link rendering.
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"slackblocks/__init__.py" = ["F401"]
+"slackblocks/rich_text/__init__.py" = ["F401"]
+"slackblocks/rich_text/objects.py" = ["W605"]
+
+[tool.ruff.format]
+# Black-compatible defaults; no overrides needed.
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/slackblocks/attachments.py
+++ b/slackblocks/attachments.py
@@ -176,9 +176,7 @@ class Attachment:
             elif len(color) == 6 and is_hex(color):
                 self.color = f"#{color}"
             else:
-                raise InvalidUsageError(
-                    "Color must be a valid hex code (e.g. `#ffffff`)"
-                )
+                raise InvalidUsageError("Color must be a valid hex code (e.g. `#ffffff`)")
         else:
             self.color = None
 

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -177,10 +177,7 @@ class ContextBlock(Block):
         self.elements = []
         if elements is not None:
             for element in elements:
-                if (
-                    element.type == CompositionObjectType.TEXT
-                    or element.type == ElementType.IMAGE
-                ):
+                if element.type == CompositionObjectType.TEXT or element.type == ElementType.IMAGE:
                     self.elements.append(element)
                 else:
                     raise InvalidUsageError(
@@ -290,9 +287,7 @@ class ImageBlock(Block):
             field_name="title",
             max_length=3000,
         )
-        self.alt_text = validate_string(
-            alt_text, field_name="alt_text", max_length=2000
-        )
+        self.alt_text = validate_string(alt_text, field_name="alt_text", max_length=2000)
         if title and isinstance(title, Text):
             if title.text_type == TextType.MARKDOWN:
                 # Coerce title into plaintext
@@ -347,18 +342,14 @@ class InputBlock(Block):
         optional: bool = False,
     ) -> None:
         super().__init__(type_=BlockType.INPUT, block_id=block_id)
-        self.label = Text.to_text(
-            label, force_plaintext=True, max_length=2000, allow_none=False
-        )
+        self.label = Text.to_text(label, force_plaintext=True, max_length=2000, allow_none=False)
         if not isinstance(element, ALLOWED_INPUT_ELEMENTS):
             raise InvalidUsageError(
                 f"InputBlocks can only hold elements of type: {ALLOWED_INPUT_ELEMENTS}"
             )
         self.element = element
         self.dispatch_action = dispatch_action
-        self.hint = Text.to_text(
-            hint, force_plaintext=True, max_length=2000, allow_none=True
-        )
+        self.hint = Text.to_text(hint, force_plaintext=True, max_length=2000, allow_none=True)
         self.optional = optional
 
     def _resolve(self) -> Dict[str, Any]:
@@ -416,9 +407,7 @@ class RichTextBlock(Block):
     def _resolve(self) -> Dict[str, Any]:
         rich_text_block: Dict[str, Any] = self._attributes()
         if self.elements is not None:
-            rich_text_block["elements"] = [
-                element._resolve() for element in self.elements
-            ]
+            rich_text_block["elements"] = [element._resolve() for element in self.elements]
         return rich_text_block
 
 
@@ -461,18 +450,14 @@ class SectionBlock(Block):
         self.text = Text.to_text(text, max_length=3000, allow_none=True)
         self.fields: Optional[List[Text]]
         if fields is not None:
-            field_list: List[Union[str, Text]] = coerce_to_list_nonnull(
-                fields, class_=(str, Text)
-            )
+            field_list: List[Union[str, Text]] = coerce_to_list_nonnull(fields, class_=(str, Text))
             self.fields = [
                 Text.to_text_nonnull(field, max_length=2000)
                 for field in field_list
                 if field is not None
             ]
             if len(self.fields) > 10:
-                raise InvalidUsageError(
-                    "Section blocks can hold a maximum of ten fields"
-                )
+                raise InvalidUsageError("Section blocks can hold a maximum of ten fields")
         else:
             self.fields = None
 
@@ -523,9 +508,7 @@ class TableBlock(Block):
         num_columns = len(rows[0])
         for row in rows:
             if len(row) != num_columns:
-                raise InvalidUsageError(
-                    "All rows must have the same number of columns."
-                )
+                raise InvalidUsageError("All rows must have the same number of columns.")
         if column_settings is not None:
             if num_columns != len(column_settings):
                 raise InvalidUsageError(
@@ -555,13 +538,9 @@ class TableBlock(Block):
 
     def _resolve(self) -> Dict[str, Any]:
         table = self._attributes()
-        table["rows"] = [
-            [self._resolve_cell(cell) for cell in row] for row in self.rows
-        ]
+        table["rows"] = [[self._resolve_cell(cell) for cell in row] for row in self.rows]
         if self.column_settings:
-            table["column_settings"] = [
-                setting._resolve() for setting in self.column_settings
-            ]
+            table["column_settings"] = [setting._resolve() for setting in self.column_settings]
         return table
 
     def _resolve_cell(self, cell: Union[RawText, RichTextObject]) -> Dict[str, Any]:

--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -121,9 +121,7 @@ class Button(Element):
         super().__init__(type_=ElementType.BUTTON)
         self.text = Text.to_text(text, max_length=75, force_plaintext=True)
         self.action_id = validate_action_id(action_id)
-        self.url = validate_string(
-            url, field_name="url", max_length=3000, allow_none=True
-        )
+        self.url = validate_string(url, field_name="url", max_length=3000, allow_none=True)
         self.value = validate_string(
             value,
             field_name="value",
@@ -252,9 +250,7 @@ class DatePicker(Element):
         self.action_id = validate_action_id(action_id)
         self.initial_date: Optional[str] = None
         if initial_date:
-            self.initial_date = datetime.strptime(initial_date, "%Y-%m-%d").strftime(
-                "%Y-%m-%d"
-            )
+            self.initial_date = datetime.strptime(initial_date, "%Y-%m-%d").strftime("%Y-%m-%d")
         self.confirm = confirm
         self.focus_on_load = focus_on_load
         self.placeholder = Text.to_text(
@@ -364,9 +360,7 @@ class EmailInput(Element):
         if self.initial_value:
             email_input["initial_value"] = self.initial_value
         if self.dispatch_action_config:
-            email_input["dispatch_action_config"] = (
-                self.dispatch_action_config._resolve()
-            )
+            email_input["dispatch_action_config"] = self.dispatch_action_config._resolve()
         if self.focus_on_load:
             email_input["focus_on_load"] = self.focus_on_load
         if self.placeholder:
@@ -404,9 +398,7 @@ class FileInput(Element):
             (str),
             allow_none=True,
         )
-        self.max_files = validate_int(
-            max_files, min_value=1, max_value=10, allow_none=True
-        )
+        self.max_files = validate_int(max_files, min_value=1, max_value=10, allow_none=True)
 
     def _resolve(self) -> Dict[str, Any]:
         file_input: Dict[str, Any] = {}
@@ -512,12 +504,8 @@ class StaticMultiSelectMenu(Element):
         super().__init__(type_=ElementType.MULTI_SELECT_STATIC)
         self.action_id = validate_action_id(action_id)
         if options and option_groups:
-            raise InvalidUsageError(
-                "Cannot set both `options` and `option_groups` parameters."
-            )
-        self.options = coerce_to_list(
-            options, class_=Option, allow_none=True, max_size=100
-        )
+            raise InvalidUsageError("Cannot set both `options` and `option_groups` parameters.")
+        self.options = coerce_to_list(options, class_=Option, allow_none=True, max_size=100)
         self.option_groups = coerce_to_list(
             option_groups, class_=OptionGroup, allow_none=True, max_size=100
         )
@@ -539,9 +527,7 @@ class StaticMultiSelectMenu(Element):
         if (
             option_groups
             and self.initial_options
-            and not all(
-                isinstance(option, OptionGroup) for option in self.initial_options
-            )
+            and not all(isinstance(option, OptionGroup) for option in self.initial_options)
         ):
             raise InvalidUsageError(
                 "If using `option_groups` then `initial_options` must also be of type "
@@ -554,9 +540,7 @@ class StaticMultiSelectMenu(Element):
             options_to_validate = self.options
         if self.option_groups:
             options_to_validate = list(
-                chain.from_iterable(
-                    option_group.options for option_group in self.option_groups
-                )
+                chain.from_iterable(option_group.options for option_group in self.option_groups)
             )
         for option in options_to_validate:
             if option.text.text_type == TextType.MARKDOWN:
@@ -575,9 +559,7 @@ class StaticMultiSelectMenu(Element):
         static_multi_select = self._attributes()
         static_multi_select["action_id"] = self.action_id
         if self.options:
-            static_multi_select["options"] = [
-                option._resolve() for option in self.options
-            ]
+            static_multi_select["options"] = [option._resolve() for option in self.options]
         if self.option_groups:
             static_multi_select["option_groups"] = [
                 option_group._resolve() for option_group in self.option_groups
@@ -791,9 +773,7 @@ class ConversationMultiSelectMenu(Element):
         conversation_multi_select = self._attributes()
         conversation_multi_select["action_id"] = self.action_id
         if self.initial_conversations:
-            conversation_multi_select["initial_conversations"] = (
-                self.initial_conversations
-            )
+            conversation_multi_select["initial_conversations"] = self.initial_conversations
         if self.default_to_current_conversation:
             conversation_multi_select["default_to_current_conversation"] = (
                 self.default_to_current_conversation
@@ -931,8 +911,7 @@ class NumberInput(Element):
         if min_value is not None and max_value is not None:
             if min_value > max_value:
                 raise InvalidUsageError(
-                    f"`min_value` ({min_value}) cannot be greater than "
-                    f"`max_value` ({max_value})"
+                    f"`min_value` ({min_value}) cannot be greater than `max_value` ({max_value})"
                 )
         self.dispatch_action_config = dispatch_action_config
         self.focus_on_load = focus_on_load
@@ -952,9 +931,7 @@ class NumberInput(Element):
         if self.max_value is not None:
             number_input["max_value"] = self.max_value
         if self.dispatch_action_config:
-            number_input["dispatch_action_config"] = (
-                self.dispatch_action_config._resolve()
-            )
+            number_input["dispatch_action_config"] = self.dispatch_action_config._resolve()
         if self.focus_on_load:
             number_input["focus_on_load"] = self.focus_on_load
         if self.placeholder:
@@ -1067,9 +1044,7 @@ class PlainTextInput(Element):
         if self.max_length:
             plain_text_input["max_length"] = self.max_length
         if self.dispatch_action_config:
-            plain_text_input["dispatch_action_config"] = (
-                self.dispatch_action_config._resolve()
-            )
+            plain_text_input["dispatch_action_config"] = self.dispatch_action_config._resolve()
         if self.focus_on_load:
             plain_text_input["focus_on_load"] = self.focus_on_load
         if self.placeholder:
@@ -1127,9 +1102,7 @@ class RadioButtonGroup(Element):
         radio_button_group = self._attributes()
         radio_button_group["action_id"] = self.action_id
         if self.options is not None:
-            radio_button_group["options"] = [
-                option._resolve() for option in self.options
-            ]
+            radio_button_group["options"] = [option._resolve() for option in self.options]
         if self.initial_option:
             radio_button_group["initial_option"] = self.initial_option._resolve()
         if self.confirm:
@@ -1182,9 +1155,7 @@ class StaticSelectMenu(Element):
         super().__init__(type_=ElementType.STATIC_SELECT_MENU)
         self.action_id = validate_action_id(action_id)
         if options and option_groups:
-            raise InvalidUsageError(
-                "Cannot set both `options` and `option_groups` parameters."
-            )
+            raise InvalidUsageError("Cannot set both `options` and `option_groups` parameters.")
         self.options: Optional[List[Option]] = coerce_to_list(
             options, class_=Option, allow_none=True, max_size=100
         )
@@ -1196,11 +1167,7 @@ class StaticSelectMenu(Element):
                 "If using `options` then `initial_option` must also be of type `Option`, "
                 f"not `{type(initial_option)}`."
             )
-        if (
-            option_groups
-            and initial_option
-            and not isinstance(initial_option, OptionGroup)
-        ):
+        if option_groups and initial_option and not isinstance(initial_option, OptionGroup):
             raise InvalidUsageError(
                 "If using `option_groups` then `initial_option` must also be of type "
                 f"`OptionGroup`, not `{type(initial_option)}`."
@@ -1212,9 +1179,7 @@ class StaticSelectMenu(Element):
             options_to_validate = self.options
         if self.option_groups:
             options_to_validate = list(
-                chain.from_iterable(
-                    option_group.options for option_group in self.option_groups
-                )
+                chain.from_iterable(option_group.options for option_group in self.option_groups)
             )
         for option in options_to_validate:
             if option.text.text_type == TextType.MARKDOWN:
@@ -1233,9 +1198,7 @@ class StaticSelectMenu(Element):
         static_select_menu = self._attributes()
         static_select_menu["action_id"] = self.action_id
         if self.options:
-            static_select_menu["options"] = [
-                option._resolve() for option in self.options
-            ]
+            static_select_menu["options"] = [option._resolve() for option in self.options]
         if self.option_groups:
             static_select_menu["option_groups"] = [
                 option_group._resolve() for option_group in self.option_groups
@@ -1256,7 +1219,7 @@ class ExternalSelectMenu(Element):
     A select menu interactive UI element, sourced with externally provided options.
 
     See:
-        <https://api.slack.com/slackblocks/latest/reference/block-kit/block-elements#external_select>. # noqa: E501
+        <https://api.slack.com/slackblocks/latest/reference/block-kit/block-elements#external_select>.
 
     Args:
         action_id: an identifier so the source of the action can be known.
@@ -1743,9 +1706,7 @@ class RichTextInput(Element):
         if self.initial_value is not None:
             rich_text_input["initial_value"] = self.initial_value._resolve()
         if self.dispatch_action_config is not None:
-            rich_text_input["dispatch_action_config"] = (
-                self.dispatch_action_config._resolve()
-            )
+            rich_text_input["dispatch_action_config"] = self.dispatch_action_config._resolve()
         if self.focus_on_load is not None:
             rich_text_input["focus_on_load"] = self.focus_on_load
         if self.placeholder is not None:

--- a/slackblocks/messages.py
+++ b/slackblocks/messages.py
@@ -29,9 +29,7 @@ class ResponseType(Enum):
         if isinstance(value, ResponseType):
             return value.value
         if value not in [response_type.value for response_type in ResponseType]:
-            raise InvalidUsageError(
-                "ResponseType must be either `ephemeral` or `in_channel`"
-            )
+            raise InvalidUsageError("ResponseType must be either `ephemeral` or `in_channel`")
         return value
 
 
@@ -53,9 +51,7 @@ class BaseMessage:
         self.blocks = coerce_to_list(blocks, class_=Block, allow_none=True)
         self.channel = channel
         self.text = text
-        self.attachments = coerce_to_list(
-            attachments, class_=Attachment, allow_none=True
-        )
+        self.attachments = coerce_to_list(attachments, class_=Attachment, allow_none=True)
         self.thread_ts = thread_ts
         self.mrkdwn = mrkdwn
 
@@ -67,9 +63,7 @@ class BaseMessage:
         if self.blocks:
             message["blocks"] = [block._resolve() for block in self.blocks]
         if self.attachments:
-            message["attachments"] = [
-                attachment._resolve() for attachment in self.attachments
-            ]
+            message["attachments"] = [attachment._resolve() for attachment in self.attachments]
         if self.thread_ts:
             message["thread_ts"] = self.thread_ts
         if self.text or self.text == "":
@@ -229,9 +223,7 @@ class WebhookMessage:
         self.attachments: Optional[List[Attachment]] = coerce_to_list(
             attachments, Attachment, allow_none=True
         )
-        self.blocks: Optional[List[Block]] = coerce_to_list(
-            blocks, Block, allow_none=True
-        )
+        self.blocks: Optional[List[Block]] = coerce_to_list(blocks, Block, allow_none=True)
         self.response_type = (
             ResponseType.get_value(response_type) if response_type is not None else None
         )
@@ -248,9 +240,7 @@ class WebhookMessage:
             webhook_message["text"] = self.text
         if self.attachments is not None:
             webhook_message["attachments"] = [
-                attachment._resolve()
-                for attachment in self.attachments
-                if attachment is not None
+                attachment._resolve() for attachment in self.attachments if attachment is not None
             ]
         if self.blocks is not None:
             webhook_message["blocks"] = [

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -99,9 +99,7 @@ class Text(CompositionObject):
     ) -> None:
         super().__init__(type_=CompositionObjectType.TEXT)
         self.text_type = type_
-        self.text = validate_string_nonnull(
-            text, field_name="text", min_length=1, max_length=3000
-        )
+        self.text = validate_string_nonnull(text, field_name="text", min_length=1, max_length=3000)
         if self.text_type == TextType.MARKDOWN:
             self.verbatim = verbatim
             self.emoji = False
@@ -170,11 +168,7 @@ class Text(CompositionObject):
             InvalidUsageError: if the text length exceeds the specified max_length.
         """
         original_type = text.text_type if isinstance(text, Text) else None
-        type_ = (
-            TextType.PLAINTEXT
-            if force_plaintext
-            else original_type or TextType.MARKDOWN
-        )
+        type_ = TextType.PLAINTEXT if force_plaintext else original_type or TextType.MARKDOWN
         if text and max_length and len(text) > max_length:
             raise InvalidUsageError(
                 f"`text` length ({len(text)}) exceeds `max_length` ({max_length})"
@@ -182,9 +176,7 @@ class Text(CompositionObject):
         if isinstance(text, str):
             return Text(text=text, type_=type_)
         elif isinstance(text, Text):
-            return Text(
-                text=text.text, type_=type_, emoji=text.emoji, verbatim=text.verbatim
-            )
+            return Text(text=text.text, type_=type_, emoji=text.emoji, verbatim=text.verbatim)
         else:
             raise InvalidUsageError("This field must be a string or Text object")
 
@@ -234,9 +226,7 @@ class ConfirmationDialogue(CompositionObject):
         super().__init__(type_=CompositionObjectType.CONFIRM)
         self.title = Text.to_text_nonnull(title, max_length=100, force_plaintext=True)
         self.text = Text.to_text_nonnull(text, max_length=300)
-        self.confirm = Text.to_text_nonnull(
-            confirm, max_length=30, force_plaintext=True
-        )
+        self.confirm = Text.to_text_nonnull(confirm, max_length=30, force_plaintext=True)
         self.deny = Text.to_text_nonnull(deny, max_length=30, force_plaintext=True)
 
     def _resolve(self) -> Dict[str, Any]:
@@ -365,9 +355,7 @@ class DispatchActionConfiguration(CompositionObject):
             `trigger_actions_on`.
     """
 
-    def __init__(
-        self, trigger_actions_on: Optional[Union[str, List[str]]] = None
-    ) -> None:
+    def __init__(self, trigger_actions_on: Optional[Union[str, List[str]]] = None) -> None:
         super().__init__(type_=CompositionObjectType.DISPATCH)
         trigger_actions_on = trigger_actions_on or []
         self.trigger_actions_on = list(
@@ -414,9 +402,7 @@ class ConversationFilter(CompositionObject):
     ) -> None:
         super().__init__(type_=CompositionObjectType.FILTER)
         if not (
-            include
-            or exclude_external_shared_channels is not None
-            or exclude_bot_users is not None
+            include or exclude_external_shared_channels is not None or exclude_bot_users is not None
         ):
             raise InvalidUsageError(
                 "One of `include`, `exclude_external_shared_channels`, or "
@@ -431,9 +417,7 @@ class ConversationFilter(CompositionObject):
         if self.include:
             filter["include"] = self.include
         if self.exclude_external_shared_channels is not None:
-            filter["exclude_external_shared_channels"] = (
-                self.exclude_external_shared_channels
-            )
+            filter["exclude_external_shared_channels"] = self.exclude_external_shared_channels
         if self.exclude_bot_users is not None:
             filter["exclude_bot_users"] = self.exclude_bot_users
         return filter
@@ -522,9 +506,7 @@ class Trigger(CompositionObject):
     def __init__(
         self,
         url: str,
-        customizable_input_parameters: Optional[
-            Union[InputParameter, List[InputParameter]]
-        ],
+        customizable_input_parameters: Optional[Union[InputParameter, List[InputParameter]]],
     ) -> None:
         super().__init__(type_=CompositionObjectType.TRIGGER)
         self.url = url
@@ -610,9 +592,7 @@ class ColumnSettings:
         is_wrapped: Optional[bool] = None,
     ) -> None:
         if align and align not in ["left", "center", "right"]:
-            raise InvalidUsageError(
-                "`align` must be one of `left`, `center`, or `right`"
-            )
+            raise InvalidUsageError("`align` must be one of `left`, `center`, or `right`")
         self.align = align
         self.is_wrapped = is_wrapped
 

--- a/slackblocks/utils.py
+++ b/slackblocks/utils.py
@@ -109,9 +109,7 @@ def is_hex(string: str) -> bool:
     return all(char in hexdigits for char in string)
 
 
-def validate_action_id(
-    action_id: Optional[str], allow_none: bool = False
-) -> Optional[str]:
+def validate_action_id(action_id: Optional[str], allow_none: bool = False) -> Optional[str]:
     """
     Action IDs are used in the handing of user interactivity within Slack blocks.
     This function checks that a given `action_id` is valid as per the requirements
@@ -169,9 +167,7 @@ def validate_string(
     """
     if string is None:
         if not allow_none:
-            raise InvalidUsageError(
-                f"Expecting string for field `{field_name}`, cannot be None."
-            )
+            raise InvalidUsageError(f"Expecting string for field `{field_name}`, cannot be None.")
         return None
     return validate_string_nonnull(
         string, field_name=field_name, max_length=max_length, min_length=min_length

--- a/slackblocks/views.py
+++ b/slackblocks/views.py
@@ -111,12 +111,8 @@ class ModalView(View):
             external_id=external_id,
         )
         self.title = Text.to_text_nonnull(title, force_plaintext=True, max_length=24)
-        self.close = Text.to_text(
-            close, force_plaintext=True, max_length=24, allow_none=True
-        )
-        self.submit = Text.to_text(
-            submit, force_plaintext=True, max_length=24, allow_none=True
-        )
+        self.close = Text.to_text(close, force_plaintext=True, max_length=24, allow_none=True)
+        self.submit = Text.to_text(submit, force_plaintext=True, max_length=24, allow_none=True)
         self.clear_on_close = clear_on_close
         self.notify_on_close = notify_on_close
         self.submit_disabled = submit_disabled

--- a/test/unit/test_attachments.py
+++ b/test/unit/test_attachments.py
@@ -3,9 +3,7 @@ from slackblocks import Attachment, Color, SectionBlock
 
 def test_single_attachment() -> None:
     block = SectionBlock("I like pretty colours", block_id="fake_block_id")
-    attachment = Attachment(
-        blocks=block, color=Color.BLACK, fallback="Colours preference"
-    )
+    attachment = Attachment(blocks=block, color=Color.BLACK, fallback="Colours preference")
     with open("test/samples/attachments/attachment_simple.json", "r") as expected:
         assert repr(attachment) == expected.read()
 

--- a/test/unit/test_blocks.py
+++ b/test/unit/test_blocks.py
@@ -31,9 +31,7 @@ from .utils import fetch_sample
 
 def test_basic_section_block() -> None:
     block = SectionBlock("Hello, world!", block_id="fake_block_id")
-    assert fetch_sample(
-        path="test/samples/blocks/section_block_text_only.json"
-    ) == repr(block)
+    assert fetch_sample(path="test/samples/blocks/section_block_text_only.json") == repr(block)
 
 
 def test_basic_section_fields() -> None:
@@ -42,9 +40,7 @@ def test_basic_section_fields() -> None:
         fields=[Text(text="foo", type_=TextType.PLAINTEXT), Text(text="bar")],
         block_id="fake_block_id",
     )
-    assert fetch_sample(path="test/samples/blocks/section_block_fields.json") == repr(
-        block
-    )
+    assert fetch_sample(path="test/samples/blocks/section_block_fields.json") == repr(block)
 
 
 def test_section_empty_text_field_value() -> None:
@@ -98,23 +94,19 @@ def test_section_both_text_and_fields() -> None:
             Text("There?", type_=TextType.PLAINTEXT, emoji=True),
         ],
     )
-    assert fetch_sample(
-        path="test/samples/blocks/section_block_both_text_and_fields.json"
-    ) == repr(block)
+    assert fetch_sample(path="test/samples/blocks/section_block_both_text_and_fields.json") == repr(
+        block
+    )
 
 
 def test_basic_context_block() -> None:
     block = ContextBlock(elements=[Text("Hello, world!")], block_id="fake_block_id")
-    assert fetch_sample(
-        path="test/samples/blocks/context_block_text_only.json"
-    ) == repr(block)
+    assert fetch_sample(path="test/samples/blocks/context_block_text_only.json") == repr(block)
 
 
 def test_basic_divider_block() -> None:
     block = DividerBlock(block_id="fake_block_id")
-    assert fetch_sample(path="test/samples/blocks/divider_block_only.json") == repr(
-        block
-    )
+    assert fetch_sample(path="test/samples/blocks/divider_block_only.json") == repr(block)
 
 
 def test_basic_image_block() -> None:
@@ -129,9 +121,7 @@ def test_basic_image_block() -> None:
 
 def test_basic_header_block() -> None:
     block = HeaderBlock(text="AloHa!", block_id="fake_block_id")
-    assert fetch_sample(path="test/samples/blocks/header_block_only.json") == repr(
-        block
-    )
+    assert fetch_sample(path="test/samples/blocks/header_block_only.json") == repr(block)
 
 
 def test_checkbox_action_block() -> None:
@@ -144,9 +134,7 @@ def test_checkbox_action_block() -> None:
         block_id="fake_block_id",
         elements=CheckboxGroup(action_id="actionId-0", options=options),
     )
-    assert fetch_sample(
-        path="test/samples/blocks/actions_block_checkboxes.json"
-    ) == repr(block)
+    assert fetch_sample(path="test/samples/blocks/actions_block_checkboxes.json") == repr(block)
 
 
 def test_basic_input_block() -> None:

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -53,9 +53,7 @@ def test_button_basic() -> None:
 
 def test_button_link() -> None:
     link_button = Button(text="Link!", url="https://ndl.im/", action_id="button")
-    assert fetch_sample(path="test/samples/elements/button_link.json") == repr(
-        link_button
-    )
+    assert fetch_sample(path="test/samples/elements/button_link.json") == repr(link_button)
 
 
 def test_button_style() -> None:
@@ -65,27 +63,21 @@ def test_button_style() -> None:
         value="im_a_style_button",
         action_id="button",
     )
-    assert fetch_sample(path="test/samples/elements/button_style.json") == repr(
-        style_button
-    )
+    assert fetch_sample(path="test/samples/elements/button_style.json") == repr(style_button)
 
 
 def test_checkbox_basic() -> None:
     checkbox = CheckboxGroup(
         options=TWO_OPTIONS, action_id="and...action", initial_options=OPTION_A
     )
-    assert fetch_sample(path="test/samples/elements/checkbox_basic.json") == repr(
-        checkbox
-    )
+    assert fetch_sample(path="test/samples/elements/checkbox_basic.json") == repr(checkbox)
 
 
 def test_datepicker_basic() -> None:
     datepicker = DatePicker(
         action_id="datepicker", initial_date="1970-01-01", placeholder="Pick a date"
     )
-    assert fetch_sample(path="test/samples/elements/date_picker_basic.json") == repr(
-        datepicker
-    )
+    assert fetch_sample(path="test/samples/elements/date_picker_basic.json") == repr(datepicker)
 
 
 def test_datepicker_without_initial_date() -> None:
@@ -119,12 +111,10 @@ def test_datepicker_with_confirm_resolves() -> None:
 
 
 def test_datetime_picker_basic() -> None:
-    datetime_picker = DateTimePicker(
-        action_id="datetime_picker", initial_datetime=1628633830
+    datetime_picker = DateTimePicker(action_id="datetime_picker", initial_datetime=1628633830)
+    assert fetch_sample(path="test/samples/elements/datetime_picker_basic.json") == repr(
+        datetime_picker
     )
-    assert fetch_sample(
-        path="test/samples/elements/datetime_picker_basic.json"
-    ) == repr(datetime_picker)
 
 
 def test_datetime_picker_without_initial_datetime() -> None:
@@ -159,9 +149,7 @@ def test_datetime_picker_with_confirm_resolves() -> None:
 
 def test_email_input_basic() -> None:
     email_input = EmailInput(action_id="email_input", placeholder="Enter your email")
-    assert fetch_sample(path="test/samples/elements/email_input_basic.json") == repr(
-        email_input
-    )
+    assert fetch_sample(path="test/samples/elements/email_input_basic.json") == repr(email_input)
 
 
 def test_image_basic() -> None:
@@ -199,9 +187,9 @@ def test_multi_select_conversation() -> None:
         action_id="multi_conversations_select",
         placeholder=Text("Select conversations", type_=TextType.PLAINTEXT),
     )
-    assert fetch_sample(
-        path="test/samples/elements/multi_select_conversation.json"
-    ) == repr(multi_select_conversation)
+    assert fetch_sample(path="test/samples/elements/multi_select_conversation.json") == repr(
+        multi_select_conversation
+    )
 
 
 def test_multi_select_conversation_initial_conversations_key() -> None:
@@ -224,9 +212,9 @@ def test_multi_select_external() -> None:
         placeholder=Text("Select items", type_=TextType.PLAINTEXT),
         min_query_length=3,
     )
-    assert fetch_sample(
-        path="test/samples/elements/multi_select_external.json"
-    ) == repr(multi_select_external)
+    assert fetch_sample(path="test/samples/elements/multi_select_external.json") == repr(
+        multi_select_external
+    )
 
 
 def test_multi_select_static() -> None:
@@ -245,8 +233,7 @@ def test_multi_select_static_invalid_option() -> None:
         StaticMultiSelectMenu(
             action_id="multi_static_select",
             placeholder=Text("Select one or more", type_=TextType.PLAINTEXT),
-            options=TWO_OPTIONS
-            + [Option(text=Text("C", type_=TextType.MARKDOWN), value="X")],
+            options=TWO_OPTIONS + [Option(text=Text("C", type_=TextType.MARKDOWN), value="X")],
         )
 
 
@@ -290,9 +277,7 @@ def test_static_multi_select_with_option_groups_validates_text() -> None:
                 OptionGroup(label="Group 1", options=TWO_OPTIONS),
                 OptionGroup(
                     label="Group 2",
-                    options=[
-                        Option(text=Text("Bad", type_=TextType.MARKDOWN), value="bad")
-                    ],
+                    options=[Option(text=Text("Bad", type_=TextType.MARKDOWN), value="bad")],
                 ),
             ],
         )
@@ -321,9 +306,7 @@ def test_multi_select_user_with_initial_users() -> None:
 
 def test_number_input_basic() -> None:
     number_input = NumberInput(action_id="number_input", is_decimal_allowed=False)
-    assert fetch_sample(path="test/samples/elements/number_input_basic.json") == repr(
-        number_input
-    )
+    assert fetch_sample(path="test/samples/elements/number_input_basic.json") == repr(number_input)
 
 
 def test_number_input_zero_min_value_emitted() -> None:
@@ -365,18 +348,18 @@ def test_plaintext_input_menu_basic() -> None:
     plaintext_input = PlainTextInput(
         action_id="plaintext_input", placeholder="Enter your plain text"
     )
-    assert fetch_sample(
-        path="test/samples/elements/plaintext_input_basic.json"
-    ) == repr(plaintext_input)
+    assert fetch_sample(path="test/samples/elements/plaintext_input_basic.json") == repr(
+        plaintext_input
+    )
 
 
 def test_radio_button_group_basic() -> None:
     radio_button_group = RadioButtonGroup(
         action_id="radio_buttons", initial_option=OPTION_A, options=THREE_OPTIONS
     )
-    assert fetch_sample(
-        path="test/samples/elements/radio_button_group_basic.json"
-    ) == repr(radio_button_group)
+    assert fetch_sample(path="test/samples/elements/radio_button_group_basic.json") == repr(
+        radio_button_group
+    )
 
 
 def test_select_menu_channel() -> None:
@@ -392,9 +375,9 @@ def test_select_menu_conversation() -> None:
     select_menu_conversation = ConversationSelectMenu(
         action_id="conversations_select", placeholder="Select one conversation"
     )
-    assert fetch_sample(
-        path="test/samples/elements/select_menu_conversation.json"
-    ) == repr(select_menu_conversation)
+    assert fetch_sample(path="test/samples/elements/select_menu_conversation.json") == repr(
+        select_menu_conversation
+    )
 
 
 def test_conversation_select_menu_with_filter_resolves() -> None:
@@ -438,15 +421,12 @@ def test_select_menu_static_invalid_option() -> None:
         StaticSelectMenu(
             action_id="static_select",
             placeholder="Select one item",
-            options=THREE_OPTIONS
-            + [Option(text=Text("C", type_=TextType.MARKDOWN), value="X")],
+            options=THREE_OPTIONS + [Option(text=Text("C", type_=TextType.MARKDOWN), value="X")],
         )
 
 
 def test_select_menu_user() -> None:
-    select_menu_user = UserSelectMenu(
-        action_id="users_select", placeholder="Select one user"
-    )
+    select_menu_user = UserSelectMenu(action_id="users_select", placeholder="Select one user")
     assert fetch_sample(path="test/samples/elements/select_menu_user.json") == repr(
         select_menu_user
     )
@@ -459,9 +439,7 @@ def test_timepicker_basic() -> None:
         initial_time="12:00",
         placeholder="Select your time",
     )
-    assert fetch_sample(path="test/samples/elements/timepicker_basic.json") == repr(
-        timepicker
-    )
+    assert fetch_sample(path="test/samples/elements/timepicker_basic.json") == repr(timepicker)
 
 
 def test_timepicker_with_confirm_resolves() -> None:
@@ -485,9 +463,7 @@ def test_timepicker_with_confirm_resolves() -> None:
 
 def test_url_input_basic() -> None:
     url_input = URLInput(action_id="url_text_input")
-    assert fetch_sample(path="test/samples/elements/url_input_basic.json") == repr(
-        url_input
-    )
+    assert fetch_sample(path="test/samples/elements/url_input_basic.json") == repr(url_input)
 
 
 def test_url_input_with_placeholder_resolves() -> None:
@@ -520,15 +496,13 @@ def test_workflow_button_basic() -> None:
             )
         ),
     )
-    assert fetch_sample(
-        path="test/samples/elements/workflow_button_basic.json"
-    ) == repr(workflow_button)
+    assert fetch_sample(path="test/samples/elements/workflow_button_basic.json") == repr(
+        workflow_button
+    )
 
 
 def test_rich_text_input_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/elements/rich_text_input_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/elements/rich_text_input_basic.json") == repr(
         RichTextInput(
             action_id="action_id",
             initial_value=RichText("I'm rich"),
@@ -547,13 +521,9 @@ def test_rich_text_input_dispatch_action_config_resolves() -> None:
     rich_text_input = RichTextInput(
         action_id="rt",
         placeholder="Type something",
-        dispatch_action_config=DispatchActionConfiguration(
-            trigger_actions_on=["on_enter_pressed"]
-        ),
+        dispatch_action_config=DispatchActionConfiguration(trigger_actions_on=["on_enter_pressed"]),
     )
     resolved = rich_text_input._resolve()
     dumps(resolved)
-    assert resolved["dispatch_action_config"] == {
-        "trigger_actions_on": ["on_enter_pressed"]
-    }
+    assert resolved["dispatch_action_config"] == {"trigger_actions_on": ["on_enter_pressed"]}
     assert resolved["placeholder"] == {"type": "plain_text", "text": "Type something"}

--- a/test/unit/test_messages.py
+++ b/test/unit/test_messages.py
@@ -25,9 +25,7 @@ def test_message_with_optional_arguments() -> None:
         unfurl_links=False,
         unfurl_media=False,
     )
-    with open(
-        "test/samples/messages/message_with_optional_arguments.json", "r"
-    ) as expected:
+    with open("test/samples/messages/message_with_optional_arguments.json", "r") as expected:
         assert repr(message) == expected.read()
 
 

--- a/test/unit/test_objects.py
+++ b/test/unit/test_objects.py
@@ -45,9 +45,9 @@ def test_text_plaintext_emoji() -> None:
 
 
 def test_text_markdown_verbatim() -> None:
-    assert fetch_sample(
-        path="test/samples/objects/text_markdown_verbatim.json"
-    ) == repr(Text(text="hi", type_=TextType.MARKDOWN, verbatim=True))
+    assert fetch_sample(path="test/samples/objects/text_markdown_verbatim.json") == repr(
+        Text(text="hi", type_=TextType.MARKDOWN, verbatim=True)
+    )
 
 
 def test_text_coerce_from_string() -> None:
@@ -88,9 +88,9 @@ def test_confirmation_dialogue_basic() -> None:
         confirm=Text("Yes", type_=TextType.PLAINTEXT),
         deny=Text("Nope!", type_=TextType.PLAINTEXT),
     )
-    assert fetch_sample(
-        path="test/samples/objects/confirmation_dialogue_basic.json"
-    ) == repr(confirmation_dialogue)
+    assert fetch_sample(path="test/samples/objects/confirmation_dialogue_basic.json") == repr(
+        confirmation_dialogue
+    )
 
 
 def test_confirm_alias_equivalent_to_confirmation_dialogue() -> None:
@@ -103,9 +103,9 @@ def test_confirm_alias_equivalent_to_confirmation_dialogue() -> None:
         confirm=Text("Yes", type_=TextType.PLAINTEXT),
         deny=Text("Nope!", type_=TextType.PLAINTEXT),
     )
-    assert fetch_sample(
-        path="test/samples/objects/confirmation_dialogue_basic.json"
-    ) == repr(confirm)
+    assert fetch_sample(path="test/samples/objects/confirmation_dialogue_basic.json") == repr(
+        confirm
+    )
 
 
 def test_conversation_filter_basic() -> None:
@@ -116,9 +116,9 @@ def test_conversation_filter_basic() -> None:
         ],
         exclude_bot_users=True,
     )
-    assert fetch_sample(
-        path="test/samples/objects/conversation_filter_basic.json"
-    ) == repr(conversation_filter)
+    assert fetch_sample(path="test/samples/objects/conversation_filter_basic.json") == repr(
+        conversation_filter
+    )
 
 
 def test_dispatch_action_config_basic() -> None:
@@ -163,9 +163,7 @@ def test_option_group_basic() -> None:
         label="Group A",
         options=THREE_OPTIONS,
     )
-    assert fetch_sample(path="test/samples/objects/option_group_basic.json") == repr(
-        option_group
-    )
+    assert fetch_sample(path="test/samples/objects/option_group_basic.json") == repr(option_group)
 
 
 def test_trigger_basic() -> None:
@@ -183,6 +181,4 @@ def test_workflow_basic() -> None:
             customizable_input_parameters=INPUT_PARAMETERS,
         )
     )
-    assert fetch_sample(path="test/samples/objects/workflow_basic.json") == repr(
-        workflow
-    )
+    assert fetch_sample(path="test/samples/objects/workflow_basic.json") == repr(workflow)

--- a/test/unit/test_rich_text.py
+++ b/test/unit/test_rich_text.py
@@ -16,9 +16,7 @@ from .utils import fetch_sample
 
 
 def test_rich_text_channel_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_channel_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_channel_basic.json") == repr(
         RichTextChannel(
             channel_id="C0261C65XNY",
             bold=True,
@@ -32,9 +30,7 @@ def test_rich_text_channel_basic() -> None:
 
 
 def test_rich_text_emoji_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_emoji_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_emoji_basic.json") == repr(
         RichTextEmoji(
             name="wave",
         )
@@ -42,9 +38,7 @@ def test_rich_text_emoji_basic() -> None:
 
 
 def test_rich_text_link_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_link_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_link_basic.json") == repr(
         RichTextLink(
             url="https://google.com/",
             text="Google",
@@ -69,9 +63,7 @@ def test_rich_text_basic() -> None:
 
 
 def test_rich_text_user_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_user_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_user_basic.json") == repr(
         RichTextUser(
             user_id="DR36TNNLA",
             bold=True,
@@ -85,9 +77,7 @@ def test_rich_text_user_basic() -> None:
 
 
 def test_rich_text_user_group_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_user_group_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_user_group_basic.json") == repr(
         RichTextUserGroup(
             user_group_id="C01RGRU0RUK",
             bold=True,
@@ -109,9 +99,7 @@ USER_GROUP = "user_group"
 
 
 def test_rich_text_list_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_list_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_list_basic.json") == repr(
         RichTextList(
             elements=[
                 RichTextSection(
@@ -139,9 +127,7 @@ def test_rich_text_list_basic() -> None:
 
 
 def test_rich_text_list_ordered() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_list_ordered.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_list_ordered.json") == repr(
         RichTextList(
             elements=[
                 RichTextSection(
@@ -168,9 +154,7 @@ def test_rich_text_list_ordered() -> None:
 
 
 def test_rich_tex_code_block_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_code_block_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_code_block_basic.json") == repr(
         RichTextCodeBlock(
             elements=[RichText(text="\ndef hello_world():\n    print('hello, world')")],
             border=0,
@@ -179,22 +163,14 @@ def test_rich_tex_code_block_basic() -> None:
 
 
 def test_rich_text_quote_basic() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_quote_basic.json"
-    ) == repr(
-        RichTextQuote(
-            elements=[RichText(text="Great and good are seldom the same man")], border=1
-        ),
+    assert fetch_sample(path="test/samples/rich_text/rich_text_quote_basic.json") == repr(
+        RichTextQuote(elements=[RichText(text="Great and good are seldom the same man")], border=1),
     )
 
 
 def test_rich_text_section() -> None:
-    assert fetch_sample(
-        path="test/samples/rich_text/rich_text_section_basic.json"
-    ) == repr(
+    assert fetch_sample(path="test/samples/rich_text/rich_text_section_basic.json") == repr(
         RichTextSection(
-            elements=[
-                RichText(text="The only true wisdom is in knowing you know nothing")
-            ]
+            elements=[RichText(text="The only true wisdom is in knowing you know nothing")]
         )
     )

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -132,7 +132,4 @@ def test_validate_string_nonnull_positional_arg_order() -> None:
 
 def test_validate_string_nonnull_keyword_args() -> None:
     """validate_string_nonnull continues to accept keyword arguments."""
-    assert (
-        validate_string_nonnull("ok", field_name="x", max_length=10, min_length=1)
-        == "ok"
-    )
+    assert validate_string_nonnull("ok", field_name="x", max_length=10, min_length=1) == "ok"

--- a/uv.lock
+++ b/uv.lock
@@ -434,93 +434,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "24.8.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mypy-extensions", marker = "python_full_version < '3.9'" },
-    { name = "packaging", marker = "python_full_version < '3.9'" },
-    { name = "pathspec", version = "0.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "platformdirs", version = "4.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b0/46fb0d4e00372f4a86a6f8efa3cb193c9f64863615e39010b1477e010578/black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f", size = 644810, upload-time = "2024-08-02T17:43:18.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/6e/74e29edf1fba3887ed7066930a87f698ffdcd52c5dbc263eabb06061672d/black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6", size = 1632092, upload-time = "2024-08-02T17:47:26.911Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/575cb6c3faee690b05c9d11ee2e8dba8fbd6d6c134496e644c1feb1b47da/black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb", size = 1457529, upload-time = "2024-08-02T17:47:29.109Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/b4/d34099e95c437b53d01c4aa37cf93944b233066eb034ccf7897fa4e5f286/black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42", size = 1757443, upload-time = "2024-08-02T17:46:20.306Z" },
-    { url = "https://files.pythonhosted.org/packages/87/a0/6d2e4175ef364b8c4b64f8441ba041ed65c63ea1db2720d61494ac711c15/black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a", size = 1418012, upload-time = "2024-08-02T17:47:20.33Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a6/0a3aa89de9c283556146dc6dbda20cd63a9c94160a6fbdebaf0918e4a3e1/black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1", size = 1615080, upload-time = "2024-08-02T17:48:05.467Z" },
-    { url = "https://files.pythonhosted.org/packages/db/94/b803d810e14588bb297e565821a947c108390a079e21dbdcb9ab6956cd7a/black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af", size = 1438143, upload-time = "2024-08-02T17:47:30.247Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b5/f485e1bbe31f768e2e5210f52ea3f432256201289fd1a3c0afda693776b0/black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4", size = 1738774, upload-time = "2024-08-02T17:46:17.837Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/69/a000fc3736f89d1bdc7f4a879f8aaf516fb03613bb51a0154070383d95d9/black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af", size = 1427503, upload-time = "2024-08-02T17:46:22.654Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/a8/05fb14195cfef32b7c8d4585a44b7499c2a4b205e1662c427b941ed87054/black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368", size = 1646132, upload-time = "2024-08-02T17:49:52.843Z" },
-    { url = "https://files.pythonhosted.org/packages/41/77/8d9ce42673e5cb9988f6df73c1c5c1d4e9e788053cccd7f5fb14ef100982/black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed", size = 1448665, upload-time = "2024-08-02T17:47:54.479Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/94/eff1ddad2ce1d3cc26c162b3693043c6b6b575f538f602f26fe846dfdc75/black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018", size = 1762458, upload-time = "2024-08-02T17:46:19.384Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ea/18b8d86a9ca19a6942e4e16759b2fa5fc02bbc0eb33c1b866fcd387640ab/black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2", size = 1436109, upload-time = "2024-08-02T17:46:52.97Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/d4/ae03761ddecc1a37d7e743b89cccbcf3317479ff4b88cfd8818079f890d0/black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd", size = 1617322, upload-time = "2024-08-02T17:51:20.203Z" },
-    { url = "https://files.pythonhosted.org/packages/14/4b/4dfe67eed7f9b1ddca2ec8e4418ea74f0d1dc84d36ea874d618ffa1af7d4/black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2", size = 1442108, upload-time = "2024-08-02T17:50:40.824Z" },
-    { url = "https://files.pythonhosted.org/packages/97/14/95b3f91f857034686cae0e73006b8391d76a8142d339b42970eaaf0416ea/black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e", size = 1745786, upload-time = "2024-08-02T17:46:02.939Z" },
-    { url = "https://files.pythonhosted.org/packages/95/54/68b8883c8aa258a6dde958cd5bdfada8382bec47c5162f4a01e66d839af1/black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920", size = 1426754, upload-time = "2024-08-02T17:46:38.603Z" },
-    { url = "https://files.pythonhosted.org/packages/13/b2/b3f24fdbb46f0e7ef6238e131f13572ee8279b70f237f221dd168a9dba1a/black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c", size = 1631706, upload-time = "2024-08-02T17:49:57.606Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/35/31010981e4a05202a84a3116423970fd1a59d2eda4ac0b3570fbb7029ddc/black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e", size = 1457429, upload-time = "2024-08-02T17:49:12.764Z" },
-    { url = "https://files.pythonhosted.org/packages/27/25/3f706b4f044dd569a20a4835c3b733dedea38d83d2ee0beb8178a6d44945/black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47", size = 1756488, upload-time = "2024-08-02T17:46:08.067Z" },
-    { url = "https://files.pythonhosted.org/packages/63/72/79375cd8277cbf1c5670914e6bd4c1b15dea2c8f8e906dc21c448d0535f0/black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb", size = 1417721, upload-time = "2024-08-02T17:46:42.637Z" },
-    { url = "https://files.pythonhosted.org/packages/27/1e/83fa8a787180e1632c3d831f7e58994d7aaf23a0961320d21e84f922f919/black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed", size = 206504, upload-time = "2024-08-02T17:43:15.747Z" },
-]
-
-[[package]]
-name = "black"
-version = "24.10.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.10' and python_full_version < '3.15'",
-    "python_full_version > '3.9' and python_full_version < '3.10'",
-    "python_full_version == '3.9'",
-]
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "mypy-extensions", marker = "python_full_version >= '3.9'" },
-    { name = "packaging", marker = "python_full_version >= '3.9'" },
-    { name = "pathspec", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813, upload-time = "2024-10-07T19:20:50.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/f3/465c0eb5cddf7dbbfe1fecd9b875d1dcf51b88923cd2c1d7e9ab95c6336b/black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812", size = 1623211, upload-time = "2024-10-07T19:26:12.43Z" },
-    { url = "https://files.pythonhosted.org/packages/df/57/b6d2da7d200773fdfcc224ffb87052cf283cec4d7102fab450b4a05996d8/black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea", size = 1457139, upload-time = "2024-10-07T19:25:06.453Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c5/9023b7673904a5188f9be81f5e129fff69f51f5515655fbd1d5a4e80a47b/black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f", size = 1753774, upload-time = "2024-10-07T19:23:58.47Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/32/df7f18bd0e724e0d9748829765455d6643ec847b3f87e77456fc99d0edab/black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e", size = 1414209, upload-time = "2024-10-07T19:24:42.54Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/cc/7496bb63a9b06a954d3d0ac9fe7a73f3bf1cd92d7a58877c27f4ad1e9d41/black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad", size = 1607468, upload-time = "2024-10-07T19:26:14.966Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e3/69a738fb5ba18b5422f50b4f143544c664d7da40f09c13969b2fd52900e0/black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50", size = 1437270, upload-time = "2024-10-07T19:25:24.291Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/9b/2db8045b45844665c720dcfe292fdaf2e49825810c0103e1191515fc101a/black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392", size = 1737061, upload-time = "2024-10-07T19:23:52.18Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/95/17d4a09a5be5f8c65aa4a361444d95edc45def0de887810f508d3f65db7a/black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175", size = 1423293, upload-time = "2024-10-07T19:24:41.7Z" },
-    { url = "https://files.pythonhosted.org/packages/90/04/bf74c71f592bcd761610bbf67e23e6a3cff824780761f536512437f1e655/black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3", size = 1644256, upload-time = "2024-10-07T19:27:53.355Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ea/a77bab4cf1887f4b2e0bce5516ea0b3ff7d04ba96af21d65024629afedb6/black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65", size = 1448534, upload-time = "2024-10-07T19:26:44.953Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/3e/443ef8bc1fbda78e61f79157f303893f3fddf19ca3c8989b163eb3469a12/black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f", size = 1761892, upload-time = "2024-10-07T19:24:10.264Z" },
-    { url = "https://files.pythonhosted.org/packages/52/93/eac95ff229049a6901bc84fec6908a5124b8a0b7c26ea766b3b8a5debd22/black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8", size = 1434796, upload-time = "2024-10-07T19:25:06.239Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a0/a993f58d4ecfba035e61fca4e9f64a2ecae838fc9f33ab798c62173ed75c/black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981", size = 1643986, upload-time = "2024-10-07T19:28:50.684Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d5/602d0ef5dfcace3fb4f79c436762f130abd9ee8d950fa2abdbf8bbc555e0/black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b", size = 1448085, upload-time = "2024-10-07T19:28:12.093Z" },
-    { url = "https://files.pythonhosted.org/packages/47/6d/a3a239e938960df1a662b93d6230d4f3e9b4a22982d060fc38c42f45a56b/black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2", size = 1760928, upload-time = "2024-10-07T19:24:15.233Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/cf/af018e13b0eddfb434df4d9cd1b2b7892bab119f7a20123e93f6910982e8/black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b", size = 1436875, upload-time = "2024-10-07T19:24:42.762Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/02/f408c804e0ee78c367dcea0a01aedde4f1712af93b8b6e60df981e0228c7/black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd", size = 1622516, upload-time = "2024-10-07T19:29:40.629Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/b9/9b706ed2f55bfb28b436225a9c57da35990c9005b90b8c91f03924454ad7/black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f", size = 1456181, upload-time = "2024-10-07T19:28:11.16Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1c/314d7f17434a5375682ad097f6f4cc0e3f414f3c95a9b1bb4df14a0f11f9/black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800", size = 1752801, upload-time = "2024-10-07T19:23:56.594Z" },
-    { url = "https://files.pythonhosted.org/packages/39/a7/20e5cd9237d28ad0b31438de5d9f01c8b99814576f4c0cda1edd62caf4b0/black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7", size = 1413626, upload-time = "2024-10-07T19:24:46.133Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898, upload-time = "2024-10-07T19:20:48.317Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -979,32 +892,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/f8/bbe24f43695c0c480181e39ce910c2650c794831886ec46ddd7c40520e6a/flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23", size = 48767, upload-time = "2023-07-29T19:05:05.665Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5", size = 58260, upload-time = "2023-07-29T19:05:02.783Z" },
-]
-
-[[package]]
-name = "flake8-pyproject"
-version = "1.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/6a/cdee9ff7f2b7c6ddc219fd95b7c70c0a3d9f0367a506e9793eedfc72e337/flake8_pyproject-1.2.4-py3-none-any.whl", hash = "sha256:ea34c057f9a9329c76d98723bb2bb498cc6ba8ff9872c4d19932d48c91249a77", size = 5694, upload-time = "2025-11-28T21:40:01.309Z" },
 ]
 
 [[package]]
@@ -1870,15 +1757,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/1b/a7782984844bd519ad4ffdbebbba2671ec5d0ebbeac34736c15fb86399e8/markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7", size = 14566, upload-time = "2025-09-27T18:37:37.09Z" },
     { url = "https://files.pythonhosted.org/packages/18/1f/8d9c20e1c9440e215a44be5ab64359e207fcb4f675543f1cf9a2a7f648d0/markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e", size = 15053, upload-time = "2025-09-27T18:37:38.054Z" },
     { url = "https://files.pythonhosted.org/packages/4e/d3/fe08482b5cd995033556d45041a4f4e76e7f0521112a9c9991d40d39825f/markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8", size = 13928, upload-time = "2025-09-27T18:37:39.037Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -3024,15 +2902,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/8f/fa09ae2acc737b9507b5734a9aec9a2b35fa73409982f57db1b42f8c3c65/pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f", size = 38974, upload-time = "2023-10-12T23:39:39.762Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67", size = 31132, upload-time = "2023-10-12T23:39:38.242Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -3057,15 +2926,6 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/fb/7251eaec19a055ec6aafb3d1395db7622348130d1b9b763f78567b2aab32/pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc", size = 63636, upload-time = "2023-07-29T17:00:41.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774", size = 62616, upload-time = "2023-07-29T17:00:40.344Z" },
 ]
 
 [[package]]
@@ -3499,6 +3359,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3561,13 +3446,10 @@ source = { editable = "." }
 dev = [
     { name = "aiohttp", version = "3.10.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "aiohttp", version = "3.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "black", version = "24.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "black", version = "24.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "flake8" },
-    { name = "flake8-pyproject" },
     { name = "mypy" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "ruff" },
     { name = "slack-sdk" },
     { name = "twine", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "twine", version = "6.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -3589,11 +3471,9 @@ docs = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiohttp", specifier = ">=3.10.11,<4.0.0" },
-    { name = "black", specifier = ">=24.8.0,<25.0.0" },
-    { name = "flake8", specifier = ">=6.1.0,<7.0.0" },
-    { name = "flake8-pyproject", specifier = ">=1.2.3,<2.0.0" },
     { name = "mypy", specifier = ">=1.14.1,<1.15.0" },
     { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "ruff", specifier = ">=0.8.0,<1.0.0" },
     { name = "slack-sdk", specifier = ">=3.33.4,<4.0.0" },
     { name = "twine", specifier = ">=6.0.1,<7.0.0" },
     { name = "wheel", specifier = ">=0.45.1,<1.0.0" },


### PR DESCRIPTION
Closes #162

## Summary
Migrates the linting + formatting toolchain from `black` + `flake8` (+ `flake8-pyproject`) to [ruff](https://docs.astral.sh/ruff/), which provides both linting and formatting in a single tool with native `pyproject.toml` support and dramatically faster execution.

## Changes
- **Dependencies** (`pyproject.toml`):
  - Drop `black`, `flake8`, `flake8-pyproject` from `dev` group.
  - Add `ruff` to `dev` group.
- **Configuration** (`pyproject.toml`):
  - Remove `[tool.flake8]` section.
  - Add `[tool.ruff]` (line-length 100, same exclude set), `[tool.ruff.lint]` (rule families `E`, `F`, `W` mirroring pycodestyle + pyflakes; `E501` ignored because the formatter handles widths and some Slack-API URL docstrings exceed 100 chars and cannot be wrapped without breaking Markdown links), `[tool.ruff.lint.per-file-ignores]` matching the previous flake8 ignores, and `[tool.ruff.format]` (black-compatible defaults).
- **Workflows** (renamed for clarity):
  - `.github/workflows/formatting.yml` -> `ruff-format.yml`. Workflow name and job name both `Ruff Format`. Runs `uv run ruff format --check .`.
  - `.github/workflows/linting.yml` -> `ruff-lint.yml`. Workflow name and job name both `Ruff Lint`. Runs `uv run ruff check .`.
- **Source cleanups**:
  - Removed a now-meaningless `# noqa: E501` inside a docstring in `slackblocks/elements.py`. flake8 had inadvertently honored it as if it were a real comment; ruff (correctly) does not.
  - Ran `ruff format` once across the repo. Ruff's formatter is black-compatible but slightly more aggressive about collapsing wrapped function calls when they fit within the 100-character budget. The resulting diff is purely stylistic; `pytest` (132 tests) and `mypy` are unchanged.

## Branch protection
The required status checks on `master` currently reference the old job names (`black Formatting`, `flake8 Linting`). Once this PR lands they need to be updated to `Ruff Format` and `Ruff Lint` via `gh api`. The PR is gated on the *new* job names producing successful runs, which will happen automatically when CI fires here.

## Verification
Locally with the new toolchain:
- `uv run ruff format --check .` — clean
- `uv run ruff check .` — clean
- `uv run mypy slackblocks` — clean
- `uv run pytest test/unit` — 132 passed