### PR TITLE
chore: enable additional ruff rule families (B, I, SIM, TC)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,14 +63,21 @@ target-version = "py310"
 exclude = [".venv", "build", "dist", ".eggs", ".git"]
 
 [tool.ruff.lint]
-# pycodestyle (E,W) + pyflakes (F) + pyupgrade (UP). Additional rule families
-# (B, SIM, I, TCH) can be enabled in a follow-up PR with their own targeted
-# code changes.
-select = ["E", "F", "UP", "W"]
+# Rule families enabled:
+#   E, W   - pycodestyle
+#   F      - pyflakes
+#   B      - flake8-bugbear (likely bugs)
+#   I      - isort (import sorting)
+#   SIM    - flake8-simplify (simpler equivalents)
+#   TC     - flake8-type-checking (move type-only imports into TYPE_CHECKING)
+#   UP     - pyupgrade (modern syntax for the target Python version)
+select = ["B", "E", "F", "I", "SIM", "TC", "UP", "W"]
 # E501 (line-too-long) is handled by the formatter; don't lint it. Long lines
 # in docstrings (e.g. Slack API URLs) can't be wrapped without breaking
 # Markdown link rendering.
-ignore = ["E501"]
+# SIM108 (force ternary) is opinionated and hurts readability for the
+# multi-branch validation patterns used in this codebase.
+ignore = ["E501", "SIM108"]
 
 [tool.ruff.lint.per-file-ignores]
 "slackblocks/__init__.py" = ["F401"]

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -511,12 +511,11 @@ class TableBlock(Block):
         for row in rows:
             if len(row) != num_columns:
                 raise InvalidUsageError("All rows must have the same number of columns.")
-        if column_settings is not None:
-            if num_columns != len(column_settings):
-                raise InvalidUsageError(
-                    f"Number of column_settings ({len(column_settings)}) must"
-                    f"match number of columns in each row ({num_columns})."
-                )
+        if column_settings is not None and num_columns != len(column_settings):
+            raise InvalidUsageError(
+                f"Number of column_settings ({len(column_settings)}) must"
+                f"match number of columns in each row ({num_columns})."
+            )
         if len(rows) > 100:
             raise InvalidUsageError("`rows` can have a maximum of 100 items.")
         for row in rows:

--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from enum import Enum
 from itertools import chain
 from json import dumps
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .errors import InvalidUsageError
 from .objects import (
@@ -26,8 +26,10 @@ from .objects import (
     TextType,
     Workflow,
 )
-from .rich_text import RichText
 from .utils import coerce_to_list, validate_action_id, validate_int, validate_string
+
+if TYPE_CHECKING:
+    from .rich_text import RichText
 
 
 class ElementType(Enum):
@@ -890,25 +892,18 @@ class NumberInput(Element):
         self.initial_value = initial_value
         self.min_value = min_value
         self.max_value = max_value
-        if min_value:
-            if not is_decimal_allowed:
-                if isinstance(min_value, float):
-                    raise InvalidUsageError(
-                        f"`min_value` ({min_value}) cannot be a float when "
-                        "`is_decimal_allowed` is `False`"
-                    )
-        if max_value:
-            if not is_decimal_allowed:
-                if isinstance(max_value, float):
-                    raise InvalidUsageError(
-                        f"`max_value` ({max_value}) cannot be a float when "
-                        "`is_decimal_allowed` is `False`"
-                    )
-        if min_value is not None and max_value is not None:
-            if min_value > max_value:
-                raise InvalidUsageError(
-                    f"`min_value` ({min_value}) cannot be greater than `max_value` ({max_value})"
-                )
+        if min_value and not is_decimal_allowed and isinstance(min_value, float):
+            raise InvalidUsageError(
+                f"`min_value` ({min_value}) cannot be a float when `is_decimal_allowed` is `False`"
+            )
+        if max_value and not is_decimal_allowed and isinstance(max_value, float):
+            raise InvalidUsageError(
+                f"`max_value` ({max_value}) cannot be a float when `is_decimal_allowed` is `False`"
+            )
+        if min_value is not None and max_value is not None and min_value > max_value:
+            raise InvalidUsageError(
+                f"`min_value` ({min_value}) cannot be greater than `max_value` ({max_value})"
+            )
         self.dispatch_action_config = dispatch_action_config
         self.focus_on_load = focus_on_load
         self.placeholder = Text.to_text(

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 # TODO(nick): enable in GH actions
-
 from os import environ
 
 from slack_sdk import WebClient

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from slackblocks.objects import Option, Text, TextType
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 OPTION_A = Option(text=Text("A", type_=TextType.PLAINTEXT), value="A")
 OPTION_B = Option(text=Text("B", type_=TextType.PLAINTEXT), value="B")


### PR DESCRIPTION
Closes #172

## Summary
Extends `[tool.ruff.lint].select` to cover `B` (bugbear), `I` (isort), `SIM` (simplify), and `TC` (type-checking) in addition to the previously-enabled `E`, `F`, `UP`, `W`. Locks in modern, idiomatic patterns going forward.

## Config

```toml
[tool.ruff.lint]
select = ["B", "E", "F", "I", "SIM", "TC", "UP", "W"]
ignore = ["E501", "SIM108"]
```

`SIM108` (force ternary) is ignored because it harms readability for the multi-branch validation patterns in this codebase.

## Fixes applied
- **I001** (isort): sort imports in `test/integration/test_integration.py`; reshuffle the import block in `slackblocks/elements.py` after moving `RichText` into `if TYPE_CHECKING:`.
- **SIM102** (collapsible-if): combine nested `if` statements in:
  - `slackblocks/blocks.py`: `TableBlock` `column_settings` length check.
  - `slackblocks/elements.py`: `NumberInput` `min_value`/`max_value` validation (three sites).
- **TC001 / TC003** (type-only imports): move into `if TYPE_CHECKING:` blocks:
  - `slackblocks/elements.py`: `from .rich_text import RichText`.
  - `test/unit/utils.py`: `from pathlib import Path`.

`B` (bugbear) reported nothing.

## Verification
- `uv run ruff check .` clean
- `uv run ruff format --check .` clean
- `uv run mypy slackblocks` clean
- `uv run pytest test/unit` — 132 passed