### PR TITLE
feat: add @overload to Text.to_text so allow_none narrows the return type

### DIFF
--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 from json import dumps
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, overload
 
 from slackblocks._core import RenderableMixin, omit_none, resolve
 from slackblocks.errors import InvalidUsageError
@@ -121,6 +121,36 @@ class Text(CompositionObject):
             }
         )
 
+    @overload
+    @staticmethod
+    def to_text(
+        text: str | Text | None,
+        force_plaintext: bool = False,
+        max_length: int | None = None,
+        *,
+        allow_none: Literal[False] = False,
+    ) -> Text: ...
+
+    @overload
+    @staticmethod
+    def to_text(
+        text: str | Text | None,
+        force_plaintext: bool = False,
+        max_length: int | None = None,
+        *,
+        allow_none: Literal[True],
+    ) -> Text | None: ...
+
+    @overload
+    @staticmethod
+    def to_text(
+        text: str | Text | None,
+        force_plaintext: bool = False,
+        max_length: int | None = None,
+        *,
+        allow_none: bool,
+    ) -> Text | None: ...
+
     @staticmethod
     def to_text(
         text: str | Text | None,
@@ -138,6 +168,10 @@ class Text(CompositionObject):
             max_length: `text` will be checked against this length in addition
                 to the standard `Text` limit of 3000 characters.
             allow_none: whether to accept `None` as a valid value for `text`.
+                The return type narrows based on this value:
+
+                - ``allow_none=False`` (the default) -> always returns ``Text``.
+                - ``allow_none=True`` -> returns ``Text | None``.
         """
         if text is None:
             if allow_none:


### PR DESCRIPTION
Closes #192

## Summary
Three new `@overload` signatures on `Text.to_text` make the return type depend on the `allow_none` argument:

- `allow_none=False` (default) -> `Text` (never `None`).
- `allow_none=True` -> `Text | None`.
- `allow_none=bool` (dynamic) -> `Text | None` (fallback).

`allow_none` becomes keyword-only via `*,` in each overload. Verified all call sites in `slackblocks/` and `test/` already pass `allow_none` as a keyword argument, so this is backwards-compatible at runtime.

## Impact
Downstream code calling `Text.to_text("hi")` no longer sees a phantom `None` in the return type. Code that previously needed `assert text is not None` after these calls can drop the assertion.

## Runtime behaviour
Unchanged. The implementation body is identical.

## Verification
- 144 tests pass.
- ruff format/lint clean; mypy clean.
- Manual `reveal_type` check confirms each overload narrows correctly.