### PR TITLE
docs: add Python version compatibility page

### DIFF
--- a/docs_src/usage/compatibility.md
+++ b/docs_src/usage/compatibility.md
@@ -1,0 +1,52 @@
+# Compatibility
+
+This page documents which Python versions are supported by each `slackblocks` release line, so you can choose the right line for your runtime.
+
+## Support matrix
+
+| `slackblocks` version | Minimum Python | Notes |
+| --- | --- | --- |
+| `1.x` (current stable) | 3.8.1 | The last release line to support Python 3.8 and 3.9. |
+| `2.x` (in development) | 3.10 | Modern typing (`X | Y`, `list[X]`), dataclasses with `slots`, `match` statements, and other Python 3.10+ features used internally. |
+
+If you cannot upgrade Python, pin to the appropriate major version:
+
+=== "pip (`requirements.txt`)"
+    ```
+    slackblocks>=1,<2     # Python 3.8/3.9 friendly
+    slackblocks>=2,<3     # Python 3.10+ only
+    ```
+
+=== "poetry (`pyproject.toml`)"
+    ```toml
+    slackblocks = "^1"    # Python 3.8/3.9 friendly
+    slackblocks = "^2"    # Python 3.10+ only
+    ```
+
+=== "uv (`pyproject.toml`)"
+    ```toml
+    "slackblocks>=1,<2"   # Python 3.8/3.9 friendly
+    "slackblocks>=2,<3"   # Python 3.10+ only
+    ```
+
+## Why we move forward
+
+`slackblocks` follows the upstream Python release cycle. Once a Python version reaches its [official end-of-life](https://devguide.python.org/versions/), it stops receiving security patches, and we prefer not to ship new feature work targeting unmaintained runtimes.
+
+| Python version | EOL date |
+| --- | --- |
+| 3.8 | 2024-10-07 |
+| 3.9 | 2025-10-31 |
+| 3.10 | 2026-10 |
+| 3.11 | 2027-10 |
+| 3.12 | 2028-10 |
+| 3.13 | 2029-10 |
+| 3.14 | 2030-10 |
+
+Bugfix releases on existing lines may continue past these dates on a best-effort basis, but new feature work will target supported Pythons.
+
+## Choosing a version
+
+- **You're on Python 3.8 or 3.9**: install the latest `1.x`.
+- **You're on Python 3.10 or newer**: install `2.x` once released; `1.x` will continue to work for the foreseeable future.
+- **You're starting a new project on a modern Python**: prefer `2.x` to take advantage of the improved typing surface.

--- a/docs_src/usage/installation.md
+++ b/docs_src/usage/installation.md
@@ -26,8 +26,12 @@ You can install `slackblocks` using any Python package manager with access to Py
 
 ## Requirements
 
-- Python 3.8.1 or newer.
+- Python 3.8.1 or newer for the `1.x` release line.
+- Python 3.10 or newer for the `2.x` release line (in development).
 - No runtime dependencies.
+
+For the full Python version support matrix and how to pin to a release line that
+matches your runtime, see [Compatibility](compatibility.md).
 
 ## Verifying your installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
   - Home: index.md
   - Usage:
     - Installation: usage/installation.md
+    - Compatibility: usage/compatibility.md
     - Using Blocks: usage/using_blocks.md
     - Sending Messages: usage/sending_messages.md
     - Cookbook: usage/cookbook.md


### PR DESCRIPTION
Closes #166

## Summary
Document which slackblocks release lines support which Python versions, so users on older Pythons know which line still works for them. This is the prerequisite for bumping the minimum Python floor in a later PR.

## Changes
- New `docs_src/usage/compatibility.md`:
  - Support matrix (1.x -> Python 3.8.1+, 2.x -> Python 3.10+).
  - Upstream Python EOL dates.
  - Pinning instructions for pip / poetry / uv.
- Cross-reference from `docs_src/usage/installation.md`.
- Add the page to `mkdocs.yml` nav under `Usage`.

## Verification
- `uv run mkdocs build --strict` succeeds and renders the page at `docs/usage/compatibility/index.html`.
- `pytest`, `ruff format --check .`, `ruff check .`, `mypy slackblocks` all clean.