### PR TITLE
feat: add Literal types for string-valued enums

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from itertools import chain
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from ._core import RenderableMixin, resolve
 from .errors import InvalidUsageError
@@ -30,6 +30,11 @@ from .utils import coerce_to_list, validate_action_id, validate_int, validate_st
 
 if TYPE_CHECKING:
     from .rich_text import RichText
+
+
+ButtonStyleName = Literal["primary", "danger"]
+"""The string-valued ``style`` accepted by ``Button`` and ``WorkflowButton``.
+Equivalent to using ``ButtonStyle.PRIMARY`` / ``ButtonStyle.DANGER``."""
 
 
 class ElementType(Enum):
@@ -115,7 +120,7 @@ class Button(Element):
         action_id: str,
         url: str | None = None,
         value: str | None = None,
-        style: str | None = None,
+        style: ButtonStyle | ButtonStyleName | None = None,
         confirm: ConfirmationDialogue | None = None,
         accessibility_label: str | None = None,
     ) -> None:
@@ -1539,6 +1544,11 @@ class ButtonStyle(Enum):
 
     @staticmethod
     def to_button_style(style: ButtonStyle | str | None) -> ButtonStyle:
+        # NOTE: this implementation uses ``ButtonStyle[style]`` which looks
+        # up the enum *name* (e.g. "PRIMARY"), not the value (e.g. "primary").
+        # Preserved here for backwards compatibility -- ``Button.style`` takes
+        # the value form via ``ButtonStyleName``. The two paths are not
+        # symmetric; see the planned Phase 7 ergonomics work for cleanup.
         if isinstance(style, ButtonStyle):
             return style
         if isinstance(style, str):

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 from json import dumps
-from typing import Any
+from typing import Any, Literal, cast
 
 from slackblocks._core import RenderableMixin, omit_none, resolve
 from slackblocks.errors import InvalidUsageError
@@ -374,6 +374,11 @@ class DispatchActionConfiguration(CompositionObject):
         return {"trigger_actions_on": self.trigger_actions_on}
 
 
+ConversationType = Literal["im", "mpim", "private", "public"]
+"""The four kinds of Slack conversation that ``ConversationFilter.include`` may
+contain. See <https://api.slack.com/reference/block-kit/composition-objects#filter_conversations>."""
+
+
 class ConversationFilter(CompositionObject):
     """
     Provides a way to filter the list of options in a conversations select menu or
@@ -397,7 +402,7 @@ class ConversationFilter(CompositionObject):
 
     def __init__(
         self,
-        include: str | list[str] | None = None,
+        include: ConversationType | list[ConversationType] | None = None,
         exclude_external_shared_channels: bool | None = None,
         exclude_bot_users: bool | None = None,
     ) -> None:
@@ -409,7 +414,7 @@ class ConversationFilter(CompositionObject):
                 "One of `include`, `exclude_external_shared_channels`, or "
                 "`exclude_bot_users` is required."
             )
-        self.include = coerce_to_list(include, str, allow_none=True)
+        self.include = coerce_to_list(cast("str | list[str] | None", include), str, allow_none=True)
         self.exclude_external_shared_channels = exclude_external_shared_channels
         self.exclude_bot_users = exclude_bot_users
 
@@ -576,6 +581,10 @@ class RawText:
         )
 
 
+ColumnAlignment = Literal["left", "center", "right"]
+"""Allowable values for ``ColumnSettings.align``."""
+
+
 class ColumnSettings:
     """
     An object that defines the settings for a column in a `Table` block.
@@ -587,7 +596,7 @@ class ColumnSettings:
 
     def __init__(
         self,
-        align: str | None = None,
+        align: ColumnAlignment | None = None,
         is_wrapped: bool | None = None,
     ) -> None:
         if align and align not in ["left", "center", "right"]:


### PR DESCRIPTION
Closes #190

## Summary
Tighten static-type signatures for parameters that accept a specific set of string literals:
- `Button.style` / `WorkflowButton.style` -> `ButtonStyle | Literal['primary', 'danger'] | None`
- `ColumnSettings.align` -> `Literal['left', 'center', 'right'] | None`
- `ConversationFilter.include` items -> `Literal['im', 'mpim', 'private', 'public']`

## Impact
mypy / pyright now reject misspellings at type-check time:
```
ColumnSettings(align='LEFT')          # error
ColumnSettings(align='middle')        # error
Button(text=..., style='warning')     # error
ConversationFilter(include=['bogus']) # error
```

## Runtime behaviour
Unchanged. Any string previously accepted is still accepted at runtime; the existing validation logic continues to run.

## Out of scope
`ButtonStyle.to_button_style` accepts `str` (rather than the new `ButtonStyleName`) because its implementation uses `ButtonStyle[name]` (name-lookup, not value-lookup), which would mis-typecheck against the value-form Literal. Documented for Phase 7 cleanup.

## Verification
- 144 tests pass.
- ruff format/lint clean.
- mypy clean.
- Manual mypy run against a synthetic file confirms each new Literal triggers an error for invalid strings.