### PR TITLE
feat: introduce _core.py with Resolvable + resolve() + omit_none()

### DIFF
--- a/slackblocks/_core.py
+++ b/slackblocks/_core.py
@@ -1,0 +1,88 @@
+"""
+Shared infrastructure for rendering slackblocks objects into Slack-API-compatible
+JSON structures.
+
+This is a private module. The public API is unchanged; the helpers here are
+used internally to deduplicate the ``_resolve`` boilerplate that every block,
+element, and composition object class previously implemented by hand.
+
+The two patterns this module captures:
+
+1. ``Resolvable`` -- a structural protocol describing the contract that every
+   slackblocks renderable class satisfies: a ``_resolve()`` method returning a
+   ``dict[str, Any]`` ready to be passed to ``json.dumps``.
+
+2. ``resolve(value)`` -- a recursive helper that walks a value (any
+   combination of ``Resolvable`` instances, dicts, lists, tuples, and JSON
+   primitives) and produces a plain JSON-serializable structure. This replaces
+   the manual ``x._resolve()`` calls inside individual ``_resolve``
+   implementations and prevents the entire class of bugs that produced eight
+   of the Phase 1 P0 fixes (forgetting to recurse into a nested object).
+
+3. ``omit_none(d)`` -- strip ``None``-valued keys from a dict. Replaces the
+   pervasive ``if self.x is not None: out['x'] = self.x`` pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Resolvable(Protocol):
+    """Structural type for any slackblocks class that renders to a JSON-compatible dict.
+
+    Implemented (implicitly, via duck typing) by every block, element, and
+    composition object in the library.
+    """
+
+    def _resolve(self) -> dict[str, Any]: ...
+
+
+def resolve(value: Any) -> Any:
+    """Recursively convert ``value`` into a JSON-serializable structure.
+
+    - ``None`` and JSON primitives (``bool``, ``int``, ``float``, ``str``) are
+      returned unchanged.
+    - ``Resolvable`` instances (objects with a ``_resolve`` method) are
+      converted by calling that method and recursively resolving the result.
+    - ``dict`` is walked, resolving each value and stripping keys whose
+      resolved value is ``None``.
+    - ``list`` and ``tuple`` are walked element-wise; ``None`` elements are
+      preserved (Slack does not generally expect ``None`` in arrays, but the
+      caller controls list contents).
+
+    The behaviour matches what the hand-written ``_resolve`` implementations
+    do today, with the recursion guaranteed at every nesting depth.
+    """
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, raw in value.items():
+            resolved = resolve(raw)
+            if resolved is not None:
+                out[key] = resolved
+        return out
+    if isinstance(value, list | tuple):
+        return [resolve(item) for item in value]
+    # Duck-typed Resolvable check: explicit attribute lookup is faster than
+    # isinstance(value, Resolvable) and avoids the runtime_checkable overhead
+    # on hot paths.
+    resolve_method = getattr(value, "_resolve", None)
+    if callable(resolve_method):
+        return resolve(resolve_method())
+    # Fall through: assume the value is already JSON-serializable (e.g. a
+    # custom numeric type). json.dumps will raise TypeError if it isn't.
+    return value
+
+
+def omit_none(d: dict[str, Any]) -> dict[str, Any]:
+    """Return a new dict with ``None``-valued keys removed.
+
+    Convenience for the ``if self.x is not None: out['x'] = self.x`` pattern
+    that appears throughout the library's ``_resolve`` methods. Prefer this
+    over manual key-by-key omission so future code consistently treats
+    ``None`` as "field not set".
+    """
+    return {key: value for key, value in d.items() if value is not None}

--- a/test/unit/test_core.py
+++ b/test/unit/test_core.py
@@ -1,0 +1,94 @@
+"""Tests for the private ``slackblocks._core`` module that provides shared
+JSON-resolution infrastructure used by the rest of the library."""
+
+from __future__ import annotations
+
+import json
+
+from slackblocks._core import Resolvable, omit_none, resolve
+
+
+class _ToyResolvable:
+    """Minimal Resolvable used in tests; produces a dict with a nested
+    Resolvable so we can verify recursion."""
+
+    def __init__(self, value: int, child: _ToyResolvable | None = None) -> None:
+        self.value = value
+        self.child = child
+
+    def _resolve(self) -> dict[str, object]:
+        return {"value": self.value, "child": self.child}
+
+
+def test_resolve_primitive_passthrough() -> None:
+    assert resolve(None) is None
+    assert resolve(True) is True
+    assert resolve(42) == 42
+    assert resolve(3.14) == 3.14
+    assert resolve("hi") == "hi"
+
+
+def test_resolve_dict_strips_none_values() -> None:
+    assert resolve({"a": 1, "b": None, "c": "x"}) == {"a": 1, "c": "x"}
+
+
+def test_resolve_list_passes_through_elements() -> None:
+    assert resolve([1, "two", None, 3.0]) == [1, "two", None, 3.0]
+
+
+def test_resolve_tuple_becomes_list() -> None:
+    assert resolve((1, 2, 3)) == [1, 2, 3]
+
+
+def test_resolve_calls_resolve_method_on_resolvable() -> None:
+    toy = _ToyResolvable(value=7)
+    assert resolve(toy) == {"value": 7}
+
+
+def test_resolve_recurses_into_nested_resolvables() -> None:
+    inner = _ToyResolvable(value=1)
+    outer = _ToyResolvable(value=2, child=inner)
+    assert resolve(outer) == {"value": 2, "child": {"value": 1}}
+
+
+def test_resolve_output_is_json_serializable() -> None:
+    """The whole point of resolve(): the output must be json.dumps-clean.
+    This guards against the entire class of Phase 1 P0 bugs."""
+    inner = _ToyResolvable(value=1)
+    outer = _ToyResolvable(value=2, child=inner)
+    payload = resolve({"top": outer, "extras": [inner, inner], "skip": None})
+    json.dumps(payload)  # Must not raise.
+    assert payload == {
+        "top": {"value": 2, "child": {"value": 1}},
+        "extras": [{"value": 1}, {"value": 1}],
+    }
+
+
+def test_omit_none_drops_only_none_values() -> None:
+    """Falsy non-None values (0, '', False, []) must be preserved."""
+    assert omit_none({"a": 1, "b": None, "c": 0, "d": "", "e": False, "f": []}) == {
+        "a": 1,
+        "c": 0,
+        "d": "",
+        "e": False,
+        "f": [],
+    }
+
+
+def test_omit_none_returns_new_dict() -> None:
+    original = {"a": 1, "b": None}
+    result = omit_none(original)
+    assert result is not original
+    assert original == {"a": 1, "b": None}
+
+
+def test_resolvable_protocol_runtime_checkable() -> None:
+    """isinstance(x, Resolvable) should succeed for duck-typed objects."""
+    toy = _ToyResolvable(value=1)
+    assert isinstance(toy, Resolvable)
+    # A class without _resolve must not pass.
+
+    class NotResolvable:
+        pass
+
+    assert not isinstance(NotResolvable(), Resolvable)


### PR DESCRIPTION
Closes #174

## Summary
First step of the Phase 3 dataclass rewrite. Introduces `slackblocks/_core.py` with the shared 'render to JSON-compatible dict' infrastructure that the existing abstract bases duplicate today.

## What's added
- `Resolvable` -- `runtime_checkable Protocol` declaring `_resolve(self) -> dict[str, Any]`. Every existing block/element/composition object already satisfies this implicitly.
- `resolve(value)` -- recursive walker that turns any combination of `Resolvable`/`dict`/`list`/`tuple`/primitive into a `json.dumps`-clean structure. This is the helper that prevents the entire class of bugs from Phase 1 (`Image.slack_file`, `URLInput.placeholder`, `TimePicker.confirm`, etc., all of which forgot to call `._resolve()` on a nested object).
- `omit_none(d)` -- strip `None`-valued keys. Replaces the pervasive `if self.x is not None: out['x'] = self.x` pattern.

## What's *not* changed
- No existing class or call site is modified.
- Public API unchanged.
- All existing `_resolve()` implementations continue to work as-is.

## Test coverage
Adds `test/unit/test_core.py` with 10 tests covering:
- primitive passthrough,
- dict resolution stripping `None`,
- list/tuple handling,
- recursive nested `Resolvable` resolution,
- `json.dumps` cleanliness guard,
- `omit_none` behaviour on falsy-but-not-None values,
- runtime `Protocol` checks.

132 -> 142 tests; all pass. `ruff`/`mypy` clean.