### PR TITLE
refactor: extract shared __repr__ from ABC bases into RenderableMixin

### DIFF
--- a/slackblocks/_core.py
+++ b/slackblocks/_core.py
@@ -6,7 +6,7 @@ This is a private module. The public API is unchanged; the helpers here are
 used internally to deduplicate the ``_resolve`` boilerplate that every block,
 element, and composition object class previously implemented by hand.
 
-The two patterns this module captures:
+The patterns this module captures:
 
 1. ``Resolvable`` -- a structural protocol describing the contract that every
    slackblocks renderable class satisfies: a ``_resolve()`` method returning a
@@ -21,10 +21,17 @@ The two patterns this module captures:
 
 3. ``omit_none(d)`` -- strip ``None``-valued keys from a dict. Replaces the
    pervasive ``if self.x is not None: out['x'] = self.x`` pattern.
+
+4. ``RenderableMixin`` -- shared ``__repr__`` (and string conversion) for
+   classes that implement ``_resolve()``. Inherited by the various abstract
+   bases (``Block``, ``Element``, ``CompositionObject``,
+   ``RichTextElement``, ``RichTextObject``) so they no longer each define
+   their own copy.
 """
 
 from __future__ import annotations
 
+from json import dumps
 from typing import Any, Protocol, runtime_checkable
 
 
@@ -86,3 +93,22 @@ def omit_none(d: dict[str, Any]) -> dict[str, Any]:
     ``None`` as "field not set".
     """
     return {key: value for key, value in d.items() if value is not None}
+
+
+class RenderableMixin:
+    """Mixin providing a shared ``__repr__`` for classes that implement
+    ``_resolve()``.
+
+    The ``__repr__`` returns a pretty-printed JSON string of the resolved
+    payload (indent=4), matching what every concrete block / element /
+    composition object class in the library has historically returned.
+
+    Inherited by the abstract base classes ``Block``, ``Element``,
+    ``CompositionObject``, ``RichTextElement``, and ``RichTextObject``.
+    """
+
+    def _resolve(self) -> dict[str, Any]:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return dumps(self._resolve(), indent=4)

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from json import dumps
 from typing import Any
 from uuid import uuid4
 
