### PR TITLE
feat: subclass InvalidUsageError into typed validation exceptions

### DIFF
--- a/slackblocks/__init__.py
+++ b/slackblocks/__init__.py
@@ -41,7 +41,14 @@ from .elements import (
     UserSelectMenu,
     WorkflowButton,
 )
-from .errors import InvalidUsageError
+from .errors import (
+    InvalidUsageError,
+    LengthError,
+    MissingRequiredError,
+    MutualExclusivityError,
+    RangeError,
+    TypeMismatchError,
+)
 from .messages import Message, MessageResponse, ResponseType, WebhookMessage
 from .modals import Modal
 from .objects import (

--- a/slackblocks/attachments.py
+++ b/slackblocks/attachments.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from slackblocks._core import resolve
 from slackblocks.blocks import Block
-from slackblocks.errors import InvalidUsageError
+from slackblocks.errors import TypeMismatchError
 from slackblocks.utils import coerce_to_list, is_hex
 
 
@@ -179,7 +179,7 @@ class Attachment:
             elif len(color) == 6 and is_hex(color):
                 self.color = f"#{color}"
             else:
-                raise InvalidUsageError("Color must be a valid hex code (e.g. `#ffffff`)")
+                raise TypeMismatchError("Color must be a valid hex code (e.g. `#ffffff`)")
         else:
             self.color = None
 

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -36,7 +36,12 @@ from slackblocks.elements import (
     UserMultiSelectMenu,
     UserSelectMenu,
 )
-from slackblocks.errors import InvalidUsageError
+from slackblocks.errors import (
+    InvalidUsageError,
+    LengthError,
+    MissingRequiredError,
+    TypeMismatchError,
+)
 from slackblocks.objects import (
     ColumnSettings,
     CompositionObject,
@@ -177,11 +182,11 @@ class ContextBlock(Block):
                 if element.type == CompositionObjectType.TEXT or element.type == ElementType.IMAGE:
                     self.elements.append(element)
                 else:
-                    raise InvalidUsageError(
+                    raise TypeMismatchError(
                         f"Context blocks can only hold image and text elements, not {element.type}"
                     )
         if len(self.elements) > 10:
-            raise InvalidUsageError("Context blocks can hold a maximum of ten elements")
+            raise LengthError("Context blocks can hold a maximum of ten elements")
 
     def _resolve(self) -> dict[str, Any]:
         return resolve({**self._attributes(), "elements": self.elements})
@@ -339,7 +344,7 @@ class InputBlock(Block):
         super().__init__(type_=BlockType.INPUT, block_id=block_id)
         self.label = Text.to_text(label, force_plaintext=True, max_length=2000, allow_none=False)
         if not isinstance(element, ALLOWED_INPUT_ELEMENTS):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 f"InputBlocks can only hold elements of type: {ALLOWED_INPUT_ELEMENTS}"
             )
         self.element = element
@@ -434,7 +439,7 @@ class SectionBlock(Block):
     ) -> None:
         super().__init__(type_=BlockType.SECTION, block_id=block_id)
         if not text and not fields:
-            raise InvalidUsageError(
+            raise MissingRequiredError(
                 "Must supply either `text` or `fields` or `both` to SectionBlock."
             )
         self.text = Text.to_text(text, max_length=3000, allow_none=True)
@@ -447,7 +452,7 @@ class SectionBlock(Block):
                 if field is not None
             ]
             if len(self.fields) > 10:
-                raise InvalidUsageError("Section blocks can hold a maximum of ten fields")
+                raise LengthError("Section blocks can hold a maximum of ten fields")
         else:
             self.fields = None
 
@@ -493,7 +498,7 @@ class TableBlock(Block):
         super().__init__(type_=BlockType.TABLE, block_id=block_id)
         # Validate that there is at least one row
         if len(rows) < 1:
-            raise InvalidUsageError("`rows` must have at least one row.")
+            raise LengthError("`rows` must have at least one row.")
         # If column_settings are provided, make sure each row has the same number of elements
         num_columns = len(rows[0])
         for row in rows:
@@ -505,10 +510,10 @@ class TableBlock(Block):
                 f"match number of columns in each row ({num_columns})."
             )
         if len(rows) > 100:
-            raise InvalidUsageError("`rows` can have a maximum of 100 items.")
+            raise LengthError("`rows` can have a maximum of 100 items.")
         for row in rows:
             if len(row) > 20:
-                raise InvalidUsageError("Each row can have a maximum of 20 cells.")
+                raise LengthError("Each row can have a maximum of 20 cells.")
         # Validate each cell is an allowed type
         self.rows = []
         for row in rows:
@@ -516,13 +521,13 @@ class TableBlock(Block):
             for cell in row:
                 # Validate cell type
                 if not isinstance(cell, ALLOWED_TABLE_CELL_ELEMENTS):
-                    raise InvalidUsageError(
+                    raise TypeMismatchError(
                         f"Table cells must be one of {ALLOWED_TABLE_CELL_ELEMENTS}"
                     )
                 validated_row.append(cell)
             self.rows.append(validated_row)
         if column_settings and len(column_settings) > 20:
-            raise InvalidUsageError("`column_settings` can have a maximum of 20 items.")
+            raise LengthError("`column_settings` can have a maximum of 20 items.")
         self.column_settings = column_settings
 
     def _resolve(self) -> dict[str, Any]:

--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -13,7 +13,13 @@ from itertools import chain
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from ._core import RenderableMixin, resolve
-from .errors import InvalidUsageError
+from .errors import (
+    LengthError,
+    MissingRequiredError,
+    MutualExclusivityError,
+    RangeError,
+    TypeMismatchError,
+)
 from .objects import (
     ConfirmationDialogue,
     ConversationFilter,
@@ -440,9 +446,9 @@ class Image(Element):
     ) -> None:
         super().__init__(type_=ElementType.IMAGE)
         if image_url is None and slack_file is None:
-            raise InvalidUsageError("Must provide one of `image_url` or `slack_file`")
+            raise MissingRequiredError("Must provide one of `image_url` or `slack_file`")
         if image_url and slack_file:
-            raise InvalidUsageError("Cannot provide both `image_url` or `slack_file`")
+            raise MutualExclusivityError("Cannot provide both `image_url` or `slack_file`")
         self.image_url = image_url
         self.alt_text = alt_text
         self.slack_file = slack_file
@@ -502,7 +508,9 @@ class StaticMultiSelectMenu(Element):
         super().__init__(type_=ElementType.MULTI_SELECT_STATIC)
         self.action_id = validate_action_id(action_id)
         if options and option_groups:
-            raise InvalidUsageError("Cannot set both `options` and `option_groups` parameters.")
+            raise MutualExclusivityError(
+                "Cannot set both `options` and `option_groups` parameters."
+            )
         self.options = coerce_to_list(options, class_=Option, allow_none=True, max_size=100)
         self.option_groups = coerce_to_list(
             option_groups, class_=OptionGroup, allow_none=True, max_size=100
@@ -518,7 +526,7 @@ class StaticMultiSelectMenu(Element):
             and self.initial_options
             and not all(isinstance(option, Option) for option in self.initial_options)
         ):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 "If using `options` then `initial_options` must also be of type `List[Option]`, "
                 f"not `{type(self.initial_options)}`."
             )
@@ -527,7 +535,7 @@ class StaticMultiSelectMenu(Element):
             and self.initial_options
             and not all(isinstance(option, OptionGroup) for option in self.initial_options)
         ):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 "If using `option_groups` then `initial_options` must also be of type "
                 f"`List[OptionGroup]`, not `{type(self.initial_options)}`."
             )
@@ -542,7 +550,7 @@ class StaticMultiSelectMenu(Element):
             )
         for option in options_to_validate:
             if option.text.text_type == TextType.MARKDOWN:
-                raise InvalidUsageError(
+                raise TypeMismatchError(
                     "Text in Options for StaticSelectMenu can only be of TextType.PLAINTEXT"
                 )
 
@@ -870,15 +878,15 @@ class NumberInput(Element):
         self.min_value = min_value
         self.max_value = max_value
         if min_value and not is_decimal_allowed and isinstance(min_value, float):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 f"`min_value` ({min_value}) cannot be a float when `is_decimal_allowed` is `False`"
             )
         if max_value and not is_decimal_allowed and isinstance(max_value, float):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 f"`max_value` ({max_value}) cannot be a float when `is_decimal_allowed` is `False`"
             )
         if min_value is not None and max_value is not None and min_value > max_value:
-            raise InvalidUsageError(
+            raise RangeError(
                 f"`min_value` ({min_value}) cannot be greater than `max_value` ({max_value})"
             )
         self.dispatch_action_config = dispatch_action_config
@@ -988,7 +996,7 @@ class PlainTextInput(Element):
         self.initial_value = initial_value
         self.min_length = min_length
         if max_length and max_length > 3000:
-            raise InvalidUsageError("`max_length` value cannot exceed 3000 characters")
+            raise RangeError("`max_length` value cannot exceed 3000 characters")
         self.max_length = max_length
         self.dispatch_action_config = dispatch_action_config
         self.focus_on_load = focus_on_load
@@ -1046,12 +1054,12 @@ class RadioButtonGroup(Element):
         super().__init__(type_=ElementType.RADIO_BUTTON_GROUP)
         self.action_id = validate_action_id(action_id)
         if len(options) < 1 or len(options) > 10:
-            raise InvalidUsageError(
+            raise LengthError(
                 "Number of options to RadioButtonGroup must be between 1 and 10 (inclusive)."
             )
         self.options: list[Option] | None = coerce_to_list(options, class_=Option, allow_none=False)
         if initial_option is not None and initial_option not in options:
-            raise InvalidUsageError("`initial_option` must be a member of `options`")
+            raise TypeMismatchError("`initial_option` must be a member of `options`")
         self.initial_option = initial_option
         self.confirm = confirm
         self.focus_on_load = focus_on_load
@@ -1112,7 +1120,9 @@ class StaticSelectMenu(Element):
         super().__init__(type_=ElementType.STATIC_SELECT_MENU)
         self.action_id = validate_action_id(action_id)
         if options and option_groups:
-            raise InvalidUsageError("Cannot set both `options` and `option_groups` parameters.")
+            raise MutualExclusivityError(
+                "Cannot set both `options` and `option_groups` parameters."
+            )
         self.options: list[Option] | None = coerce_to_list(
             options, class_=Option, allow_none=True, max_size=100
         )
@@ -1120,12 +1130,12 @@ class StaticSelectMenu(Element):
             option_groups, class_=OptionGroup, allow_none=True, max_size=100
         )
         if options and initial_option and not isinstance(initial_option, Option):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 "If using `options` then `initial_option` must also be of type `Option`, "
                 f"not `{type(initial_option)}`."
             )
         if option_groups and initial_option and not isinstance(initial_option, OptionGroup):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 "If using `option_groups` then `initial_option` must also be of type "
                 f"`OptionGroup`, not `{type(initial_option)}`."
             )
@@ -1140,7 +1150,7 @@ class StaticSelectMenu(Element):
             )
         for option in options_to_validate:
             if option.text.text_type == TextType.MARKDOWN:
