### PR TITLE
refactor: migrate views/messages/attachments _resolve to use _core helpers

### DIFF
--- a/slackblocks/attachments.py
+++ b/slackblocks/attachments.py
@@ -11,6 +11,7 @@ from enum import Enum
 from json import dumps
 from typing import Any
 
+from slackblocks._core import resolve
 from slackblocks.blocks import Block
 from slackblocks.errors import InvalidUsageError
 from slackblocks.utils import coerce_to_list, is_hex
@@ -183,14 +184,16 @@ class Attachment:
             self.color = None
 
     def _resolve(self) -> dict[str, Any]:
-        attachment: dict[str, Any] = {}
-        if self.blocks:
-            attachment["blocks"] = [block._resolve() for block in self.blocks]
-        if self.color:
-            attachment["color"] = self.color
-        if self.fallback:
-            attachment["fallback"] = self.fallback
-        return attachment
+        # Note: 'fields' is intentionally not included here. The attribute
+        # exists for legacy reasons but Attachment._resolve has historically
+        # never emitted it; preserving that behaviour.
+        return resolve(
+            {
+                "blocks": self.blocks if self.blocks else None,
+                "color": self.color if self.color else None,
+                "fallback": self.fallback if self.fallback else None,
+            }
+        )
 
     def __repr__(self) -> str:
         return dumps(self._resolve(), indent=4)

--- a/slackblocks/messages.py
+++ b/slackblocks/messages.py
@@ -11,6 +11,7 @@ from enum import Enum
 from json import dumps
 from typing import Any
 
+from slackblocks._core import resolve
 from slackblocks.utils import coerce_to_list
 
 from .attachments import Attachment
@@ -58,19 +59,20 @@ class BaseMessage:
         self.mrkdwn = mrkdwn
 
     def _resolve(self) -> dict[str, Any]:
-        message: dict[str, Any] = {}
-        if self.channel:
-            message["channel"] = self.channel
-        message["mrkdwn"] = self.mrkdwn
-        if self.blocks:
-            message["blocks"] = [block._resolve() for block in self.blocks]
-        if self.attachments:
-            message["attachments"] = [attachment._resolve() for attachment in self.attachments]
-        if self.thread_ts:
-            message["thread_ts"] = self.thread_ts
-        if self.text or self.text == "":
-            message["text"] = self.text
-        return message
+        # The 'text' field is intentionally emitted even when it is an empty
+        # string (Slack uses it as a notification fallback when blocks are
+        # present). resolve() strips None but preserves "" -- exactly the
+        # semantics we want here.
+        return resolve(
+            {
+                "channel": self.channel if self.channel else None,
+                "mrkdwn": self.mrkdwn,
+                "blocks": self.blocks if self.blocks else None,
+                "attachments": self.attachments if self.attachments else None,
+                "thread_ts": self.thread_ts if self.thread_ts else None,
+                "text": self.text if (self.text or self.text == "") else None,
+            }
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return self._resolve()
@@ -131,12 +133,13 @@ class Message(BaseMessage):
         self.unfurl_media = unfurl_media
 
     def _resolve(self) -> dict[str, Any]:
-        result = {**super()._resolve()}
-        if self.unfurl_links is not None:
-            result["unfurl_links"] = self.unfurl_links
-        if self.unfurl_media is not None:
-            result["unfurl_media"] = self.unfurl_media
-        return result
+        return resolve(
+            {
+                **super()._resolve(),
+                "unfurl_links": self.unfurl_links,
+                "unfurl_media": self.unfurl_media,
+            }
+        )
 
 
 class MessageResponse(BaseMessage):
@@ -165,13 +168,13 @@ class MessageResponse(BaseMessage):
         self.ephemeral = ephemeral
 
     def _resolve(self) -> dict[str, Any]:
-        result: dict[str, Any] = {
-            **super()._resolve(),
-            "replace_original": self.replace_original,
-        }
-        if self.ephemeral:
-            result["response_type"] = "ephemeral"
-        return result
+        return resolve(
+            {
+                **super()._resolve(),
+                "replace_original": self.replace_original,
+                "response_type": "ephemeral" if self.ephemeral else None,
+            }
+        )
 
 
 class WebhookMessage:
@@ -237,32 +240,24 @@ class WebhookMessage:
         self.headers = headers
 
     def _resolve(self) -> dict[str, Any]:
-        webhook_message: dict[str, Any] = {}
-        if self.text is not None:
-            webhook_message["text"] = self.text
-        if self.attachments is not None:
-            webhook_message["attachments"] = [
-                attachment._resolve() for attachment in self.attachments if attachment is not None
-            ]
-        if self.blocks is not None:
-            webhook_message["blocks"] = [
-                block._resolve() for block in self.blocks if block is not None
-            ]
-        if self.response_type is not None:
-            webhook_message["response_type"] = self.response_type
-        if self.replace_original is not None:
-            webhook_message["replace_original"] = self.replace_original
-        if self.delete_original is not None:
-            webhook_message["delete_original"] = self.delete_original
-        if self.unfurl_links is not None:
-            webhook_message["unfurl_links"] = self.unfurl_links
-        if self.unfurl_media is not None:
-            webhook_message["unfurl_media"] = self.unfurl_media
-        if self.metadata is not None:
-            webhook_message["metadata"] = self.metadata
-        if self.headers is not None:
-            webhook_message["headers"] = self.headers
-        return webhook_message
+        return resolve(
+            {
+                "text": self.text,
+                "attachments": [att for att in self.attachments if att is not None]
+                if self.attachments is not None
+                else None,
+                "blocks": [block for block in self.blocks if block is not None]
+                if self.blocks is not None
+                else None,
+                "response_type": self.response_type,
+                "replace_original": self.replace_original,
+                "delete_original": self.delete_original,
+                "unfurl_links": self.unfurl_links,
+                "unfurl_media": self.unfurl_media,
+                "metadata": self.metadata,
+                "headers": self.headers,
+            }
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return self._resolve()

--- a/slackblocks/views.py
+++ b/slackblocks/views.py
@@ -10,6 +10,7 @@ from enum import Enum
 from json import dumps
 from typing import Any
 
+from slackblocks._core import resolve
 from slackblocks.blocks import Block
 from slackblocks.objects import Text, TextLike
 from slackblocks.utils import coerce_to_list, validate_string
@@ -45,17 +46,15 @@ class View:
         self.external_id = external_id
 
     def _resolve(self) -> dict[str, Any]:
-        view: dict[str, Any] = {}
-        view["type"] = self.type_
-        if self.blocks is not None:
-            view["blocks"] = [block._resolve() for block in self.blocks]
-        if self.private_metadata:
-            view["private_metadata"] = self.private_metadata
-        if self.callback_id:
-            view["callback_id"] = self.callback_id
-        if self.external_id:
-            view["external_id"] = self.external_id
-        return view
+        return resolve(
+            {
+                "type": self.type_,
+                "blocks": self.blocks,
+                "private_metadata": self.private_metadata if self.private_metadata else None,
+                "callback_id": self.callback_id if self.callback_id else None,
+                "external_id": self.external_id if self.external_id else None,
+            }
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return self._resolve()
@@ -120,19 +119,17 @@ class ModalView(View):
         self.submit_disabled = submit_disabled
 
     def _resolve(self) -> dict[str, Any]:
-        modal_view = super()._resolve()
-        modal_view["title"] = self.title._resolve()
-        if self.close:
-            modal_view["close"] = self.close._resolve()
-        if self.submit:
-            modal_view["submit"] = self.submit._resolve()
-        if self.clear_on_close:
-            modal_view["clear_on_close"] = self.clear_on_close
-        if self.notify_on_close:
-            modal_view["notify_on_close"] = self.notify_on_close
-        if self.submit_disabled:
-            modal_view["submit_disabled"] = self.submit_disabled
-        return modal_view
+        return resolve(
+            {
+                **super()._resolve(),
+                "title": self.title,
+                "close": self.close if self.close else None,
+                "submit": self.submit if self.submit else None,
+                "clear_on_close": self.clear_on_close if self.clear_on_close else None,
+                "notify_on_close": self.notify_on_close if self.notify_on_close else None,
+                "submit_disabled": self.submit_disabled if self.submit_disabled else None,
+            }
+        )
 
 
 class HomeTabView(View):


### PR DESCRIPTION
Closes #184

## Summary
Final migration step. Each `_resolve` method in `views.py`, `messages.py`, and `attachments.py` becomes a single declarative `resolve({...})` call.

## Diff highlights
- `views.py`: `View._resolve` and `ModalView._resolve` migrated.
- `messages.py`: `BaseMessage._resolve`, `Message._resolve`, `MessageResponse._resolve`, `WebhookMessage._resolve` migrated.
- `attachments.py`: `Attachment._resolve` migrated. `Field._resolve` returns a string (a legacy quirk -- it is never called from `Attachment._resolve` anyway) and is intentionally not touched.

## Behaviour preservation
- All public class signatures unchanged.
- 142 tests pass; ruff format/lint clean; mypy clean.
- `Message._resolve` empty-string `text` semantics preserved (Slack uses `text` as the notification fallback when blocks are present; `resolve()` preserves `""` and only strips `None`).