### PR TITLE
feat: declare module-level type aliases with TypeAlias (PEP 613)

### DIFF
--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from ._core import RenderableMixin, resolve
 from .errors import InvalidUsageError
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from .rich_text import RichText
 
 
-ButtonStyleName = Literal["primary", "danger"]
+ButtonStyleName: TypeAlias = Literal["primary", "danger"]
 """The string-valued ``style`` accepted by ``Button`` and ``WorkflowButton``.
 Equivalent to using ``ButtonStyle.PRIMARY`` / ``ButtonStyle.DANGER``."""
 
@@ -1558,7 +1558,7 @@ class ButtonStyle(Enum):
         )
 
 
-ButtonStyleLike = ButtonStyle | str
+ButtonStyleLike: TypeAlias = ButtonStyle | str
 
 
 class WorkflowButton(Element):

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 from json import dumps
-from typing import Any, Literal, cast, overload
+from typing import Any, Literal, TypeAlias, cast, overload
 
 from slackblocks._core import RenderableMixin, omit_none, resolve
 from slackblocks.errors import InvalidUsageError
@@ -234,7 +234,7 @@ class Text(CompositionObject):
 
 
 # Used for accepting strings and `Text`` where coercion to `Text` is desirable.
-TextLike = str | Text
+TextLike: TypeAlias = str | Text
 
 
 class ConfirmationDialogue(CompositionObject):
@@ -408,7 +408,7 @@ class DispatchActionConfiguration(CompositionObject):
         return {"trigger_actions_on": self.trigger_actions_on}
 
 
-ConversationType = Literal["im", "mpim", "private", "public"]
+ConversationType: TypeAlias = Literal["im", "mpim", "private", "public"]
 """The four kinds of Slack conversation that ``ConversationFilter.include`` may
 contain. See <https://api.slack.com/reference/block-kit/composition-objects#filter_conversations>."""
 
@@ -615,7 +615,7 @@ class RawText:
         )
 
 
-ColumnAlignment = Literal["left", "center", "right"]
+ColumnAlignment: TypeAlias = Literal["left", "center", "right"]
 """Allowable values for ``ColumnSettings.align``."""
 
 


### PR DESCRIPTION
Closes #194

## Summary
Mark every module-level type alias with `typing.TypeAlias` so type checkers know the right-hand side is intended as a type, not a runtime value.

Aliases updated:
- `TextLike` (`slackblocks/objects.py`)
- `ConversationType` (`slackblocks/objects.py`)
- `ColumnAlignment` (`slackblocks/objects.py`)
- `ButtonStyleName` (`slackblocks/elements.py`)
- `ButtonStyleLike` (`slackblocks/elements.py`)

## Behaviour
Runtime values unchanged; the aliases continue to resolve to their underlying typing objects.

## Out of scope
Not migrating to PEP 695 `type X = ...` syntax -- that requires Python 3.12+ and we still support 3.10/3.11.