-from slackblocks._core import resolve
+from slackblocks._core import RenderableMixin, resolve
 from slackblocks.elements import (
     ChannelMultiSelectMenu,
     ChannelSelectMenu,
@@ -106,7 +105,7 @@ class BlockType(Enum):
     TABLE = "table"
 
 
-class Block(ABC):
+class Block(RenderableMixin, ABC):
     """
     Basis block containing attributes and behaviour common to all blocks.
     N.B: Block is an abstract class and cannot be sent directly.
@@ -125,9 +124,6 @@ class Block(ABC):
     @abstractmethod
     def _resolve(self) -> dict[str, Any]:
         pass
-
-    def __repr__(self) -> str:
-        return dumps(self._resolve(), indent=4)
 
 
 class ActionsBlock(Block):

--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -10,10 +10,9 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from itertools import chain
-from json import dumps
 from typing import TYPE_CHECKING, Any
 
-from ._core import resolve
+from ._core import RenderableMixin, resolve
 from .errors import InvalidUsageError
 from .objects import (
     ConfirmationDialogue,
@@ -66,7 +65,7 @@ class ElementType(Enum):
     RICH_TEXT_INPUT = "rich_text_input"
 
 
-class Element(ABC):
+class Element(RenderableMixin, ABC):
     """
     Basis element containing attributes and behaviour common to all elements.
     N.B: Element is an abstract class and cannot be used directly.
@@ -86,9 +85,6 @@ class Element(ABC):
     @property
     def type(self) -> ElementType:
         return self._type
-
-    def __repr__(self) -> str:
-        return dumps(self._resolve(), indent=4)
 
 
 class Button(Element):

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -11,7 +11,7 @@ from enum import Enum
 from json import dumps
 from typing import Any
 
-from slackblocks._core import omit_none, resolve
+from slackblocks._core import RenderableMixin, omit_none, resolve
 from slackblocks.errors import InvalidUsageError
 from slackblocks.utils import (
     coerce_to_list,
@@ -38,7 +38,7 @@ class CompositionObjectType(Enum):
     WORKFLOW = "workflow"
 
 
-class CompositionObject(ABC):
+class CompositionObject(RenderableMixin, ABC):
     """
     Basis element containing attributes and behaviour common to all
     composition objects.
@@ -56,9 +56,6 @@ class CompositionObject(ABC):
     @abstractmethod
     def _resolve(self) -> dict[str, Any]:
         pass
-
-    def __repr__(self) -> str:
-        return dumps(self._resolve(), indent=4)
 
 
 class TextType(Enum):

--- a/slackblocks/rich_text/elements.py
+++ b/slackblocks/rich_text/elements.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from json import dumps
 from typing import Any
 
-from slackblocks._core import omit_none
+from slackblocks._core import RenderableMixin, omit_none
 from slackblocks.utils import validate_string
 
 
@@ -39,7 +38,7 @@ def _style_dict(**flags: bool | None) -> dict[str, bool] | None:
     return style if style else None
 
 
-class RichTextElement(ABC):
+class RichTextElement(RenderableMixin, ABC):
     """
     Abstract base class for all rich text element classes.
 
@@ -54,9 +53,6 @@ class RichTextElement(ABC):
     @abstractmethod
     def _resolve(self) -> dict[str, Any]:
         return {"type": self.type_.value}
-
-    def __repr__(self) -> str:
-        return dumps(self._resolve(), indent=4)
 
 
 class RichText(RichTextElement):

--- a/slackblocks/rich_text/objects.py
+++ b/slackblocks/rich_text/objects.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from json import dumps
 from typing import Any
 
-from slackblocks._core import resolve
+from slackblocks._core import RenderableMixin, resolve
 from slackblocks.errors import InvalidUsageError
 from slackblocks.rich_text.elements import (
     RichText,
@@ -50,7 +49,7 @@ class ListType(Enum):
         return [list_type.value for list_type in ListType]
 
 
-class RichTextObject(ABC):
+class RichTextObject(RenderableMixin, ABC):
     """
     Abstract class housing shared functionality of RichTextObjects.
 
@@ -65,9 +64,6 @@ class RichTextObject(ABC):
     @abstractmethod
     def _resolve(self) -> dict[str, Any]:
         return {"type": self.type_.value}
-
-    def __repr__(self) -> str:
-        return dumps(self._resolve(), indent=4)
 
 
 class RichTextSection(RichTextObject):

--- a/test/unit/test_core.py
+++ b/test/unit/test_core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 
-from slackblocks._core import Resolvable, omit_none, resolve
+from slackblocks._core import RenderableMixin, Resolvable, omit_none, resolve
 
 
 class _ToyResolvable:
@@ -92,3 +92,28 @@ def test_resolvable_protocol_runtime_checkable() -> None:
         pass
 
     assert not isinstance(NotResolvable(), Resolvable)
+
+
+def test_renderable_mixin_repr_is_indented_json() -> None:
+    """RenderableMixin.__repr__ returns the resolved payload as a pretty
+    JSON string with indent=4, matching what every concrete renderable class
+    in slackblocks has historically returned."""
+
+    class Toy(RenderableMixin):
+        def _resolve(self) -> dict[str, object]:
+            return {"a": 1, "b": "two"}
+
+    result = repr(Toy())
+    # 4-space indent confirms it matches the json.dumps(..., indent=4)
+    # contract that the rest of the library relies on.
+    assert result == '{\n    "a": 1,\n    "b": "two"\n}'
+
+
+def test_renderable_mixin_stub_raises_when_unoverridden() -> None:
+    """The mixin's stub _resolve raises NotImplementedError if a subclass
+    forgets to override it. This catches programmer mistakes early."""
+    import pytest
+
+    instance = RenderableMixin()
+    with pytest.raises(NotImplementedError):
+        instance._resolve()


### PR DESCRIPTION
Closes #188

## Summary
Final Phase 3 step. Five abstract base classes (`Block`, `Element`, `CompositionObject`, `RichTextElement`, `RichTextObject`) each defined an identical `__repr__` returning `dumps(self._resolve(), indent=4)`. Extract into a shared `RenderableMixin` in `_core.py` and inherit.

## Changes
- New `RenderableMixin` in `slackblocks/_core.py`:
  - Shared `__repr__`.
  - Stub `_resolve()` that raises `NotImplementedError` (catches subclasses that forget to override).
- Each abstract base lists `RenderableMixin` as its first base and drops its own `__repr__`.
- `from json import dumps` removed from 4 modules that no longer need it directly (`objects.py` keeps it for `Text.__str__`).
- 2 new tests in `test/unit/test_core.py` cover the mixin.

## Limits
- The 5 bases use different attribute names for their type (`type`, `_type`, `type_`). Unifying them would break the public API surface. Out of scope.

## Verification
- 144 tests pass.
- ruff check + format clean.
- mypy clean.