### PR TITLE
refactor: migrate rich_text/* to _core helpers + dedupe style emission

### DIFF
--- a/slackblocks/rich_text/elements.py
+++ b/slackblocks/rich_text/elements.py
@@ -11,6 +11,7 @@ from enum import Enum
 from json import dumps
 from typing import Any
 
+from slackblocks._core import omit_none
 from slackblocks.utils import validate_string
 
 
@@ -25,6 +26,17 @@ class RichTextElementType(Enum):
     TEXT = "text"
     USER = "user"
     USER_GROUP = "usergroup"
+
+
+def _style_dict(**flags: bool | None) -> dict[str, bool] | None:
+    """Build a rich text "style" sub-object from named boolean flags.
+
+    Any flag that is explicitly ``None`` is dropped. If every flag is dropped
+    (i.e. nothing was set), returns ``None`` so the caller can decide whether
+    to emit the ``style`` key at all.
+    """
+    style = omit_none(flags)
+    return style if style else None
 
 
 class RichTextElement(ABC):
@@ -80,20 +92,15 @@ class RichText(RichTextElement):
         self.code = code
 
     def _resolve(self) -> dict[str, Any]:
-        rich_text = super()._resolve()
-        rich_text["text"] = self.text
-        style = {}
-        if self.bold is not None:
-            style["bold"] = self.bold
-        if self.italic is not None:
-            style["italic"] = self.italic
-        if self.strike is not None:
-            style["strike"] = self.strike
-        if self.code is not None:
-            style["code"] = self.code
-        if style:
-            rich_text["style"] = style
-        return rich_text
+        return omit_none(
+            {
+                **super()._resolve(),
+                "text": self.text,
+                "style": _style_dict(
+                    bold=self.bold, italic=self.italic, strike=self.strike, code=self.code
+                ),
+            }
+        )
 
 
 class RichTextChannel(RichTextElement):
@@ -134,24 +141,20 @@ class RichTextChannel(RichTextElement):
         self.unlink = unlink
 
     def _resolve(self) -> dict[str, Any]:
-        channel = super()._resolve()
-        channel["channel_id"] = self.channel_id
-        style = {}
-        if self.bold is not None:
-            style["bold"] = self.bold
-        if self.italic is not None:
-            style["italic"] = self.italic
-        if self.strike is not None:
-            style["strike"] = self.strike
-        if self.highlight is not None:
-            style["highlight"] = self.highlight
-        if self.client_highlight is not None:
-            style["client_highlight"] = self.client_highlight
-        if self.unlink is not None:
-            style["unlink"] = self.unlink
-        if style:
-            channel["style"] = style
-        return channel
+        return omit_none(
+            {
+                **super()._resolve(),
+                "channel_id": self.channel_id,
+                "style": _style_dict(
+                    bold=self.bold,
+                    italic=self.italic,
+                    strike=self.strike,
+                    highlight=self.highlight,
+                    client_highlight=self.client_highlight,
+                    unlink=self.unlink,
+                ),
+            }
+        )
 
 
 class RichTextEmoji(RichTextElement):
@@ -174,9 +177,7 @@ class RichTextEmoji(RichTextElement):
         self.name = validate_string(name, field_name="name", min_length=1)
 
     def _resolve(self) -> dict[str, Any]:
-        emoji = super()._resolve()
-        emoji["name"] = self.name
-        return emoji
+        return {**super()._resolve(), "name": self.name}
 
 
 class RichTextLink(RichTextElement):
@@ -217,24 +218,17 @@ class RichTextLink(RichTextElement):
         self.code = code
 
     def _resolve(self) -> dict[str, Any]:
-        link = super()._resolve()
-        link["url"] = self.url
-        if self.text is not None:
-            link["text"] = self.text
-        if self.unsafe is not None:
-            link["unsafe"] = self.unsafe
-        style = {}
-        if self.bold is not None:
-            style["bold"] = self.bold
-        if self.italic is not None:
-            style["italic"] = self.italic
-        if self.strike is not None:
-            style["strike"] = self.strike
-        if self.code is not None:
-            style["code"] = self.code
-        if style:
-            link["style"] = style
-        return link
+        return omit_none(
+            {
+                **super()._resolve(),
+                "url": self.url,
+                "text": self.text,
+                "unsafe": self.unsafe,
+                "style": _style_dict(
+                    bold=self.bold, italic=self.italic, strike=self.strike, code=self.code
+                ),
+            }
+        )
 
 
 class RichTextUser(RichTextElement):
@@ -276,24 +270,20 @@ class RichTextUser(RichTextElement):
         self.unlink = unlink
 
     def _resolve(self) -> dict[str, Any]:
-        user = super()._resolve()
-        user["user_id"] = self.user_id
-        style = {}
-        if self.bold is not None:
-            style["bold"] = self.bold
-        if self.italic is not None:
-            style["italic"] = self.italic
-        if self.strike is not None:
-            style["strike"] = self.strike
-        if self.highlight is not None:
-            style["highlight"] = self.highlight
-        if self.client_highlight is not None:
-            style["client_highlight"] = self.client_highlight
-        if self.unlink is not None:
-            style["unlink"] = self.unlink
-        if style:
-            user["style"] = style
-        return user
+        return omit_none(
+            {
+                **super()._resolve(),
+                "user_id": self.user_id,
+                "style": _style_dict(
+                    bold=self.bold,
+                    italic=self.italic,
+                    strike=self.strike,
+                    highlight=self.highlight,
+                    client_highlight=self.client_highlight,
+                    unlink=self.unlink,
+                ),
+            }
+        )
 
 
 class RichTextUserGroup(RichTextElement):
@@ -334,21 +324,17 @@ class RichTextUserGroup(RichTextElement):
         self.unlink = unlink
 
     def _resolve(self) -> dict[str, Any]:
-        user_group = super()._resolve()
-        user_group["usergroup_id"] = self.user_group_id
-        style = {}
-        if self.bold is not None:
-            style["bold"] = self.bold
-        if self.italic is not None:
-            style["italic"] = self.italic
-        if self.strike is not None:
-            style["strike"] = self.strike
-        if self.highlight is not None:
-            style["highlight"] = self.highlight
-        if self.client_highlight is not None:
-            style["client_highlight"] = self.client_highlight
-        if self.unlink is not None:
-            style["unlink"] = self.unlink
-        if style:
-            user_group["style"] = style
-        return user_group
+        return omit_none(
+            {
+                **super()._resolve(),
+                "usergroup_id": self.user_group_id,
+                "style": _style_dict(
+                    bold=self.bold,
+                    italic=self.italic,
+                    strike=self.strike,
+                    highlight=self.highlight,
+                    client_highlight=self.client_highlight,
+                    unlink=self.unlink,
+                ),
+            }
+        )

--- a/slackblocks/rich_text/objects.py
+++ b/slackblocks/rich_text/objects.py
@@ -12,6 +12,7 @@ from enum import Enum
 from json import dumps
 from typing import Any
 
+from slackblocks._core import resolve
 from slackblocks.errors import InvalidUsageError
 from slackblocks.rich_text.elements import (
     RichText,
@@ -102,10 +103,7 @@ class RichTextSection(RichTextObject):
         )
 
     def _resolve(self) -> dict[str, Any]:
-        section = super()._resolve()
-        if self.elements is not None:
-            section["elements"] = [element._resolve() for element in self.elements]
-        return section
+        return resolve({**super()._resolve(), "elements": self.elements})
 
 
 class RichTextList(RichTextObject):
@@ -149,19 +147,18 @@ class RichTextList(RichTextObject):
         self.border = validate_int(border, allow_none=True)
 
     def _resolve(self) -> dict[str, Any]:
-        rich_text_list: dict[str, Any] = super()._resolve()
-        if self.elements is not None:
-            rich_text_list["elements"] = [
-                element._resolve() for element in self.elements if element is not None
-            ]
-        rich_text_list["style"] = self.style
-        if self.indent is not None:
-            rich_text_list["indent"] = self.indent
-        if self.offset is not None:
-            rich_text_list["offset"] = self.offset
-        if self.border is not None:
-            rich_text_list["border"] = self.border
-        return rich_text_list
+        return resolve(
+            {
+                **super()._resolve(),
+                "elements": [element for element in self.elements if element is not None]
+                if self.elements is not None
+                else None,
+                "style": self.style,
+                "indent": self.indent,
+                "offset": self.offset,
+                "border": self.border,
+            }
+        )
 
 
 class RichTextCodeBlock(RichTextObject):
@@ -203,14 +200,15 @@ class RichTextCodeBlock(RichTextObject):
         self.border = border
 
     def _resolve(self) -> dict[str, Any]:
-        preformatted = super()._resolve()
-        if self.elements is not None:
-            preformatted["elements"] = [
-                element._resolve() for element in self.elements if element is not None
-            ]
-        if self.border is not None:
-            preformatted["border"] = self.border
-        return preformatted
+        return resolve(
+            {
+                **super()._resolve(),
+                "elements": [element for element in self.elements if element is not None]
+                if self.elements is not None
+                else None,
+                "border": self.border,
+            }
+        )
 
 
 class RichTextQuote(RichTextObject):
@@ -248,11 +246,12 @@ class RichTextQuote(RichTextObject):
         self.border = border
 
     def _resolve(self) -> dict[str, Any]:
-        quote = super()._resolve()
-        if self.elements is not None:
-            quote["elements"] = [
-                element._resolve() for element in self.elements if element is not None
-            ]
-        if self.border is not None:
-            quote["border"] = self.border
-        return quote
+        return resolve(
+            {
+                **super()._resolve(),
+                "elements": [element for element in self.elements if element is not None]
+                if self.elements is not None
+                else None,
+                "border": self.border,
+            }
+        )


### PR DESCRIPTION
Closes #182

## Summary
Migrate rich text `_resolve` methods to use `_core.resolve()` and `_core.omit_none()`. Also introduces a small private helper `_style_dict()` in `rich_text/elements.py` to dedupe the 8-line style-building pattern duplicated across 5 classes.

## Diff highlights
- `rich_text/elements.py` (-57 lines net): the 5 duplicate style-emit blocks collapse to a single `_style_dict(**flags)` helper; each `_resolve` becomes a one-shot `omit_none({...})` call.
- `rich_text/objects.py` (-7 lines net): the 4 `_resolve` methods become one-liners.

## Behaviour preservation
- Public class signatures unchanged.
- 142 tests pass.
- ruff format + lint clean; mypy clean.