### PR TITLE
feat: add VideoBlock for Slack's video block type

### DIFF
--- a/slackblocks/__init__.py
+++ b/slackblocks/__init__.py
@@ -13,6 +13,7 @@ from .blocks import (
     RichTextBlock,
     SectionBlock,
     TableBlock,
+    VideoBlock,
 )
 from .elements import (
     Button,

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -114,6 +114,7 @@ class BlockType(Enum):
     RICH_TEXT = "rich_text"
     SECTION = "section"
     TABLE = "table"
+    VIDEO = "video"
 
 
 class Block(RenderableMixin, ABC):
@@ -593,3 +594,91 @@ class TableBlock(Block):
         else:
             # Wrap RichTextObject in rich_text structure
             return {"type": "rich_text", "elements": [cell._resolve()]}
+
+
+class VideoBlock(Block):
+    """
+    Embeds a video. Used to display video content inside a Slack message,
+    modal, or App Home tab.
+
+    See: <https://api.slack.com/reference/block-kit/blocks#video>.
+
+    Note: Slack restricts which domains may be embedded. The server-side
+    whitelist (e.g. YouTube, Vimeo) is enforced by Slack on receipt of the
+    payload, not by this library; supplying an unsupported URL will result
+    in a Slack API error rather than an `InvalidUsageError` at construction.
+
+    Args:
+        alt_text: a plain-text summary of the video, used for accessibility
+            and notifications (max 200 chars).
+        thumbnail_url: a URL pointing to the preview image shown before
+            playback. Must be HTTPS in production usage.
+        title: the title shown above the video player (plain text, max 200
+            chars). A `str` is coerced to `TextType.PLAINTEXT` `Text`.
+        video_url: the URL of the video to embed. Must point to a
+            Slack-supported provider (see Slack's documentation).
+        author_name: optional author name shown beneath the video
+            (max 50 chars).
+        block_id: an optional deterministic identifier for the block.
+        description: optional plain-text description below the video
+            (max 200 chars). A `str` is coerced to `TextType.PLAINTEXT`.
+        provider_icon_url: an optional URL to the provider's icon.
+        provider_name: an optional provider name shown alongside the icon
+            (max 50 chars).
+        title_url: an optional URL to link the title to.
+
+    Throws:
+        LengthError: if any length-constrained string exceeds its limit.
+    """
+
+    def __init__(
+        self,
+        alt_text: str,
+        thumbnail_url: str,
+        title: TextLike,
+        video_url: str,
+        author_name: str | None = None,
+        block_id: str | None = None,
+        description: TextLike | None = None,
+        provider_icon_url: str | None = None,
+        provider_name: str | None = None,
+        title_url: str | None = None,
+    ) -> None:
+        super().__init__(type_=BlockType.VIDEO, block_id=block_id)
+        self.alt_text = validate_string_nonnull(
+            alt_text, field_name="alt_text", min_length=1, max_length=200
+        )
+        self.thumbnail_url = validate_string_nonnull(
+            thumbnail_url, field_name="thumbnail_url", min_length=1
+        )
+        self.title = Text.to_text(title, force_plaintext=True, max_length=200)
+        self.video_url = validate_string_nonnull(video_url, field_name="video_url", min_length=1)
+        self.author_name = validate_string(
+            author_name, field_name="author_name", max_length=50, allow_none=True
+        )
+        self.description = Text.to_text(
+            description, force_plaintext=True, max_length=200, allow_none=True
+        )
+        self.provider_icon_url = validate_string(
+            provider_icon_url, field_name="provider_icon_url", allow_none=True
+        )
+        self.provider_name = validate_string(
+            provider_name, field_name="provider_name", max_length=50, allow_none=True
+        )
+        self.title_url = validate_string(title_url, field_name="title_url", allow_none=True)
+
+    def _resolve(self) -> dict[str, Any]:
+        return resolve(
+            {
+                **self._attributes(),
+                "alt_text": self.alt_text,
+                "thumbnail_url": self.thumbnail_url,
+                "title": self.title,
+                "video_url": self.video_url,
+                "author_name": self.author_name,
+                "description": self.description,
+                "provider_icon_url": self.provider_icon_url,
+                "provider_name": self.provider_name,
+                "title_url": self.title_url,
+            }
+        )

--- a/test/samples/blocks/video_block_basic.json
+++ b/test/samples/blocks/video_block_basic.json
@@ -1,0 +1,11 @@
+{
+    "type": "video",
+    "block_id": "b1",
+    "alt_text": "alt",
+    "thumbnail_url": "https://example.com/t.png",
+    "title": {
+        "type": "plain_text",
+        "text": "Title"
+    },
+    "video_url": "https://example.com/v.mp4"
+}

--- a/test/samples/blocks/video_block_full.json
+++ b/test/samples/blocks/video_block_full.json
@@ -1,0 +1,19 @@
+{
+    "type": "video",
+    "block_id": "video_1",
+    "alt_text": "How to use Slack",
+    "thumbnail_url": "https://example.com/thumb.png",
+    "title": {
+        "type": "plain_text",
+        "text": "Getting Started"
+    },
+    "video_url": "https://example.com/video.mp4",
+    "author_name": "Slack",
+    "description": {
+        "type": "plain_text",
+        "text": "A short intro"
+    },
+    "provider_icon_url": "https://example.com/icon.png",
+    "provider_name": "YouTube",
+    "title_url": "https://example.com"
+}

--- a/test/unit/test_blocks.py
+++ b/test/unit/test_blocks.py
@@ -27,6 +27,7 @@ from slackblocks import (
     TableBlock,
     Text,
     TextType,
+    VideoBlock,
 )
 from slackblocks.rich_text import RichTextLink
 
@@ -289,3 +290,115 @@ def test_markdown_block_accepts_exactly_12000_chars() -> None:
     """Boundary case: the documented max is 12000 characters inclusive."""
     block = MarkdownBlock(text="x" * 12000)
     assert len(block.text) == 12000
+
+
+def test_video_block_basic() -> None:
+    """Minimal ``VideoBlock`` (required fields only) matches the documented
+    Slack JSON shape."""
+    block = VideoBlock(
+        alt_text="alt",
+        thumbnail_url="https://example.com/t.png",
+        title="Title",
+        video_url="https://example.com/v.mp4",
+        block_id="b1",
+    )
+    sample = json.loads(fetch_sample(path="test/samples/blocks/video_block_basic.json"))
+    assert sample == json.loads(repr(block))
+
+
+def test_video_block_full() -> None:
+    """Full ``VideoBlock`` with every optional field populated."""
+    block = VideoBlock(
+        alt_text="How to use Slack",
+        thumbnail_url="https://example.com/thumb.png",
+        title="Getting Started",
+        video_url="https://example.com/video.mp4",
+        author_name="Slack",
+        description="A short intro",
+        provider_icon_url="https://example.com/icon.png",
+        provider_name="YouTube",
+        title_url="https://example.com",
+        block_id="video_1",
+    )
+    sample = json.loads(fetch_sample(path="test/samples/blocks/video_block_full.json"))
+    assert sample == json.loads(repr(block))
+
+
+def test_video_block_accepts_text_title_and_description() -> None:
+    """``title`` and ``description`` accept ``Text`` objects directly,
+    with markdown text coerced to plaintext via ``force_plaintext``."""
+    block = VideoBlock(
+        alt_text="alt",
+        thumbnail_url="https://example.com/t.png",
+        title=Text("Title", type_=TextType.MARKDOWN),
+        video_url="https://example.com/v.mp4",
+        description=Text("Desc", type_=TextType.MARKDOWN),
+        block_id="b1",
+    )
+    resolved = block._resolve()
+    assert resolved["title"] == {"type": "plain_text", "text": "Title"}
+    assert resolved["description"] == {"type": "plain_text", "text": "Desc"}
+
+
+def test_video_block_block_id_is_optional() -> None:
+    block = VideoBlock(
+        alt_text="alt",
+        thumbnail_url="https://example.com/t.png",
+        title="Title",
+        video_url="https://example.com/v.mp4",
+    )
+    resolved = block._resolve()
+    assert resolved["block_id"] is not None and len(resolved["block_id"]) > 0
+
+
+def test_video_block_alt_text_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        VideoBlock(
+            alt_text="x" * 201,
+            thumbnail_url="https://example.com/t.png",
+            title="Title",
+            video_url="https://example.com/v.mp4",
+        )
+
+
+def test_video_block_title_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        VideoBlock(
+            alt_text="alt",
+            thumbnail_url="https://example.com/t.png",
+            title="x" * 201,
+            video_url="https://example.com/v.mp4",
+        )
+
+
+def test_video_block_author_name_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        VideoBlock(
+            alt_text="alt",
+            thumbnail_url="https://example.com/t.png",
+            title="Title",
+            video_url="https://example.com/v.mp4",
+            author_name="x" * 51,
+        )
+
+
+def test_video_block_provider_name_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        VideoBlock(
+            alt_text="alt",
+            thumbnail_url="https://example.com/t.png",
+            title="Title",
+            video_url="https://example.com/v.mp4",
+            provider_name="x" * 51,
+        )
+
+
+def test_video_block_description_too_long_raises_length_error() -> None:
+    with pytest.raises(LengthError):
+        VideoBlock(
+            alt_text="alt",
+            thumbnail_url="https://example.com/t.png",
+            title="Title",
+            video_url="https://example.com/v.mp4",
+            description="x" * 201,
+        )


### PR DESCRIPTION
Closes #200

## Summary
Adds support for Slack's `video` block type, used to embed video content from a supported provider (e.g. YouTube, Vimeo) in a message, modal, or App Home tab.

Reference: <https://api.slack.com/reference/block-kit/blocks#video>

## Required fields
- `alt_text` (1-200 chars)
- `thumbnail_url` (non-empty)
- `title` (plain text, max 200 chars; coerced from `str` via `Text.to_text`)
- `video_url` (non-empty)

## Optional fields
- `author_name` (max 50 chars)
- `description` (plain text, max 200 chars; coerced from `str`)
- `provider_icon_url`
- `provider_name` (max 50 chars)
- `title_url`
- `block_id`

All length-bound violations raise `LengthError` (Phase 5).

## What this PR does NOT validate
URL format / scheme constraints (e.g. Slack requires HTTPS and whitelists specific video provider domains). Those are server-side checks; sending an unsupported URL produces a Slack API error rather than an `InvalidUsageError` at construction time. We don't attempt to mirror Slack's whitelist client-side because it would drift.

## Changes
- `slackblocks/blocks.py`: `BlockType.VIDEO`, `VideoBlock` class.
- `slackblocks/__init__.py`: export `VideoBlock`.
- Two golden-fixture samples (basic / full).
- 9 new tests in `test/unit/test_blocks.py` covering rendering, `Text` coercion for `title` and `description`, optional `block_id`, and length-bound rejection for every constrained field.

## Verification
- Test count: 174 -> 183.
- ruff lint/format clean; mypy clean.