### PR TITLE
chore: modernize annotations to PEP 585/604 syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,14 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 line-length = 100
+target-version = "py310"
 exclude = [".venv", "build", "dist", ".eggs", ".git"]
 
 [tool.ruff.lint]
-# Mirror the previous flake8 + flake8-black behavior. Start conservatively:
-# pycodestyle (E,W) + pyflakes (F). Additional rule families (UP, B, SIM, I, TCH)
-# can be enabled in a follow-up PR with their own targeted code changes.
-select = ["E", "F", "W"]
+# pycodestyle (E,W) + pyflakes (F) + pyupgrade (UP). Additional rule families
+# (B, SIM, I, TCH) can be enabled in a follow-up PR with their own targeted
+# code changes.
+select = ["E", "F", "UP", "W"]
 # E501 (line-too-long) is handled by the formatter; don't lint it. Long lines
 # in docstrings (e.g. Slack API URLs) can't be wrapped without breaking
 # Markdown link rendering.

--- a/slackblocks/__init__.py
+++ b/slackblocks/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .attachments import Attachment, Color, Field
 from .blocks import (
     ActionsBlock,

--- a/slackblocks/attachments.py
+++ b/slackblocks/attachments.py
@@ -5,9 +5,11 @@ attachments API.
 See: <https://api.slack.com/slackblocks/latest/reference/messaging/attachments>.
 """
 
+from __future__ import annotations
+
 from enum import Enum
 from json import dumps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from slackblocks.blocks import Block
 from slackblocks.errors import InvalidUsageError
@@ -115,9 +117,9 @@ class Field:
 
     def __init__(
         self,
-        title: Optional[str] = None,
-        value: Optional[str] = None,
-        short: Optional[bool] = False,
+        title: str | None = None,
+        value: str | None = None,
+        short: bool | None = False,
     ):
         self.title = title
         self.value = value
@@ -159,15 +161,15 @@ class Attachment:
 
     def __init__(
         self,
-        blocks: Optional[Union[Block, List[Block]]] = None,
-        color: Optional[Union[str, Color]] = None,
-        fields: Optional[Union[Field, List[Field]]] = None,
-        fallback: Optional[str] = None,
+        blocks: Block | list[Block] | None = None,
+        color: str | Color | None = None,
+        fields: Field | list[Field] | None = None,
+        fallback: str | None = None,
     ):
         self.blocks = coerce_to_list(blocks, Block, allow_none=True)
         self.fields = coerce_to_list(fields, Field, allow_none=True)
         self.fallback = fallback
-        self.color: Optional[str]
+        self.color: str | None
         if type(color) is Color:
             self.color = color.value
         elif type(color) is str:
@@ -180,8 +182,8 @@ class Attachment:
         else:
             self.color = None
 
-    def _resolve(self) -> Dict[str, Any]:
-        attachment: Dict[str, Any] = {}
+    def _resolve(self) -> dict[str, Any]:
+        attachment: dict[str, Any] = {}
         if self.blocks:
             attachment["blocks"] = [block._resolve() for block in self.blocks]
         if self.color:

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -5,10 +5,12 @@ interactive messages.
 See: <https://api.slack.com/reference/block-kit/blocks>.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from enum import Enum
 from json import dumps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from uuid import uuid4
 
 from slackblocks.elements import (
@@ -109,18 +111,18 @@ class Block(ABC):
     N.B: Block is an abstract class and cannot be sent directly.
     """
 
-    def __init__(self, type_: BlockType, block_id: Optional[str] = None) -> None:
+    def __init__(self, type_: BlockType, block_id: str | None = None) -> None:
         self.type = type_
         self.block_id = block_id if block_id else str(uuid4())
 
-    def __add__(self, other: "Block"):
+    def __add__(self, other: Block):
         return [self, other]
 
     def _attributes(self):
         return {"type": self.type.value, "block_id": self.block_id}
 
     @abstractmethod
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         pass
 
     def __repr__(self) -> str:
@@ -142,11 +144,11 @@ class ActionsBlock(Block):
 
     def __init__(
         self,
-        elements: Optional[List[Element]] = None,
-        block_id: Optional[str] = None,
+        elements: list[Element] | None = None,
+        block_id: str | None = None,
     ) -> None:
         super().__init__(type_=BlockType.ACTIONS, block_id=block_id)
-        self.elements: Optional[List[Element]] = coerce_to_list(
+        self.elements: list[Element] | None = coerce_to_list(
             elements, (Element), allow_none=True, max_size=25
         )
 
@@ -170,8 +172,8 @@ class ContextBlock(Block):
 
     def __init__(
         self,
-        elements: Optional[List[Union[Element, CompositionObject]]] = None,
-        block_id: Optional[str] = None,
+        elements: list[Element | CompositionObject] | None = None,
+        block_id: str | None = None,
     ) -> None:
         super().__init__(type_=BlockType.CONTEXT, block_id=block_id)
         self.elements = []
@@ -186,7 +188,7 @@ class ContextBlock(Block):
         if len(self.elements) > 10:
             raise InvalidUsageError("Context blocks can hold a maximum of ten elements")
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         context = self._attributes()
         context["elements"] = [element._resolve() for element in self.elements]
         return context
@@ -201,7 +203,7 @@ class DividerBlock(Block):
         block_id: you can use this field to provide a deterministic identifier for the block.
     """
 
-    def __init__(self, block_id: Optional[str] = None) -> None:
+    def __init__(self, block_id: str | None = None) -> None:
         super().__init__(type_=BlockType.DIVIDER, block_id=block_id)
 
     def _resolve(self):
@@ -224,14 +226,14 @@ class FileBlock(Block):
     def __init__(
         self,
         external_id: str,
-        block_id: Optional[str] = None,
+        block_id: str | None = None,
         source: str = "remote",
     ) -> None:
         super().__init__(type_=BlockType.FILE, block_id=block_id)
         self.external_id = external_id
         self.source = source
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         file = self._attributes()
         file["external_id"] = self.external_id
         file["source"] = self.source
@@ -247,14 +249,14 @@ class HeaderBlock(Block):
         block_id: you can use this field to provide a deterministic identifier for the block.
     """
 
-    def __init__(self, text: Union[str, Text], block_id: Optional[str] = None) -> None:
+    def __init__(self, text: str | Text, block_id: str | None = None) -> None:
         super().__init__(type_=BlockType.HEADER, block_id=block_id)
         if type(text) is Text:
             self.text = text
         else:
             self.text = Text.to_text_nonnull(text=text, force_plaintext=True)
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         header = self._attributes()
         header["text"] = self.text._resolve()
         return header
@@ -277,9 +279,9 @@ class ImageBlock(Block):
     def __init__(
         self,
         image_url: str,
-        alt_text: Optional[str] = " ",
-        title: Optional[Union[Text, str]] = None,
-        block_id: Optional[str] = None,
+        alt_text: str | None = " ",
+        title: Text | str | None = None,
+        block_id: str | None = None,
     ) -> None:
         super().__init__(type_=BlockType.IMAGE, block_id=block_id)
         self.image_url = validate_string(
@@ -302,7 +304,7 @@ class ImageBlock(Block):
         elif isinstance(title, str):
             self.title = Text(text=title, type_=TextType.PLAINTEXT)
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         image = self._attributes()
         image["image_url"] = self.image_url
         if self.alt_text:
@@ -337,8 +339,8 @@ class InputBlock(Block):
         label: TextLike,
         element: Element,
         dispatch_action: bool = False,
-        block_id: Optional[str] = None,
-        hint: Optional[TextLike] = None,
+        block_id: str | None = None,
+        hint: TextLike | None = None,
         optional: bool = False,
     ) -> None:
         super().__init__(type_=BlockType.INPUT, block_id=block_id)
@@ -352,7 +354,7 @@ class InputBlock(Block):
         self.hint = Text.to_text(hint, force_plaintext=True, max_length=2000, allow_none=True)
         self.optional = optional
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         input_block = self._attributes()
         if self.label is not None:
             input_block["label"] = self.label._resolve()
@@ -389,8 +391,8 @@ class RichTextBlock(Block):
 
     def __init__(
         self,
-        elements: Union[RichTextObject, List[RichTextObject]],
-        block_id: Optional[str] = None,
+        elements: RichTextObject | list[RichTextObject],
+        block_id: str | None = None,
     ) -> None:
         super().__init__(type_=BlockType.RICH_TEXT, block_id=block_id)
         self.elements = coerce_to_list(
@@ -404,8 +406,8 @@ class RichTextBlock(Block):
             min_size=1,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
-        rich_text_block: Dict[str, Any] = self._attributes()
+    def _resolve(self) -> dict[str, Any]:
+        rich_text_block: dict[str, Any] = self._attributes()
         if self.elements is not None:
             rich_text_block["elements"] = [element._resolve() for element in self.elements]
         return rich_text_block
@@ -437,10 +439,10 @@ class SectionBlock(Block):
 
     def __init__(
         self,
-        text: Optional[TextLike] = None,
-        block_id: Optional[str] = None,
-        fields: Optional[Union[TextLike, List[TextLike]]] = None,
-        accessory: Optional[Element] = None,
+        text: TextLike | None = None,
+        block_id: str | None = None,
+        fields: TextLike | list[TextLike] | None = None,
+        accessory: Element | None = None,
     ) -> None:
         super().__init__(type_=BlockType.SECTION, block_id=block_id)
         if not text and not fields:
@@ -448,9 +450,9 @@ class SectionBlock(Block):
                 "Must supply either `text` or `fields` or `both` to SectionBlock."
             )
         self.text = Text.to_text(text, max_length=3000, allow_none=True)
-        self.fields: Optional[List[Text]]
+        self.fields: list[Text] | None
         if fields is not None:
-            field_list: List[Union[str, Text]] = coerce_to_list_nonnull(fields, class_=(str, Text))
+            field_list: list[str | Text] = coerce_to_list_nonnull(fields, class_=(str, Text))
             self.fields = [
                 Text.to_text_nonnull(field, max_length=2000)
                 for field in field_list
@@ -463,7 +465,7 @@ class SectionBlock(Block):
 
         self.accessory = accessory
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         section = self._attributes()
         if self.text:
             section["text"] = self.text._resolve()
@@ -496,9 +498,9 @@ class TableBlock(Block):
 
     def __init__(
         self,
-        rows: List[List[Union[RawText, RichTextObject]]],
-        column_settings: Optional[List[ColumnSettings]] = None,
-        block_id: Optional[str] = None,
+        rows: list[list[RawText | RichTextObject]],
+        column_settings: list[ColumnSettings] | None = None,
+        block_id: str | None = None,
     ) -> None:
         super().__init__(type_=BlockType.TABLE, block_id=block_id)
         # Validate that there is at least one row
@@ -536,14 +538,14 @@ class TableBlock(Block):
             raise InvalidUsageError("`column_settings` can have a maximum of 20 items.")
         self.column_settings = column_settings
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         table = self._attributes()
         table["rows"] = [[self._resolve_cell(cell) for cell in row] for row in self.rows]
         if self.column_settings:
             table["column_settings"] = [setting._resolve() for setting in self.column_settings]
         return table
 
-    def _resolve_cell(self, cell: Union[RawText, RichTextObject]) -> Dict[str, Any]:
+    def _resolve_cell(self, cell: RawText | RichTextObject) -> dict[str, Any]:
         """
         Resolve a table cell to its JSON representation.
 

--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -4,12 +4,14 @@ Block elements can be used inside of section, context, input, and actions layout
 See: <https://api.slack.com/reference/block-kit/block-elements>
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from itertools import chain
 from json import dumps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from .errors import InvalidUsageError
 from .objects import (
@@ -71,11 +73,11 @@ class Element(ABC):
         super().__init__()
         self._type = type_
 
-    def _attributes(self) -> Dict[str, Any]:
+    def _attributes(self) -> dict[str, Any]:
         return {"type": self._type.value}
 
     @abstractmethod
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         pass
 
     @property
@@ -112,11 +114,11 @@ class Button(Element):
         self,
         text: TextLike,
         action_id: str,
-        url: Optional[str] = None,
-        value: Optional[str] = None,
-        style: Optional[str] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
-        accessibility_label: Optional[str] = None,
+        url: str | None = None,
+        value: str | None = None,
+        style: str | None = None,
+        confirm: ConfirmationDialogue | None = None,
+        accessibility_label: str | None = None,
     ) -> None:
         super().__init__(type_=ElementType.BUTTON)
         self.text = Text.to_text(text, max_length=75, force_plaintext=True)
@@ -128,7 +130,7 @@ class Button(Element):
             max_length=2000,
             allow_none=True,
         )
-        self.style: Optional[str] = None
+        self.style: str | None = None
         if isinstance(style, ButtonStyle):
             self.style = style.value
         elif isinstance(style, str):
@@ -143,7 +145,7 @@ class Button(Element):
             allow_none=True,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         button = self._attributes()
         if self.text is not None:
             button["text"] = self.text._resolve()
@@ -189,9 +191,9 @@ class CheckboxGroup(Element):
     def __init__(
         self,
         action_id: str,
-        options: Union[Option, List[Option]],
-        initial_options: Optional[Union[Option, List[Option]]] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        options: Option | list[Option],
+        initial_options: Option | list[Option] | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
     ) -> None:
         super().__init__(type_=ElementType.CHECKBOXES)
@@ -201,7 +203,7 @@ class CheckboxGroup(Element):
         self.confirm = confirm
         self.focus_on_load = focus_on_load
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         checkbox_group = self._attributes()
         checkbox_group["action_id"] = self.action_id
         if self.options is not None:
@@ -241,14 +243,14 @@ class DatePicker(Element):
     def __init__(
         self,
         action_id: str,
-        initial_date: Optional[str] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        initial_date: str | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.DATE_PICKER)
         self.action_id = validate_action_id(action_id)
-        self.initial_date: Optional[str] = None
+        self.initial_date: str | None = None
         if initial_date:
             self.initial_date = datetime.strptime(initial_date, "%Y-%m-%d").strftime("%Y-%m-%d")
         self.confirm = confirm
@@ -257,7 +259,7 @@ class DatePicker(Element):
             placeholder, force_plaintext=True, max_length=150, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         date_picker = self._attributes()
         date_picker["action_id"] = self.action_id
         if self.initial_date is not None:
@@ -294,8 +296,8 @@ class DateTimePicker(Element):
     def __init__(
         self,
         action_id: str,
-        initial_datetime: Optional[int] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        initial_datetime: int | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
     ) -> None:
         super().__init__(type_=ElementType.DATETIME_PICKER)
@@ -304,7 +306,7 @@ class DateTimePicker(Element):
         self.confirm = confirm
         self.focus_on_load = focus_on_load
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         datetime_picker = self._attributes()
         datetime_picker["action_id"] = self.action_id
         if self.initial_datetime:
@@ -340,10 +342,10 @@ class EmailInput(Element):
     def __init__(
         self,
         action_id: str,
-        initial_value: Optional[str] = None,
-        dispatch_action_config: Optional[DispatchActionConfiguration] = None,
+        initial_value: str | None = None,
+        dispatch_action_config: DispatchActionConfiguration | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.EMAIL_INPUT)
         self.action_id = validate_action_id(action_id)
@@ -387,9 +389,9 @@ class FileInput(Element):
 
     def __init__(
         self,
-        action_id: Optional[str] = None,
-        filetypes: Optional[Union[str, List[str]]] = None,
-        max_files: Optional[int] = None,
+        action_id: str | None = None,
+        filetypes: str | list[str] | None = None,
+        max_files: int | None = None,
     ) -> None:
         super().__init__(ElementType.FILE_INPUT)
         self.action_id = validate_action_id(action_id)
@@ -400,8 +402,8 @@ class FileInput(Element):
         )
         self.max_files = validate_int(max_files, min_value=1, max_value=10, allow_none=True)
 
-    def _resolve(self) -> Dict[str, Any]:
-        file_input: Dict[str, Any] = {}
+    def _resolve(self) -> dict[str, Any]:
+        file_input: dict[str, Any] = {}
         if self.action_id is not None:
             file_input["action_id"] = self.action_id
         if self.filetypes is not None:
@@ -436,8 +438,8 @@ class Image(Element):
     def __init__(
         self,
         alt_text: str = " ",
-        image_url: Optional[str] = None,
-        slack_file: Optional[SlackFile] = None,
+        image_url: str | None = None,
+        slack_file: SlackFile | None = None,
     ) -> None:
         super().__init__(type_=ElementType.IMAGE)
         if image_url is None and slack_file is None:
@@ -448,7 +450,7 @@ class Image(Element):
         self.alt_text = alt_text
         self.slack_file = slack_file
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         image = self._attributes()
         if self.image_url is not None:
             image["image_url"] = self.image_url
@@ -491,15 +493,13 @@ class StaticMultiSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        options: Union[Option, List[Option]],
-        option_groups: Optional[Union[OptionGroup, List[OptionGroup]]] = None,
-        initial_options: Optional[
-            Union[Option, List[Option], OptionGroup, List[OptionGroup]]
-        ] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
-        max_selected_items: Optional[int] = None,
+        options: Option | list[Option],
+        option_groups: OptionGroup | list[OptionGroup] | None = None,
+        initial_options: Option | list[Option] | OptionGroup | list[OptionGroup] | None = None,
+        confirm: ConfirmationDialogue | None = None,
+        max_selected_items: int | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.MULTI_SELECT_STATIC)
         self.action_id = validate_action_id(action_id)
@@ -535,7 +535,7 @@ class StaticMultiSelectMenu(Element):
             )
 
         # Check that Option Text is all TextType.PLAINTEXT
-        options_to_validate: List[Option] = []
+        options_to_validate: list[Option] = []
         if self.options:
             options_to_validate = self.options
         if self.option_groups:
@@ -555,7 +555,7 @@ class StaticMultiSelectMenu(Element):
             placeholder, force_plaintext=True, max_length=150, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         static_multi_select = self._attributes()
         static_multi_select["action_id"] = self.action_id
         if self.options:
@@ -608,14 +608,12 @@ class ExternalMultiSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        min_query_length: Optional[int] = None,
-        initial_options: Optional[
-            Union[Option, List[Option], OptionGroup, List[OptionGroup]]
-        ] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
-        max_selected_items: Optional[int] = None,
+        min_query_length: int | None = None,
+        initial_options: Option | list[Option] | OptionGroup | list[OptionGroup] | None = None,
+        confirm: ConfirmationDialogue | None = None,
+        max_selected_items: int | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.MULTI_SELECT_EXTERNAL)
         self.action_id = validate_action_id(action_id)
@@ -633,7 +631,7 @@ class ExternalMultiSelectMenu(Element):
             placeholder, force_plaintext=True, max_length=150, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         external_select_menu = self._attributes()
         external_select_menu["action_id"] = self.action_id
         if self.min_query_length:
@@ -680,17 +678,15 @@ class UserMultiSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        initial_users: Optional[List[str]] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
-        max_selected_items: Optional[int] = None,
+        initial_users: list[str] | None = None,
+        confirm: ConfirmationDialogue | None = None,
+        max_selected_items: int | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.MULTI_SELECT_USERS)
         self.action_id = validate_action_id(action_id)
-        self.initial_users: Optional[List[str]] = coerce_to_list(
-            initial_users, str, allow_none=True
-        )
+        self.initial_users: list[str] | None = coerce_to_list(initial_users, str, allow_none=True)
         self.confirm = confirm
         self.max_selected_items = max_selected_items
         self.focus_on_load = focus_on_load
@@ -698,7 +694,7 @@ class UserMultiSelectMenu(Element):
             placeholder, force_plaintext=True, max_length=150, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         user_multi_select = self._attributes()
         user_multi_select["action_id"] = self.action_id
         if self.initial_users:
@@ -747,17 +743,17 @@ class ConversationMultiSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        initial_conversations: Optional[List[str]] = None,
-        default_to_current_conversation: Optional[bool] = False,
-        confirm: Optional[ConfirmationDialogue] = None,
-        max_selected_items: Optional[int] = None,
-        filter: Optional[ConversationFilter] = None,
-        focus_on_load: Optional[bool] = False,
-        placeholder: Optional[TextLike] = None,
+        initial_conversations: list[str] | None = None,
+        default_to_current_conversation: bool | None = False,
+        confirm: ConfirmationDialogue | None = None,
+        max_selected_items: int | None = None,
+        filter: ConversationFilter | None = None,
+        focus_on_load: bool | None = False,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.MULTI_SELECT_CONVERSATIONS)
         self.action_id = validate_action_id(action_id)
-        self.initial_conversations: Optional[List[str]] = coerce_to_list(
+        self.initial_conversations: list[str] | None = coerce_to_list(
             initial_conversations, str, allow_none=True
         )
         self.default_to_current_conversation = default_to_current_conversation
@@ -769,7 +765,7 @@ class ConversationMultiSelectMenu(Element):
             placeholder, force_plaintext=True, max_length=150, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         conversation_multi_select = self._attributes()
         conversation_multi_select["action_id"] = self.action_id
         if self.initial_conversations:
@@ -818,15 +814,15 @@ class ChannelMultiSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        initial_channels: Optional[List[str]] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
-        max_selected_items: Optional[int] = None,
+        initial_channels: list[str] | None = None,
+        confirm: ConfirmationDialogue | None = None,
+        max_selected_items: int | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.MULTI_SELECT_CHANNELS)
         self.action_id = validate_action_id(action_id)
-        self.initial_channels: Optional[List[str]] = coerce_to_list(
+        self.initial_channels: list[str] | None = coerce_to_list(
             initial_channels, class_=str, allow_none=True
         )
         self.confirm = confirm
@@ -836,7 +832,7 @@ class ChannelMultiSelectMenu(Element):
             placeholder, force_plaintext=True, max_length=150, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         channel_multi_select = self._attributes()
         channel_multi_select["action_id"] = self.action_id
         if self.initial_channels:
@@ -880,13 +876,13 @@ class NumberInput(Element):
     def __init__(
         self,
         is_decimal_allowed: bool,
-        action_id: Optional[str] = None,
-        initial_value: Optional[str] = None,
-        min_value: Optional[Union[float, int]] = None,
-        max_value: Optional[Union[float, int]] = None,
-        dispatch_action_config: Optional[DispatchActionConfiguration] = None,
+        action_id: str | None = None,
+        initial_value: str | None = None,
+        min_value: float | int | None = None,
+        max_value: float | int | None = None,
+        dispatch_action_config: DispatchActionConfiguration | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.NUMBER_INPUT)
         self.is_decimal_allowed = is_decimal_allowed
@@ -919,7 +915,7 @@ class NumberInput(Element):
             placeholder, max_length=150, force_plaintext=True, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         number_input = self._attributes()
         number_input["is_decimal_allowed"] = self.is_decimal_allowed
         if self.action_id:
@@ -960,15 +956,15 @@ class OverflowMenu(Element):
     def __init__(
         self,
         action_id: str,
-        options: Union[Option, List[Option]],
-        confirm: Optional[ConfirmationDialogue] = None,
+        options: Option | list[Option],
+        confirm: ConfirmationDialogue | None = None,
     ) -> None:
         super().__init__(type_=ElementType.OVERFLOW_MENU)
         self.action_id = validate_action_id(action_id)
         self.options = coerce_to_list(options, Option, min_size=1, max_size=5)
         self.confirm = confirm
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         overflow_menu = self._attributes()
         overflow_menu["action_id"] = self.action_id
         if self.options is not None:
@@ -1009,13 +1005,13 @@ class PlainTextInput(Element):
     def __init__(
         self,
         action_id: str,
-        initial_value: Optional[str] = None,
+        initial_value: str | None = None,
         multiline: bool = False,
-        min_length: Optional[int] = None,
-        max_length: Optional[int] = None,
-        dispatch_action_config: Optional[DispatchActionConfiguration] = None,
+        min_length: int | None = None,
+        max_length: int | None = None,
+        dispatch_action_config: DispatchActionConfiguration | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.PLAIN_TEXT_INPUT)
         self.action_id = validate_action_id(action_id)
@@ -1031,7 +1027,7 @@ class PlainTextInput(Element):
             placeholder, max_length=150, force_plaintext=True, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         plain_text_input = self._attributes()
         if self.multiline:
             plain_text_input["multiline"] = self.multiline
@@ -1078,9 +1074,9 @@ class RadioButtonGroup(Element):
     def __init__(
         self,
         action_id: str,
-        options: List[Option],
-        initial_option: Optional[Option] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        options: list[Option],
+        initial_option: Option | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
     ) -> None:
         super().__init__(type_=ElementType.RADIO_BUTTON_GROUP)
@@ -1089,16 +1085,14 @@ class RadioButtonGroup(Element):
             raise InvalidUsageError(
                 "Number of options to RadioButtonGroup must be between 1 and 10 (inclusive)."
             )
-        self.options: Optional[List[Option]] = coerce_to_list(
-            options, class_=Option, allow_none=False
-        )
+        self.options: list[Option] | None = coerce_to_list(options, class_=Option, allow_none=False)
         if initial_option is not None and initial_option not in options:
             raise InvalidUsageError("`initial_option` must be a member of `options`")
         self.initial_option = initial_option
         self.confirm = confirm
         self.focus_on_load = focus_on_load
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         radio_button_group = self._attributes()
         radio_button_group["action_id"] = self.action_id
         if self.options is not None:
@@ -1145,21 +1139,21 @@ class StaticSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        options: Optional[List[Option]] = None,
-        option_groups: Optional[List[OptionGroup]] = None,
-        initial_option: Optional[Union[Option, OptionGroup]] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        options: list[Option] | None = None,
+        option_groups: list[OptionGroup] | None = None,
+        initial_option: Option | OptionGroup | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.STATIC_SELECT_MENU)
         self.action_id = validate_action_id(action_id)
         if options and option_groups:
             raise InvalidUsageError("Cannot set both `options` and `option_groups` parameters.")
-        self.options: Optional[List[Option]] = coerce_to_list(
+        self.options: list[Option] | None = coerce_to_list(
             options, class_=Option, allow_none=True, max_size=100
         )
-        self.option_groups: Optional[List[OptionGroup]] = coerce_to_list(
+        self.option_groups: list[OptionGroup] | None = coerce_to_list(
             option_groups, class_=OptionGroup, allow_none=True, max_size=100
         )
         if options and initial_option and not isinstance(initial_option, Option):
@@ -1174,7 +1168,7 @@ class StaticSelectMenu(Element):
             )
 
         # Check that Option Text is all TextType.PLAINTEXT
-        options_to_validate: List[Option] = []
+        options_to_validate: list[Option] = []
         if self.options:
             options_to_validate = self.options
         if self.option_groups:
@@ -1194,7 +1188,7 @@ class StaticSelectMenu(Element):
             placeholder, max_length=150, force_plaintext=True, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         static_select_menu = self._attributes()
         static_select_menu["action_id"] = self.action_id
         if self.options:
@@ -1242,11 +1236,11 @@ class ExternalSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        initial_option: Optional[Union[Option, OptionGroup]] = None,
-        min_query_length: Optional[int] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        initial_option: Option | OptionGroup | None = None,
+        min_query_length: int | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.EXTERNAL_SELECT_MENU)
         self.action_id = validate_action_id(action_id)
@@ -1261,7 +1255,7 @@ class ExternalSelectMenu(Element):
             allow_none=True,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         external_select_menu = self._attributes()
         external_select_menu["action_id"] = self.action_id
         if self.initial_option:
@@ -1302,10 +1296,10 @@ class UserSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        initial_user: Optional[str] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        initial_user: str | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.USERS_SELECT_MENU)
         self.action_id = validate_action_id(action_id)
@@ -1316,7 +1310,7 @@ class UserSelectMenu(Element):
             placeholder, max_length=150, force_plaintext=True, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         user_select_menu = self._attributes()
         user_select_menu["action_id"] = self.action_id
         if self.initial_user:
@@ -1364,13 +1358,13 @@ class ConversationSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        initial_conversation: Optional[str] = None,
-        default_to_current_conversation: Optional[bool] = False,
-        confirm: Optional[ConfirmationDialogue] = None,
-        response_url_enabled: Optional[bool] = False,
-        filter: Optional[ConversationFilter] = None,
+        initial_conversation: str | None = None,
+        default_to_current_conversation: bool | None = False,
+        confirm: ConfirmationDialogue | None = None,
+        response_url_enabled: bool | None = False,
+        filter: ConversationFilter | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.CONVERSATIONS_SELECT_MENU)
         self.action_id = validate_action_id(action_id)
@@ -1387,7 +1381,7 @@ class ConversationSelectMenu(Element):
             allow_none=True,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         conversation_select_menu = self._attributes()
         conversation_select_menu["action_id"] = self.action_id
         if self.initial_conversation:
@@ -1437,11 +1431,11 @@ class ChannelSelectMenu(Element):
     def __init__(
         self,
         action_id: str,
-        initial_channel: Optional[str] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
-        response_url_enabled: Optional[bool] = False,
+        initial_channel: str | None = None,
+        confirm: ConfirmationDialogue | None = None,
+        response_url_enabled: bool | None = False,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.CHANNELS_SELECT_MENU)
         self.action_id = validate_action_id(action_id)
@@ -1456,7 +1450,7 @@ class ChannelSelectMenu(Element):
             allow_none=True,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         channel_select_menu = self._attributes()
         channel_select_menu["action_id"] = self.action_id
         if self.initial_channel:
@@ -1496,11 +1490,11 @@ class TimePicker(Element):
     def __init__(
         self,
         action_id: str,
-        initial_time: Optional[str] = None,
-        confirm: Optional[ConfirmationDialogue] = None,
+        initial_time: str | None = None,
+        confirm: ConfirmationDialogue | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
-        timezone: Optional[str] = None,
+        placeholder: TextLike | None = None,
+        timezone: str | None = None,
     ) -> None:
         super().__init__(type_=ElementType.TIME_PICKER)
         self.action_id = validate_action_id(action_id)
@@ -1515,7 +1509,7 @@ class TimePicker(Element):
         )
         self.timezone = timezone
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         time_picker = self._attributes()
         time_picker["action_id"] = self.action_id
         if self.initial_time:
@@ -1556,10 +1550,10 @@ class URLInput(Element):
     def __init__(
         self,
         action_id: str,
-        initial_value: Optional[str] = None,
-        dispatch_action_config: Optional[DispatchActionConfiguration] = None,
+        initial_value: str | None = None,
+        dispatch_action_config: DispatchActionConfiguration | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(type_=ElementType.URL_INPUT)
         self.action_id = validate_action_id(action_id)
@@ -1573,7 +1567,7 @@ class URLInput(Element):
             allow_none=True,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         url_input = self._attributes()
         url_input["action_id"] = self.action_id
         if self.initial_value is not None:
@@ -1597,7 +1591,7 @@ class ButtonStyle(Enum):
     DANGER = "danger"
 
     @staticmethod
-    def to_button_style(style: Optional[Union["ButtonStyle", str]]) -> "ButtonStyle":
+    def to_button_style(style: ButtonStyle | str | None) -> ButtonStyle:
         if isinstance(style, ButtonStyle):
             return style
         if isinstance(style, str):
@@ -1607,7 +1601,7 @@ class ButtonStyle(Enum):
         )
 
 
-ButtonStyleLike = Union[ButtonStyle, str]
+ButtonStyleLike = ButtonStyle | str
 
 
 class WorkflowButton(Element):
@@ -1635,9 +1629,9 @@ class WorkflowButton(Element):
     def __init__(
         self,
         text: TextLike,
-        workflow: Optional[Workflow] = None,
-        style: Optional[ButtonStyleLike] = ButtonStyle.DEFAULT,
-        accessibility_label: Optional[str] = None,
+        workflow: Workflow | None = None,
+        style: ButtonStyleLike | None = ButtonStyle.DEFAULT,
+        accessibility_label: str | None = None,
     ) -> None:
         super().__init__(type_=ElementType.WORKFLOW_BUTTON)
         self.text = Text.to_text(text, force_plaintext=True, max_length=75)
@@ -1645,7 +1639,7 @@ class WorkflowButton(Element):
         self.style = ButtonStyle.to_button_style(style).value
         self.accessibility_label = accessibility_label
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         workflow_button = self._attributes()
         if self.text is not None:
             workflow_button["text"] = self.text._resolve()
@@ -1683,10 +1677,10 @@ class RichTextInput(Element):
     def __init__(
         self,
         action_id: str,
-        initial_value: Optional[RichText] = None,
-        dispatch_action_config: Optional[DispatchActionConfiguration] = None,
+        initial_value: RichText | None = None,
+        dispatch_action_config: DispatchActionConfiguration | None = None,
         focus_on_load: bool = False,
-        placeholder: Optional[TextLike] = None,
+        placeholder: TextLike | None = None,
     ) -> None:
         super().__init__(ElementType.RICH_TEXT_INPUT)
         self.action_id = validate_action_id(action_id)
@@ -1700,7 +1694,7 @@ class RichTextInput(Element):
             allow_none=True,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         rich_text_input = super()._attributes()
         rich_text_input["action_id"] = self.action_id
         if self.initial_value is not None:

--- a/slackblocks/errors.py
+++ b/slackblocks/errors.py
@@ -2,6 +2,8 @@
 Custom error classes for clearer error reporting.
 """
 
+from __future__ import annotations
+
 
 class InvalidUsageError(Exception):
     """
@@ -14,4 +16,4 @@ class InvalidUsageError(Exception):
     """
 
     def __init__(self, message: str) -> None:
-        return super(InvalidUsageError, self).__init__(message)
+        return super().__init__(message)

--- a/slackblocks/messages.py
+++ b/slackblocks/messages.py
@@ -5,9 +5,11 @@ built out using blocks, elements, objects, and rich text features.
 See: <https://api.slack.com/messaging>
 """
 
+from __future__ import annotations
+
 from enum import Enum
 from json import dumps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from slackblocks.utils import coerce_to_list
 
@@ -25,7 +27,7 @@ class ResponseType(Enum):
     IN_CHANNEL = "in_channel"
 
     @staticmethod
-    def get_value(value: Union["ResponseType", str]) -> str:
+    def get_value(value: ResponseType | str) -> str:
         if isinstance(value, ResponseType):
             return value.value
         if value not in [response_type.value for response_type in ResponseType]:
@@ -41,11 +43,11 @@ class BaseMessage:
 
     def __init__(
         self,
-        channel: Optional[str] = None,
-        text: Optional[str] = "",
-        blocks: Optional[Union[Block, List[Block]]] = None,
-        attachments: Optional[Union[Attachment, List[Attachment]]] = None,
-        thread_ts: Optional[str] = None,
+        channel: str | None = None,
+        text: str | None = "",
+        blocks: Block | list[Block] | None = None,
+        attachments: Attachment | list[Attachment] | None = None,
+        thread_ts: str | None = None,
         mrkdwn: bool = True,
     ) -> None:
         self.blocks = coerce_to_list(blocks, class_=Block, allow_none=True)
@@ -55,8 +57,8 @@ class BaseMessage:
         self.thread_ts = thread_ts
         self.mrkdwn = mrkdwn
 
-    def _resolve(self) -> Dict[str, Any]:
-        message: Dict[str, Any] = {}
+    def _resolve(self) -> dict[str, Any]:
+        message: dict[str, Any] = {}
         if self.channel:
             message["channel"] = self.channel
         message["mrkdwn"] = self.mrkdwn
@@ -70,7 +72,7 @@ class BaseMessage:
             message["text"] = self.text
         return message
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return self._resolve()
 
     def json(self) -> str:
@@ -82,7 +84,7 @@ class BaseMessage:
     def __getitem__(self, item):
         return self._resolve()[item]
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return list(self._resolve().keys())
 
 
@@ -116,19 +118,19 @@ class Message(BaseMessage):
     def __init__(
         self,
         channel: str,
-        text: Optional[str] = "",
-        blocks: Optional[Union[List[Block], Block]] = None,
-        attachments: Optional[List[Attachment]] = None,
-        thread_ts: Optional[str] = None,
+        text: str | None = "",
+        blocks: list[Block] | Block | None = None,
+        attachments: list[Attachment] | None = None,
+        thread_ts: str | None = None,
         mrkdwn: bool = True,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
+        unfurl_links: bool | None = None,
+        unfurl_media: bool | None = None,
     ) -> None:
         super().__init__(channel, text, blocks, attachments, thread_ts, mrkdwn)
         self.unfurl_links = unfurl_links
         self.unfurl_media = unfurl_media
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         result = {**super()._resolve()}
         if self.unfurl_links is not None:
             result["unfurl_links"] = self.unfurl_links
@@ -144,10 +146,10 @@ class MessageResponse(BaseMessage):
 
     def __init__(
         self,
-        text: Optional[str] = "",
-        blocks: Optional[Union[List[Block], Block]] = None,
-        attachments: Optional[List[Attachment]] = None,
-        thread_ts: Optional[str] = None,
+        text: str | None = "",
+        blocks: list[Block] | Block | None = None,
+        attachments: list[Attachment] | None = None,
+        thread_ts: str | None = None,
         mrkdwn: bool = True,
         replace_original: bool = False,
         ephemeral: bool = False,
@@ -162,8 +164,8 @@ class MessageResponse(BaseMessage):
         self.replace_original = replace_original
         self.ephemeral = ephemeral
 
-    def _resolve(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {
+    def _resolve(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
             **super()._resolve(),
             "replace_original": self.replace_original,
         }
@@ -208,22 +210,22 @@ class WebhookMessage:
 
     def __init__(
         self,
-        text: Optional[str] = None,
-        attachments: Optional[Union[Attachment, List[Attachment]]] = None,
-        blocks: Optional[Union[Block, List[Block]]] = None,
-        response_type: Optional[Union[ResponseType, str]] = None,
-        replace_original: Optional[bool] = None,
-        delete_original: Optional[bool] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        text: str | None = None,
+        attachments: Attachment | list[Attachment] | None = None,
+        blocks: Block | list[Block] | None = None,
+        response_type: ResponseType | str | None = None,
+        replace_original: bool | None = None,
+        delete_original: bool | None = None,
+        unfurl_links: bool | None = None,
+        unfurl_media: bool | None = None,
+        metadata: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self.text = text
-        self.attachments: Optional[List[Attachment]] = coerce_to_list(
+        self.attachments: list[Attachment] | None = coerce_to_list(
             attachments, Attachment, allow_none=True
         )
-        self.blocks: Optional[List[Block]] = coerce_to_list(blocks, Block, allow_none=True)
+        self.blocks: list[Block] | None = coerce_to_list(blocks, Block, allow_none=True)
         self.response_type = (
             ResponseType.get_value(response_type) if response_type is not None else None
         )
@@ -234,8 +236,8 @@ class WebhookMessage:
         self.metadata = metadata
         self.headers = headers
 
-    def _resolve(self) -> Dict[str, Any]:
-        webhook_message: Dict[str, Any] = {}
+    def _resolve(self) -> dict[str, Any]:
+        webhook_message: dict[str, Any] = {}
         if self.text is not None:
             webhook_message["text"] = self.text
         if self.attachments is not None:
@@ -262,7 +264,7 @@ class WebhookMessage:
             webhook_message["headers"] = self.headers
         return webhook_message
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return self._resolve()
 
     def json(self) -> str:
@@ -274,5 +276,5 @@ class WebhookMessage:
     def __getitem__(self, item):
         return self._resolve()[item]
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return list(self._resolve().keys())

--- a/slackblocks/modals.py
+++ b/slackblocks/modals.py
@@ -8,8 +8,10 @@ been largely subsumed as a subtype of view.
 See: <https://api.slack.com/surfaces/modals>
 """
 
+from __future__ import annotations
+
 from json import dumps
-from typing import Any, Dict
+from typing import Any
 
 from slackblocks.views import ModalView
 
@@ -23,7 +25,7 @@ class Modal(ModalView):
     def __repr__(self) -> str:
         return dumps(self._resolve(), indent=4)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return self._resolve()
 
     def json(self) -> str:

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -4,10 +4,12 @@ Composition objects are the lowest-level primitives used inside of Block objects
 See: <https://api.slack.com/reference/block-kit/composition-objects>.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from enum import Enum
 from json import dumps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from slackblocks.errors import InvalidUsageError
 from slackblocks.utils import (
@@ -47,11 +49,11 @@ class CompositionObject(ABC):
         super().__init__()
         self.type = type_
 
-    def _attributes(self) -> Dict[str, Any]:
+    def _attributes(self) -> dict[str, Any]:
         return {"type": self.type.value}
 
     @abstractmethod
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         pass
 
     def __repr__(self) -> str:
@@ -107,7 +109,7 @@ class Text(CompositionObject):
             self.verbatim = False
             self.emoji = emoji
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         text = self._attributes()
         text["type"] = self.text_type.value
         text["text"] = self.text
@@ -119,11 +121,11 @@ class Text(CompositionObject):
 
     @staticmethod
     def to_text(
-        text: Optional[Union[str, "Text"]],
+        text: str | Text | None,
         force_plaintext: bool = False,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         allow_none: bool = False,
-    ) -> Optional["Text"]:
+    ) -> Text | None:
         """
         Coerces `str` or `Text` objects into `Text` objects.
 
@@ -147,10 +149,10 @@ class Text(CompositionObject):
 
     @staticmethod
     def to_text_nonnull(
-        text: Union[str, "Text"],
+        text: str | Text,
         force_plaintext: bool = False,
-        max_length: Optional[int] = None,
-    ) -> "Text":
+        max_length: int | None = None,
+    ) -> Text:
         """
         Coerces `str` or `Text` objects into `Text` objects, but does not allow `None` values.
 
@@ -196,7 +198,7 @@ class Text(CompositionObject):
 
 
 # Used for accepting strings and `Text`` where coercion to `Text` is desirable.
-TextLike = Union[str, Text]
+TextLike = str | Text
 
 
 class ConfirmationDialogue(CompositionObject):
@@ -229,7 +231,7 @@ class ConfirmationDialogue(CompositionObject):
         self.confirm = Text.to_text_nonnull(confirm, max_length=30, force_plaintext=True)
         self.deny = Text.to_text_nonnull(deny, max_length=30, force_plaintext=True)
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
 
         return {
             "title": self.title._resolve(),
@@ -273,8 +275,8 @@ class Option(CompositionObject):
         self,
         text: TextLike,
         value: str,
-        description: Optional[TextLike] = None,
-        url: Optional[str] = None,
+        description: TextLike | None = None,
+        url: str | None = None,
     ) -> None:
         super().__init__(type_=CompositionObjectType.OPTION)
         self.text = Text.to_text_nonnull(text, max_length=75)
@@ -286,8 +288,8 @@ class Option(CompositionObject):
             raise InvalidUsageError("Option URLs must be less than 3000 characters")
         self.url = url
 
-    def _resolve(self) -> Dict[str, Any]:
-        option: Dict[str, Any] = {}  # Does not include type in JSON
+    def _resolve(self) -> dict[str, Any]:
+        option: dict[str, Any] = {}  # Does not include type in JSON
         option["text"] = self.text._resolve()
         option["value"] = self.value
         if self.description is not None:
@@ -320,18 +322,18 @@ class OptionGroup(CompositionObject):
         InvalidUsageError: if no options are provided or the label is not valid.
     """
 
-    def __init__(self, label: TextLike, options: List[Option]) -> None:
+    def __init__(self, label: TextLike, options: list[Option]) -> None:
         super().__init__(type_=CompositionObjectType.OPTION_GROUP)
         self.label = Text.to_text(label, max_length=75, force_plaintext=True)
-        self.options: List[Option] = coerce_to_list_nonnull(
+        self.options: list[Option] = coerce_to_list_nonnull(
             options,
             class_=Option,
             min_size=1,
             max_size=100,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
-        option_group: Dict[str, Any] = {}  # Does not include type in JSON
+    def _resolve(self) -> dict[str, Any]:
+        option_group: dict[str, Any] = {}  # Does not include type in JSON
         if self.label is not None:
             option_group["label"] = self.label._resolve()
         if self.options is not None:
@@ -355,7 +357,7 @@ class DispatchActionConfiguration(CompositionObject):
             `trigger_actions_on`.
     """
 
-    def __init__(self, trigger_actions_on: Optional[Union[str, List[str]]] = None) -> None:
+    def __init__(self, trigger_actions_on: str | list[str] | None = None) -> None:
         super().__init__(type_=CompositionObjectType.DISPATCH)
         trigger_actions_on = trigger_actions_on or []
         self.trigger_actions_on = list(
@@ -367,7 +369,7 @@ class DispatchActionConfiguration(CompositionObject):
                     f"Trigger {trigger} not in allowable values ({ALLOWABLE_TRIGGERS})"
                 )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         dispatch_action_config = {}  # Does not include type in JSON
         dispatch_action_config["trigger_actions_on"] = self.trigger_actions_on
         return dispatch_action_config
@@ -396,9 +398,9 @@ class ConversationFilter(CompositionObject):
 
     def __init__(
         self,
-        include: Optional[Union[str, List[str]]] = None,
-        exclude_external_shared_channels: Optional[bool] = None,
-        exclude_bot_users: Optional[bool] = None,
+        include: str | list[str] | None = None,
+        exclude_external_shared_channels: bool | None = None,
+        exclude_bot_users: bool | None = None,
     ) -> None:
         super().__init__(type_=CompositionObjectType.FILTER)
         if not (
@@ -412,8 +414,8 @@ class ConversationFilter(CompositionObject):
         self.exclude_external_shared_channels = exclude_external_shared_channels
         self.exclude_bot_users = exclude_bot_users
 
-    def _resolve(self) -> Dict[str, Any]:
-        filter: Dict[str, Any] = {}  # Does not include type in JSON
+    def _resolve(self) -> dict[str, Any]:
+        filter: dict[str, Any] = {}  # Does not include type in JSON
         if self.include:
             filter["include"] = self.include
         if self.exclude_external_shared_channels is not None:
@@ -439,7 +441,7 @@ class InputParameter(CompositionObject):
         self.name = name
         self.value = value
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         input_parameter = {}  # Does not include type in JSON
         input_parameter["name"] = self.name
         input_parameter["value"] = self.value
@@ -467,8 +469,8 @@ class SlackFile(CompositionObject):
 
     def __init__(
         self,
-        url: Optional[str],
-        id: Optional[str],
+        url: str | None,
+        id: str | None,
     ) -> None:
         super().__init__(CompositionObjectType.SLACK_FILE)
         if url and id:
@@ -476,7 +478,7 @@ class SlackFile(CompositionObject):
         self.url = url
         self.id = id
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         file = {}  # Does not include type in JSON
         if self.url:
             file["url"] = self.url
@@ -506,7 +508,7 @@ class Trigger(CompositionObject):
     def __init__(
         self,
         url: str,
-        customizable_input_parameters: Optional[Union[InputParameter, List[InputParameter]]],
+        customizable_input_parameters: InputParameter | list[InputParameter] | None,
     ) -> None:
         super().__init__(type_=CompositionObjectType.TRIGGER)
         self.url = url
@@ -514,8 +516,8 @@ class Trigger(CompositionObject):
             customizable_input_parameters, InputParameter, allow_none=True
         )
 
-    def _resolve(self) -> Dict[str, Any]:
-        trigger: Dict[str, Any] = {}  # Does not include type in JSON
+    def _resolve(self) -> dict[str, Any]:
+        trigger: dict[str, Any] = {}  # Does not include type in JSON
         trigger["url"] = self.url
         if self.customizable_input_parameters:
             trigger["customizable_input_parameters"] = [
@@ -538,7 +540,7 @@ class Workflow(CompositionObject):
         super().__init__(type_=CompositionObjectType.WORKFLOW)
         self.trigger = trigger
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         workflow = {}  # Does not include type in JSON
         workflow["trigger"] = self.trigger._resolve()
         return workflow
@@ -567,8 +569,8 @@ class RawText:
         self.text = text
         self.emoji = emoji
 
-    def _resolve(self) -> Dict[str, Any]:
-        raw_text: Dict[str, Any] = {
+    def _resolve(self) -> dict[str, Any]:
+        raw_text: dict[str, Any] = {
             "type": self.type,
             "text": self.text,
         }
@@ -588,16 +590,16 @@ class ColumnSettings:
 
     def __init__(
         self,
-        align: Optional[str] = None,
-        is_wrapped: Optional[bool] = None,
+        align: str | None = None,
+        is_wrapped: bool | None = None,
     ) -> None:
         if align and align not in ["left", "center", "right"]:
             raise InvalidUsageError("`align` must be one of `left`, `center`, or `right`")
         self.align = align
         self.is_wrapped = is_wrapped
 
-    def _resolve(self) -> Dict[str, Any]:
-        column_settings: Dict[str, Any] = {}
+    def _resolve(self) -> dict[str, Any]:
+        column_settings: dict[str, Any] = {}
         if self.align:
             column_settings["align"] = self.align
         if self.is_wrapped is not None:

--- a/slackblocks/rich_text/__init__.py
+++ b/slackblocks/rich_text/__init__.py
@@ -9,6 +9,8 @@ These formatting elements can only be used within a
 See: <https://api.slack.com/reference/block-kit/blocks#rich_text>.
 """
 
+from __future__ import annotations
+
 from .elements import (
     RichText,
     RichTextChannel,

--- a/slackblocks/rich_text/elements.py
+++ b/slackblocks/rich_text/elements.py
@@ -4,10 +4,12 @@ Rich text elements are the primitive elements used to populate the rich
     [`RichTextBlock`](/slackblocks/latest/reference/blocks/#blocks.RichTextBlock).
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from enum import Enum
 from json import dumps
-from typing import Any, Dict, Optional
+from typing import Any
 
 from slackblocks.utils import validate_string
 
@@ -38,7 +40,7 @@ class RichTextElement(ABC):
         self.type_ = type_
 
     @abstractmethod
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         return {"type": self.type_.value}
 
     def __repr__(self) -> str:
@@ -65,10 +67,10 @@ class RichText(RichTextElement):
     def __init__(
         self,
         text: str,
-        bold: Optional[bool] = None,
-        italic: Optional[bool] = None,
-        strike: Optional[bool] = None,
-        code: Optional[bool] = None,
+        bold: bool | None = None,
+        italic: bool | None = None,
+        strike: bool | None = None,
+        code: bool | None = None,
     ) -> None:
         super().__init__(type_=RichTextElementType.TEXT)
         self.text = text
@@ -77,7 +79,7 @@ class RichText(RichTextElement):
         self.strike = strike
         self.code = code
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         rich_text = super()._resolve()
         rich_text["text"] = self.text
         style = {}
@@ -115,12 +117,12 @@ class RichTextChannel(RichTextElement):
     def __init__(
         self,
         channel_id: str,
-        bold: Optional[bool] = None,
-        italic: Optional[bool] = None,
-        strike: Optional[bool] = None,
-        highlight: Optional[bool] = None,
-        client_highlight: Optional[bool] = None,
-        unlink: Optional[bool] = None,
+        bold: bool | None = None,
+        italic: bool | None = None,
+        strike: bool | None = None,
+        highlight: bool | None = None,
+        client_highlight: bool | None = None,
+        unlink: bool | None = None,
     ) -> None:
         super().__init__(RichTextElementType.CHANNEL)
         self.channel_id = channel_id
@@ -131,7 +133,7 @@ class RichTextChannel(RichTextElement):
         self.client_highlight = client_highlight
         self.unlink = unlink
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         channel = super()._resolve()
         channel["channel_id"] = self.channel_id
         style = {}
@@ -171,7 +173,7 @@ class RichTextEmoji(RichTextElement):
         super().__init__(RichTextElementType.EMOJI)
         self.name = validate_string(name, field_name="name", min_length=1)
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         emoji = super()._resolve()
         emoji["name"] = self.name
         return emoji
@@ -198,12 +200,12 @@ class RichTextLink(RichTextElement):
     def __init__(
         self,
         url: str,
-        text: Optional[str] = None,
-        unsafe: Optional[bool] = None,
-        bold: Optional[bool] = None,
-        italic: Optional[bool] = None,
-        strike: Optional[bool] = None,
-        code: Optional[bool] = None,
+        text: str | None = None,
+        unsafe: bool | None = None,
+        bold: bool | None = None,
+        italic: bool | None = None,
+        strike: bool | None = None,
+        code: bool | None = None,
     ) -> None:
         super().__init__(type_=RichTextElementType.LINK)
         self.url = url
@@ -214,7 +216,7 @@ class RichTextLink(RichTextElement):
         self.strike = strike
         self.code = code
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         link = super()._resolve()
         link["url"] = self.url
         if self.text is not None:
@@ -257,12 +259,12 @@ class RichTextUser(RichTextElement):
     def __init__(
         self,
         user_id: str,
-        bold: Optional[bool] = None,
-        italic: Optional[bool] = None,
-        strike: Optional[bool] = None,
-        highlight: Optional[bool] = None,
-        client_highlight: Optional[bool] = None,
-        unlink: Optional[bool] = None,
+        bold: bool | None = None,
+        italic: bool | None = None,
+        strike: bool | None = None,
+        highlight: bool | None = None,
+        client_highlight: bool | None = None,
+        unlink: bool | None = None,
     ) -> None:
         super().__init__(RichTextElementType.USER)
         self.user_id = user_id
@@ -273,7 +275,7 @@ class RichTextUser(RichTextElement):
         self.client_highlight = client_highlight
         self.unlink = unlink
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         user = super()._resolve()
         user["user_id"] = self.user_id
         style = {}
@@ -315,12 +317,12 @@ class RichTextUserGroup(RichTextElement):
     def __init__(
         self,
         user_group_id: str,
-        bold: Optional[bool] = None,
-        italic: Optional[bool] = None,
-        strike: Optional[bool] = None,
-        highlight: Optional[bool] = None,
-        client_highlight: Optional[bool] = None,
-        unlink: Optional[bool] = None,
+        bold: bool | None = None,
+        italic: bool | None = None,
+        strike: bool | None = None,
+        highlight: bool | None = None,
+        client_highlight: bool | None = None,
+        unlink: bool | None = None,
     ) -> None:
         super().__init__(RichTextElementType.USER_GROUP)
         self.user_group_id = user_group_id
@@ -331,7 +333,7 @@ class RichTextUserGroup(RichTextElement):
         self.client_highlight = client_highlight
         self.unlink = unlink
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         user_group = super()._resolve()
         user_group["usergroup_id"] = self.user_group_id
         style = {}

--- a/slackblocks/rich_text/objects.py
+++ b/slackblocks/rich_text/objects.py
@@ -5,10 +5,12 @@ These obejects form the contents of the
     [`RichTextBlock`](/slackblocks/latest/reference/blocks/#blocks.RichTextBlock).
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from enum import Enum
 from json import dumps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from slackblocks.errors import InvalidUsageError
 from slackblocks.rich_text.elements import (
@@ -43,7 +45,7 @@ class ListType(Enum):
     ORDERED = "ordered"
 
     @classmethod
-    def all(cls) -> List[str]:
+    def all(cls) -> list[str]:
         return [list_type.value for list_type in ListType]
 
 
@@ -60,7 +62,7 @@ class RichTextObject(ABC):
         self.type_ = type_
 
     @abstractmethod
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         return {"type": self.type_.value}
 
     def __repr__(self) -> str:
@@ -84,7 +86,7 @@ class RichTextSection(RichTextObject):
             `RichTextObject`.
     """
 
-    def __init__(self, elements: Union[RichTextElement, List[RichTextElement]]) -> None:
+    def __init__(self, elements: RichTextElement | list[RichTextElement]) -> None:
         super().__init__(type_=RichTextObjectType.SECTION)
         self.elements = coerce_to_list(
             elements,
@@ -99,7 +101,7 @@ class RichTextSection(RichTextObject):
             min_size=1,
         )
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         section = super()._resolve()
         if self.elements is not None:
             section["elements"] = [element._resolve() for element in self.elements]
@@ -127,11 +129,11 @@ class RichTextList(RichTextObject):
 
     def __init__(
         self,
-        style: Union[str, ListType],
-        elements: Union[RichTextSection, List[RichTextSection]],
-        indent: Optional[int] = None,
-        offset: Optional[int] = 0,
-        border: Optional[int] = 0,
+        style: str | ListType,
+        elements: RichTextSection | list[RichTextSection],
+        indent: int | None = None,
+        offset: int | None = 0,
+        border: int | None = 0,
     ) -> None:
         super().__init__(type_=RichTextObjectType.LIST)
         if isinstance(style, str):
@@ -146,8 +148,8 @@ class RichTextList(RichTextObject):
         self.offset = validate_int(offset, allow_none=True)
         self.border = validate_int(border, allow_none=True)
 
-    def _resolve(self) -> Dict[str, Any]:
-        rich_text_list: Dict[str, Any] = super()._resolve()
+    def _resolve(self) -> dict[str, Any]:
+        rich_text_list: dict[str, Any] = super()._resolve()
         if self.elements is not None:
             rich_text_list["elements"] = [
                 element._resolve() for element in self.elements if element is not None
@@ -183,8 +185,8 @@ class RichTextCodeBlock(RichTextObject):
 
     def __init__(
         self,
-        elements: Union[RichTextElement, List[RichTextElement]],
-        border: Optional[int] = None,
+        elements: RichTextElement | list[RichTextElement],
+        border: int | None = None,
     ) -> None:
         super().__init__(type_=RichTextObjectType.PREFORMATTED)
         self.elements = coerce_to_list(
@@ -200,7 +202,7 @@ class RichTextCodeBlock(RichTextObject):
         )
         self.border = border
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         preformatted = super()._resolve()
         if self.elements is not None:
             preformatted["elements"] = [
@@ -228,8 +230,8 @@ class RichTextQuote(RichTextObject):
 
     def __init__(
         self,
-        elements: Union[RichTextElement, List[RichTextElement]],
-        border: Optional[int] = None,
+        elements: RichTextElement | list[RichTextElement],
+        border: int | None = None,
     ) -> None:
         super().__init__(RichTextObjectType.QUOTE)
         self.elements = coerce_to_list(
@@ -245,7 +247,7 @@ class RichTextQuote(RichTextObject):
         )
         self.border = border
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         quote = super()._resolve()
         if self.elements is not None:
             quote["elements"] = [

--- a/slackblocks/utils.py
+++ b/slackblocks/utils.py
@@ -3,8 +3,10 @@ This module collects various utility functions used for validating
 the input to `Messages`, `Blocks`, `Elements` and `Objects`.
 """
 
+from __future__ import annotations
+
 from string import hexdigits
-from typing import Any, List, Optional, TypeVar, Union
+from typing import Any, TypeVar
 
 from slackblocks.errors import InvalidUsageError
 
@@ -12,11 +14,11 @@ T = TypeVar("T")
 
 
 def coerce_to_list_nonnull(
-    object_or_objects: Union[T, List[T]],
-    class_: Union[Any, List[Any]],
-    min_size: Optional[int] = None,
-    max_size: Optional[int] = None,
-) -> List[T]:
+    object_or_objects: T | list[T],
+    class_: Any | list[Any],
+    min_size: int | None = None,
+    max_size: int | None = None,
+) -> list[T]:
     """
     Takes an object or list of objects and validates its contents, ensuring that the
     resulting object is a list. This version does not handle None values.
@@ -33,7 +35,7 @@ def coerce_to_list_nonnull(
     Throws:
         InvalidUsageError: if any of the validation checks fail.
     """
-    if isinstance(object_or_objects, List):
+    if isinstance(object_or_objects, list):
         items = object_or_objects
     else:
         items = [object_or_objects]
@@ -61,12 +63,12 @@ def coerce_to_list_nonnull(
 
 
 def coerce_to_list(
-    object_or_objects: Optional[Union[T, List[T]]],
-    class_: Union[Any, List[Any]],
+    object_or_objects: T | list[T] | None,
+    class_: Any | list[Any],
     allow_none: bool = False,
-    min_size: Optional[int] = None,
-    max_size: Optional[int] = None,
-) -> Optional[List[T]]:
+    min_size: int | None = None,
+    max_size: int | None = None,
+) -> list[T] | None:
     """
     Takes and object or list of objects and validates its contents, ensuring that the
     resulting object is a list.
@@ -109,7 +111,7 @@ def is_hex(string: str) -> bool:
     return all(char in hexdigits for char in string)
 
 
-def validate_action_id(action_id: Optional[str], allow_none: bool = False) -> Optional[str]:
+def validate_action_id(action_id: str | None, allow_none: bool = False) -> str | None:
     """
     Action IDs are used in the handing of user interactivity within Slack blocks.
     This function checks that a given `action_id` is valid as per the requirements
@@ -142,12 +144,12 @@ def validate_action_id(action_id: Optional[str], allow_none: bool = False) -> Op
 
 
 def validate_string(
-    string: Optional[str],
+    string: str | None,
     field_name: str,
-    max_length: Optional[int] = None,
-    min_length: Optional[int] = None,
+    max_length: int | None = None,
+    min_length: int | None = None,
     allow_none: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """
     Performs basic validation actions (e.g. length checking) on a given string
     based on the provided criteria.
@@ -177,8 +179,8 @@ def validate_string(
 def validate_string_nonnull(
     string: str,
     field_name: str = "string",
-    max_length: Optional[int] = None,
-    min_length: Optional[int] = None,
+    max_length: int | None = None,
+    min_length: int | None = None,
 ) -> str:
     length = len(string)
     if min_length is not None and length < min_length:
@@ -195,11 +197,11 @@ def validate_string_nonnull(
 
 
 def validate_int(
-    num: Optional[int],
-    min_value: Optional[int] = None,
-    max_value: Optional[int] = None,
+    num: int | None,
+    min_value: int | None = None,
+    max_value: int | None = None,
     allow_none: bool = False,
-) -> Optional[int]:
+) -> int | None:
     """
     Performs basic validation checks against a given integer.
 

--- a/slackblocks/views.py
+++ b/slackblocks/views.py
@@ -4,9 +4,11 @@ Views are app-customized visual areas within modals and Home tabs.
 See: <https://api.slack.com/reference/surfaces/views>.
 """
 
+from __future__ import annotations
+
 from enum import Enum
 from json import dumps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from slackblocks.blocks import Block
 from slackblocks.objects import Text, TextLike
@@ -24,10 +26,10 @@ class View:
     def __init__(
         self,
         type: ViewType,
-        blocks: Union[Block, List[Block]],
-        private_metadata: Optional[str] = None,
-        callback_id: Optional[str] = None,
-        external_id: Optional[str] = None,
+        blocks: Block | list[Block],
+        private_metadata: str | None = None,
+        callback_id: str | None = None,
+        external_id: str | None = None,
     ) -> None:
         self.type_ = type.value
         self.blocks = coerce_to_list(blocks, class_=Block, min_size=1, max_size=100)
@@ -42,8 +44,8 @@ class View:
         )
         self.external_id = external_id
 
-    def _resolve(self) -> Dict[str, Any]:
-        view: Dict[str, Any] = {}
+    def _resolve(self) -> dict[str, Any]:
+        view: dict[str, Any] = {}
         view["type"] = self.type_
         if self.blocks is not None:
             view["blocks"] = [block._resolve() for block in self.blocks]
@@ -55,7 +57,7 @@ class View:
             view["external_id"] = self.external_id
         return view
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return self._resolve()
 
     def __repr__(self) -> str:
@@ -93,15 +95,15 @@ class ModalView(View):
     def __init__(
         self,
         title: TextLike,
-        blocks: Union[Block, List[Block]],
-        close: Optional[TextLike] = None,
-        submit: Optional[TextLike] = None,
-        private_metadata: Optional[str] = None,
-        callback_id: Optional[str] = None,
-        clear_on_close: Optional[bool] = False,
-        notify_on_close: Optional[bool] = False,
-        external_id: Optional[str] = None,
-        submit_disabled: Optional[bool] = False,
+        blocks: Block | list[Block],
+        close: TextLike | None = None,
+        submit: TextLike | None = None,
+        private_metadata: str | None = None,
+        callback_id: str | None = None,
+        clear_on_close: bool | None = False,
+        notify_on_close: bool | None = False,
+        external_id: str | None = None,
+        submit_disabled: bool | None = False,
     ) -> None:
         super().__init__(
             type=ViewType.MODAL,
@@ -117,7 +119,7 @@ class ModalView(View):
         self.notify_on_close = notify_on_close
         self.submit_disabled = submit_disabled
 
-    def _resolve(self) -> Dict[str, Any]:
+    def _resolve(self) -> dict[str, Any]:
         modal_view = super()._resolve()
         modal_view["title"] = self.title._resolve()
         if self.close:
@@ -150,10 +152,10 @@ class HomeTabView(View):
 
     def __init__(
         self,
-        blocks: Union[Block, List[Block]],
-        private_metadata: Optional[str] = None,
-        callback_id: Optional[str] = None,
-        external_id: Optional[str] = None,
+        blocks: Block | list[Block],
+        private_metadata: str | None = None,
+        callback_id: str | None = None,
+        external_id: str | None = None,
     ) -> None:
         super().__init__(
             type=ViewType.HOME,

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # TODO(nick): enable in GH actions
 
 from os import environ
@@ -19,7 +21,7 @@ def test_basic_attachment_message() -> None:
     client = WebClient(token=environ["SLACK_BOT_TOKEN"])
     response = client.chat_postMessage(**message)
     assert response.status_code == 200
-    with open("test/samples/message_basic_attachment.json", "r") as expected:
+    with open("test/samples/message_basic_attachment.json") as expected:
         assert repr(message) == expected.read()
 
 
@@ -42,5 +44,5 @@ def test_compound_message() -> None:
     client = WebClient(token=environ["SLACK_BOT_TOKEN"])
     response = client.chat_postMessage(**message)
     assert response.status_code == 200
-    with open("test/samples/message_compound.json", "r") as expected:
+    with open("test/samples/message_compound.json") as expected:
         assert repr(message) == expected.read()

--- a/test/unit/test_attachments.py
+++ b/test/unit/test_attachments.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from slackblocks import Attachment, Color, SectionBlock
 
 
 def test_single_attachment() -> None:
     block = SectionBlock("I like pretty colours", block_id="fake_block_id")
     attachment = Attachment(blocks=block, color=Color.BLACK, fallback="Colours preference")
-    with open("test/samples/attachments/attachment_simple.json", "r") as expected:
+    with open("test/samples/attachments/attachment_simple.json") as expected:
         assert repr(attachment) == expected.read()
 
 
@@ -12,5 +14,5 @@ def test_multi_block_attachment() -> None:
     block_0 = SectionBlock("I like pretty colours", block_id="fake_block_id_0")
     block_1 = SectionBlock("I don't like pretty colours", block_id="fake_block_id_1")
     attachment = Attachment(blocks=[block_0, block_1], color=Color.PURPLE)
-    with open("test/samples/attachments/attachment_multi_block.json", "r") as expected:
+    with open("test/samples/attachments/attachment_multi_block.json") as expected:
         assert repr(attachment) == expected.read()

--- a/test/unit/test_blocks.py
+++ b/test/unit/test_blocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import pytest

--- a/test/unit/test_elements.py
+++ b/test/unit/test_elements.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from slackblocks.elements import (

--- a/test/unit/test_errors.py
+++ b/test/unit/test_errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from slackblocks import Attachment

--- a/test/unit/test_exports.py
+++ b/test/unit/test_exports.py
@@ -4,6 +4,8 @@
 Regression tests for #154 (FileInput and SlackFile were defined in submodules
 but never re-exported)."""
 
+from __future__ import annotations
+
 
 def test_file_input_is_exported() -> None:
     from slackblocks import FileInput  # noqa: F401

--- a/test/unit/test_messages.py
+++ b/test/unit/test_messages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from slackblocks import (
     Attachment,
     Color,
@@ -13,7 +15,7 @@ from slackblocks import (
 def test_basic_message() -> None:
     block = SectionBlock("Hello, world!", block_id="fake_block_id")
     message = Message(channel="#slackblocks", blocks=block)
-    with open("test/samples/messages/message_basic.json", "r") as expected:
+    with open("test/samples/messages/message_basic.json") as expected:
         assert repr(message) == expected.read()
 
 
@@ -25,7 +27,7 @@ def test_message_with_optional_arguments() -> None:
         unfurl_links=False,
         unfurl_media=False,
     )
-    with open("test/samples/messages/message_with_optional_arguments.json", "r") as expected:
+    with open("test/samples/messages/message_with_optional_arguments.json") as expected:
         assert repr(message) == expected.read()
 
 
@@ -38,14 +40,14 @@ def test_message_with_attachment() -> None:
             attachment,
         ],
     )
-    with open("test/samples/messages/message_with_attachments.json", "r") as expected:
+    with open("test/samples/messages/message_with_attachments.json") as expected:
         assert repr(message) == expected.read()
 
 
 def test_message_response() -> None:
     block = SectionBlock("Hello, world!", block_id="fake_block_id")
     message = MessageResponse(blocks=block, ephemeral=True)
-    with open("test/samples/messages/message_response.json", "r") as expected:
+    with open("test/samples/messages/message_response.json") as expected:
         assert repr(message) == expected.read()
 
 
@@ -68,7 +70,7 @@ def test_to_dict() -> None:
 
 
 def test_basic_webhook_message() -> None:
-    with open("test/samples/messages/webhook_message_basic.json", "r") as expected:
+    with open("test/samples/messages/webhook_message_basic.json") as expected:
         assert (
             repr(
                 WebhookMessage(
@@ -96,7 +98,7 @@ def test_basic_webhook_message() -> None:
 
 
 def test_webhook_message_delete() -> None:
-    with open("test/samples/messages/webhook_message_delete.json", "r") as expected:
+    with open("test/samples/messages/webhook_message_delete.json") as expected:
         assert (
             repr(
                 WebhookMessage(

--- a/test/unit/test_objects.py
+++ b/test/unit/test_objects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from slackblocks.errors import InvalidUsageError

--- a/test/unit/test_rich_text.py
+++ b/test/unit/test_rich_text.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from slackblocks.rich_text import (
     ListType,
     RichText,

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from slackblocks.errors import InvalidUsageError

--- a/test/unit/test_views.py
+++ b/test/unit/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from slackblocks import HomeTabView, Modal
 from slackblocks.blocks import DividerBlock, SectionBlock
 

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
 
 from slackblocks.objects import Option, Text, TextType
 
@@ -12,6 +13,6 @@ THREE_OPTIONS = TWO_OPTIONS + [
 ]
 
 
-def fetch_sample(path: Union[Path, str]) -> str:
-    with open(path, "r") as file_:
+def fetch_sample(path: Path | str) -> str:
+    with open(path) as file_:
         return file_.read()


### PR DESCRIPTION
Closes #170

## Summary
Modernize the entire annotation surface to use PEP 585 builtin generics and PEP 604 unions, and add `from __future__ import annotations` to every module so future code can rely on lazy annotation evaluation.

## Approach
- Added `from __future__ import annotations` to every module under `slackblocks/` and `test/` (25 files).
- Added `target-version = "py310"` to `[tool.ruff]`.
- Enabled `UP` (pyupgrade) in `[tool.ruff.lint].select`. Ruff's autofix did the heavy lifting:
  - `UP006` (`List[T]` -> `list[T]`, `Dict[K,V]` -> `dict[K,V]`)
  - `UP007` / `UP045` (`Union[X, Y]` -> `X | Y`, `Optional[X]` -> `X | None`)
  - `UP015` (redundant `open` modes)
  - `UP008` (`super()` with no parameters)
- Manually converted two runtime aliases (`TextLike`, `ButtonStyleLike`) to `X | Y` form; ruff marks these as unsafe-fix because they are runtime expressions rather than annotations, but on Python 3.10+ both forms are valid at runtime.
- Dropped now-unused `typing.{List, Dict, Optional, Union}` imports (auto-fixed via F401).

## What this isn't
- No logic changes. No new ruff rule families beyond `UP` (the rest land in #171 / Phase 2.5).
- mypy and the 132-test suite remain green.

## Verification
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy slackblocks` — clean
- `uv run pytest test/unit` — 132 passed