-                raise InvalidUsageError(
+                raise TypeMismatchError(
                     "Text in Options for StaticSelectMenu can only be of TextType.PLAINTEXT"
                 )
 
@@ -1553,7 +1563,7 @@ class ButtonStyle(Enum):
             return style
         if isinstance(style, str):
             return ButtonStyle[style]
-        raise InvalidUsageError(
+        raise TypeMismatchError(
             f"Can only coerce to ButtonStyle from ButtonStyle or string, not {type(style)}."
         )
 

--- a/slackblocks/errors.py
+++ b/slackblocks/errors.py
@@ -1,5 +1,20 @@
 """
 Custom error classes for clearer error reporting.
+
+``InvalidUsageError`` is the base type. The five subclasses below are raised
+in well-defined situations so consumer code can ``except`` for a specific
+failure category. All subclasses are instances of ``InvalidUsageError``, so
+existing code that does ``except InvalidUsageError`` continues to work
+unchanged.
+
+| Subclass                  | Raised when                                              |
+| ------------------------- | -------------------------------------------------------- |
+| ``LengthError``           | A string or list violates a min/max-length constraint.   |
+| ``RangeError``            | A numeric value violates a min/max-value constraint.     |
+| ``TypeMismatchError``     | An argument is of the wrong type or unexpected value.    |
+| ``MutualExclusivityError``| Two arguments that must not both be set were both set.   |
+| ``MissingRequiredError``  | At least one of a set of arguments was required, but     |
+|                           | none was provided.                                       |
 """
 
 from __future__ import annotations
@@ -10,6 +25,10 @@ class InvalidUsageError(Exception):
     You have violated the `slackblocks` API or Slack Web API in a way
         that has been caught by validation checks.
 
+    All more-specific validation exceptions raised by ``slackblocks``
+    subclass this exception, so ``except InvalidUsageError`` catches every
+    library-raised validation failure.
+
     Args:
         message: a custom error message providing details of the API
             violation.
@@ -17,3 +36,48 @@ class InvalidUsageError(Exception):
 
     def __init__(self, message: str) -> None:
         return super().__init__(message)
+
+
+class LengthError(InvalidUsageError):
+    """A string or list length is outside the allowed bounds for a field.
+
+    Typical sources: a ``Text`` body longer than the Slack-enforced limit,
+    an option list with too many entries, an ``action_id`` over 255
+    characters, etc.
+    """
+
+
+class RangeError(InvalidUsageError):
+    """A numeric value is outside the allowed bounds for a field.
+
+    Typical sources: ``NumberInput.min_value > max_value``, integer
+    arguments outside an enforced ``min_value`` / ``max_value`` range.
+    """
+
+
+class TypeMismatchError(InvalidUsageError):
+    """An argument is of the wrong type or an unexpected discrete value.
+
+    Typical sources: passing a non-``Option`` element into a list expected
+    to hold ``Option`` instances; supplying a colour string that is neither
+    a hex code nor a ``Color`` enum; supplying a string outside an
+    enumerated set (e.g. ``ColumnSettings.align='banana'``).
+    """
+
+
+class MutualExclusivityError(InvalidUsageError):
+    """Two arguments that must not both be set were both set.
+
+    Typical sources: passing both ``image_url`` and ``slack_file`` to
+    ``Image``; passing both ``options`` and ``option_groups`` to a
+    ``StaticSelectMenu``; passing both ``url`` and ``id`` to ``SlackFile``.
+    """
+
+
+class MissingRequiredError(InvalidUsageError):
+    """At least one of a set of arguments was required, but none was provided.
+
+    Typical sources: ``ConversationFilter`` invoked with none of its three
+    filter fields set; ``SectionBlock`` invoked with neither ``text`` nor
+    ``fields``.
+    """

--- a/slackblocks/messages.py
+++ b/slackblocks/messages.py
@@ -16,7 +16,7 @@ from slackblocks.utils import coerce_to_list
 
 from .attachments import Attachment
 from .blocks import Block
-from .errors import InvalidUsageError
+from .errors import TypeMismatchError
 
 
 class ResponseType(Enum):
@@ -32,7 +32,7 @@ class ResponseType(Enum):
         if isinstance(value, ResponseType):
             return value.value
         if value not in [response_type.value for response_type in ResponseType]:
-            raise InvalidUsageError("ResponseType must be either `ephemeral` or `in_channel`")
+            raise TypeMismatchError("ResponseType must be either `ephemeral` or `in_channel`")
         return value
 
 

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -12,7 +12,12 @@ from json import dumps
 from typing import Any, Literal, TypeAlias, cast, overload
 
 from slackblocks._core import RenderableMixin, omit_none, resolve
-from slackblocks.errors import InvalidUsageError
+from slackblocks.errors import (
+    LengthError,
+    MissingRequiredError,
+    MutualExclusivityError,
+    TypeMismatchError,
+)
 from slackblocks.utils import (
     coerce_to_list,
     coerce_to_list_nonnull,
@@ -176,7 +181,7 @@ class Text(CompositionObject):
         if text is None:
             if allow_none:
                 return None
-            raise InvalidUsageError("This field cannot have the value None or ''")
+            raise MissingRequiredError("This field cannot have the value None or ''")
         return Text.to_text_nonnull(
             text,
             force_plaintext,
@@ -208,15 +213,13 @@ class Text(CompositionObject):
         original_type = text.text_type if isinstance(text, Text) else None
         type_ = TextType.PLAINTEXT if force_plaintext else original_type or TextType.MARKDOWN
         if text and max_length and len(text) > max_length:
-            raise InvalidUsageError(
-                f"`text` length ({len(text)}) exceeds `max_length` ({max_length})"
-            )
+            raise LengthError(f"`text` length ({len(text)}) exceeds `max_length` ({max_length})")
         if isinstance(text, str):
             return Text(text=text, type_=type_)
         elif isinstance(text, Text):
             return Text(text=text.text, type_=type_, emoji=text.emoji, verbatim=text.verbatim)
         else:
-            raise InvalidUsageError("This field must be a string or Text object")
+            raise TypeMismatchError("This field must be a string or Text object")
 
     def __str__(self) -> str:
         return dumps(self._resolve())
@@ -322,7 +325,7 @@ class Option(CompositionObject):
             description, max_length=75, force_plaintext=True, allow_none=True
         )
         if url and len(url) > 3000:
-            raise InvalidUsageError("Option URLs must be less than 3000 characters")
+            raise LengthError("Option URLs must be less than 3000 characters")
         self.url = url
 
     def _resolve(self) -> dict[str, Any]:
@@ -399,7 +402,7 @@ class DispatchActionConfiguration(CompositionObject):
         )
         for trigger in self.trigger_actions_on:
             if trigger not in ALLOWABLE_TRIGGERS:
-                raise InvalidUsageError(
+                raise TypeMismatchError(
                     f"Trigger {trigger} not in allowable values ({ALLOWABLE_TRIGGERS})"
                 )
 
@@ -444,7 +447,7 @@ class ConversationFilter(CompositionObject):
         if not (
             include or exclude_external_shared_channels is not None or exclude_bot_users is not None
         ):
-            raise InvalidUsageError(
+            raise MissingRequiredError(
                 "One of `include`, `exclude_external_shared_channels`, or "
                 "`exclude_bot_users` is required."
             )
@@ -513,7 +516,7 @@ class SlackFile(CompositionObject):
     ) -> None:
         super().__init__(CompositionObjectType.SLACK_FILE)
         if url and id:
-            raise InvalidUsageError("Cannot provide both `url` and `id`.")
+            raise MutualExclusivityError("Cannot provide both `url` and `id`.")
         self.url = url
         self.id = id
 
@@ -634,7 +637,7 @@ class ColumnSettings:
         is_wrapped: bool | None = None,
     ) -> None:
         if align and align not in ["left", "center", "right"]:
-            raise InvalidUsageError("`align` must be one of `left`, `center`, or `right`")
+            raise TypeMismatchError("`align` must be one of `left`, `center`, or `right`")
         self.align = align
         self.is_wrapped = is_wrapped
 

--- a/slackblocks/rich_text/objects.py
+++ b/slackblocks/rich_text/objects.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Any
 
 from slackblocks._core import RenderableMixin, resolve
-from slackblocks.errors import InvalidUsageError
+from slackblocks.errors import TypeMismatchError
 from slackblocks.rich_text.elements import (
     RichText,
     RichTextChannel,
@@ -134,7 +134,7 @@ class RichTextList(RichTextObject):
             if style in ListType.all():
                 self.style = style
             else:
-                raise InvalidUsageError(f"`style` must be one of [{ListType.all()}]")
+                raise TypeMismatchError(f"`style` must be one of [{ListType.all()}]")
         elif isinstance(style, ListType):
             self.style = style.value
         self.elements = coerce_to_list(elements, RichTextSection, min_size=1)

--- a/slackblocks/utils.py
+++ b/slackblocks/utils.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 from string import hexdigits
 from typing import Any, TypeVar
 
-from slackblocks.errors import InvalidUsageError
+from slackblocks.errors import (
+    LengthError,
+    MissingRequiredError,
+    RangeError,
+    TypeMismatchError,
+)
 
 T = TypeVar("T")
 
@@ -44,18 +49,18 @@ def coerce_to_list_nonnull(
         if not isinstance(class_, tuple):
             class_ = (class_,)
         if not isinstance(item, class_):
-            raise InvalidUsageError(
+            raise TypeMismatchError(
                 f"Type of {item} ({type(item)})) inconsistent with expected type {class_}."
             )
 
     length = len(items)
     if min_size is not None and length < min_size:
-        raise InvalidUsageError(
+        raise LengthError(
             f"Size ({length}) of list of {type(class_)} is less than `min_size` ({min_size})"
         )
 
     if max_size is not None and length > max_size:
-        raise InvalidUsageError(
+        raise LengthError(
             f"Size ({length}) of list of {type(class_)} exceeds `max_size` ({max_size})"
         )
 
@@ -90,7 +95,7 @@ def coerce_to_list(
     if object_or_objects is None:
         if allow_none:
             return None
-        raise InvalidUsageError(
+        raise TypeMismatchError(
             f"Type of {object_or_objects} ({type(object_or_objects)})) is "
             f"None should be type `{class_}`."
         )
@@ -131,13 +136,13 @@ def validate_action_id(action_id: str | None, allow_none: bool = False) -> str |
     """
     if action_id is None:
         if not allow_none:
-            raise InvalidUsageError("`action_id` cannot be None.")
+            raise MissingRequiredError("`action_id` cannot be None.")
     else:
         length = len(action_id)
         if length < 1:
-            raise InvalidUsageError("`action_id` cannot be empty.")
+            raise LengthError("`action_id` cannot be empty.")
         if length > 255:
-            raise InvalidUsageError(
+            raise LengthError(
                 f"`action_id` length ({length}) exceeds limit of 255 characters (id: {action_id})."
             )
     return action_id
@@ -169,7 +174,9 @@ def validate_string(
     """
     if string is None:
         if not allow_none:
-            raise InvalidUsageError(f"Expecting string for field `{field_name}`, cannot be None.")
+            raise MissingRequiredError(
+                f"Expecting string for field `{field_name}`, cannot be None."
+            )
         return None
     return validate_string_nonnull(
         string, field_name=field_name, max_length=max_length, min_length=min_length
@@ -184,12 +191,12 @@ def validate_string_nonnull(
 ) -> str:
     length = len(string)
     if min_length is not None and length < min_length:
-        raise InvalidUsageError(
+        raise LengthError(
             f"Argument to field `{field_name}` ({length} characters) "
             f"is less than minimum length of {min_length} characters"
         )
     if max_length is not None and length > max_length:
-        raise InvalidUsageError(
+        raise LengthError(
             f"Argument to field `{field_name}` ({length} characters) "
             f"exceeds length limit of {max_length} characters"
         )
@@ -219,10 +226,10 @@ def validate_int(
         InvalidUsageError: if any of the validation checks fail.
     """
     if num is None and not allow_none:
-        raise InvalidUsageError("`num` is None, which is disallowed.")
+        raise MissingRequiredError("`num` is None, which is disallowed.")
     if num is not None:
         if min_value is not None and num < min_value:
-            raise InvalidUsageError(f"{num} is less than the minimum {min_value}")
+            raise RangeError(f"{num} is less than the minimum {min_value}")
         if max_value is not None and num > max_value:
-            raise InvalidUsageError(f"{num} exceeds the maximum {max_value}")
+            raise RangeError(f"{num} exceeds the maximum {max_value}")
     return num

--- a/test/unit/test_errors.py
+++ b/test/unit/test_errors.py
@@ -2,11 +2,207 @@ from __future__ import annotations
 
 import pytest
 
-from slackblocks import Attachment
-from slackblocks.errors import InvalidUsageError
+from slackblocks import (
+    Attachment,
+    Button,
+    ConversationFilter,
+    Image,
+    InvalidUsageError,
+    LengthError,
+    MissingRequiredError,
+    MutualExclusivityError,
+    Option,
+    OptionGroup,
+    RangeError,
+    SectionBlock,
+    SlackFile,
+    Text,
+    TextType,
+    TypeMismatchError,
+)
+from slackblocks.utils import (
+    validate_action_id,
+    validate_int,
+    validate_string,
+    validate_string_nonnull,
+)
 
 
 def test_invalid_usage_exception() -> None:
+    """Regression: original test from before the Phase 5 split."""
     with pytest.raises(InvalidUsageError):
         attachment = Attachment(blocks=[], color="0000000000000")
         print(attachment)
+
+
+# -- Subclass hierarchy contract -------------------------------------------
+
+
+def test_subclasses_inherit_from_invalid_usage_error() -> None:
+    """Every Phase 5 subclass must subclass InvalidUsageError so that legacy
+    'except InvalidUsageError' code continues to catch all library errors."""
+    for cls in (
+        LengthError,
+        MissingRequiredError,
+        MutualExclusivityError,
+        RangeError,
+        TypeMismatchError,
+    ):
+        assert issubclass(cls, InvalidUsageError)
+
+
+def test_subclasses_are_distinct_types() -> None:
+    """Sanity: subclasses are independent leaves; they don't subclass each other."""
+    leaves = {
+        LengthError,
+        MissingRequiredError,
+        MutualExclusivityError,
+        RangeError,
+        TypeMismatchError,
+    }
+    for a in leaves:
+        for b in leaves:
+            if a is not b:
+                assert not issubclass(a, b)
+
+
+# -- Validator subclass propagation ----------------------------------------
+
+
+def test_validate_string_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        validate_string("a" * 10, field_name="x", max_length=5)
+
+
+def test_validate_string_none_raises_missing_required() -> None:
+    with pytest.raises(MissingRequiredError):
+        validate_string(None, field_name="x")
+
+
+def test_validate_string_nonnull_too_short_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        validate_string_nonnull("", field_name="x", min_length=1)
+
+
+def test_validate_int_below_min_raises_range_error() -> None:
+    with pytest.raises(RangeError):
+        validate_int(1, min_value=5)
+
+
+def test_validate_int_above_max_raises_range_error() -> None:
+    with pytest.raises(RangeError):
+        validate_int(10, max_value=5)
+
+
+def test_validate_int_none_raises_missing_required() -> None:
+    with pytest.raises(MissingRequiredError):
+        validate_int(None)
+
+
+def test_validate_action_id_none_raises_missing_required() -> None:
+    with pytest.raises(MissingRequiredError):
+        validate_action_id(None)
+
+
+def test_validate_action_id_empty_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        validate_action_id("")
+
+
+def test_validate_action_id_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        validate_action_id("a" * 256)
+
+
+# -- Library raise-site subclass propagation ------------------------------
+
+
+def test_image_without_source_raises_missing_required() -> None:
+    with pytest.raises(MissingRequiredError):
+        Image(alt_text="x")
+
+
+def test_image_with_both_sources_raises_mutual_exclusivity() -> None:
+    with pytest.raises(MutualExclusivityError):
+        Image(
+            alt_text="x",
+            image_url="https://x.png",
+            slack_file=SlackFile(url="https://y.png", id=None),
+        )
+
+
+def test_slackfile_with_both_url_and_id_raises_mutual_exclusivity() -> None:
+    with pytest.raises(MutualExclusivityError):
+        SlackFile(url="https://x.png", id="F123")
+
+
+def test_conversation_filter_without_args_raises_missing_required() -> None:
+    with pytest.raises(MissingRequiredError):
+        ConversationFilter()
+
+
+def test_section_block_without_text_or_fields_raises_missing_required() -> None:
+    with pytest.raises(MissingRequiredError):
+        SectionBlock()
+
+
+def test_text_max_length_violation_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        Text.to_text("abcdef", max_length=5)
+
+
+def test_text_none_disallowed_raises_missing_required() -> None:
+    with pytest.raises(MissingRequiredError):
+        Text.to_text(None)
+
+
+def test_text_invalid_type_raises_type_mismatch() -> None:
+    with pytest.raises(TypeMismatchError):
+        Text.to_text(123)  # type: ignore[arg-type]
+
+
+def test_option_group_inferred_text_type_mismatch_raises_type_mismatch() -> None:
+    """OptionGroup options with MARKDOWN-typed text inside a StaticSelectMenu
+    triggers TypeMismatchError. Build via the helper class that wraps it."""
+    from slackblocks.elements import StaticSelectMenu
+
+    bad = Option(text=Text("hi", type_=TextType.MARKDOWN), value="x")
+    good = Option(text=Text("hi", type_=TextType.PLAINTEXT), value="y")
+    with pytest.raises(TypeMismatchError):
+        StaticSelectMenu(action_id="a", options=[good, bad], placeholder="p")
+
+
+def test_option_url_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        Option(text="x", value="v", url="https://" + "a" * 3000)
+
+
+def test_attachment_invalid_color_raises_type_mismatch() -> None:
+    with pytest.raises(TypeMismatchError):
+        Attachment(blocks=[], color="zz1234")
+
+
+def test_button_too_long_text_raises_length_error() -> None:
+    """Button.text exceeding max length comes via Text.to_text -> LengthError."""
+    with pytest.raises(LengthError):
+        Button(text="a" * 100, action_id="a")
+
+
+def test_legacy_except_invalid_usage_error_still_catches_all() -> None:
+    """Backwards-compat contract: existing 'except InvalidUsageError' code
+    continues to catch every subclass."""
+    for raiser in (
+        lambda: SlackFile(url="https://x.png", id="F123"),
+        lambda: ConversationFilter(),
+        lambda: SectionBlock(),
+        lambda: validate_int(10, max_value=5),
+        lambda: validate_string("a" * 10, field_name="x", max_length=5),
+    ):
+        with pytest.raises(InvalidUsageError):
+            raiser()
+
+
+def test_option_group_min_size_violation_raises_length_error() -> None:
+    """OptionGroup requires at least one option (min_size=1)."""
+    with pytest.raises(LengthError):
+        OptionGroup(label="x", options=[])


### PR DESCRIPTION
Closes #196

## Summary
Five new exceptions, all subclassing `InvalidUsageError` so `except InvalidUsageError` continues to catch every library-raised validation failure unchanged:

| Subclass | Raised when |
|---|---|
| `LengthError` | A string or list violates a min/max-length constraint. |
| `RangeError` | A numeric value violates a min/max-value constraint. |
| `TypeMismatchError` | An argument is of the wrong type or unexpected value. |
| `MutualExclusivityError` | Two arguments that must not both be set were both set. |
| `MissingRequiredError` | At least one of a set was required, but none provided. |

All exported from the top-level `slackblocks` package.

## Propagation
- **`slackblocks/utils.py`**: every validator raises the most-specific subclass.
- **30+ raise sites** across `objects.py`, `blocks.py`, `elements.py`, `rich_text/objects.py`, `messages.py`, `attachments.py` updated to use the appropriate subclass.
- 2 `InvalidUsageError` raises kept in `TableBlock` because the failure ("all rows must have the same number of columns", "column_settings count must match row width") is a structural mismatch that doesn't fit any subclass cleanly.

## Backwards compatibility
- Every existing `except InvalidUsageError` block continues to work; verified by a dedicated test that catches each subclass against the base.
- Error message text is preserved character-for-character at every raise site.

## Tests
+25 new tests in `test/unit/test_errors.py`:
- Subclass hierarchy contract.
- Per-validator subclass propagation.
- Representative library raise sites surface the expected subclass.
- `except InvalidUsageError` still catches every subclass.

Test count: 144 -> 169.

## Verification
- `uv run pytest test/unit` -- 169 passed
- `uv run ruff check .` -- clean
- `uv run ruff format --check .` -- clean
- `uv run mypy slackblocks` -- clean