### PR TITLE
feat: add block_kit_builder_url() utility

### DIFF
--- a/slackblocks/__init__.py
+++ b/slackblocks/__init__.py
@@ -15,6 +15,7 @@ from .blocks import (
     TableBlock,
     VideoBlock,
 )
+from .builder import block_kit_builder_url
 from .elements import (
     Button,
     ChannelMultiSelectMenu,

--- a/slackblocks/builder.py
+++ b/slackblocks/builder.py
@@ -1,0 +1,91 @@
+"""
+Utilities for working with Slack's [Block Kit Builder](https://app.slack.com/block-kit-builder).
+
+The Builder accepts a URL of the form ``https://app.slack.com/block-kit-builder/#<JSON>``
+where ``<JSON>`` is a URL-encoded JSON payload (typically ``{"blocks": [...]}``).
+``block_kit_builder_url`` constructs such a URL from any of the shapes the
+rest of this library renders.
+"""
+
+from __future__ import annotations
+
+from json import dumps
+from typing import Any
+from urllib.parse import quote
+
+from slackblocks._core import Resolvable, resolve
+from slackblocks.blocks import Block
+
+_BUILDER_URL_PREFIX = "https://app.slack.com/block-kit-builder/"
+
+
+def block_kit_builder_url(
+    payload: Block | list[Block] | Resolvable | dict[str, Any],
+    team_id: str | None = None,
+) -> str:
+    """Build a URL that opens ``payload`` in Slack's Block Kit Builder.
+
+    Use this to preview a message, view, or list of blocks in the browser
+    without manually copying JSON into the Builder.
+
+    Args:
+        payload: any of:
+
+            - A single ``Block`` -- wrapped in ``{"blocks": [block]}``.
+            - A list of ``Block`` -- wrapped in ``{"blocks": [...]}``.
+            - Anything with a ``_resolve`` method (``Message``,
+              ``WebhookMessage``, ``MessageResponse``, ``View``,
+              ``ModalView``, ``HomeTabView``, etc.) -- used as-is.
+            - A raw ``dict`` -- used as-is. This is the escape hatch for
+              callers building payloads outside the type hierarchy.
+
+        team_id: optional Slack team ID. When supplied, produces a
+            workspace-specific Builder URL of the form
+            ``https://app.slack.com/block-kit-builder/T0123#<JSON>``.
+            When ``None`` (the default), produces the generic URL.
+
+    Returns:
+        A fully-formed Block Kit Builder URL.
+
+    Examples:
+        Single block::
+
+            from slackblocks import SectionBlock, block_kit_builder_url
+
+            url = block_kit_builder_url(SectionBlock("Hi"))
+
+        Multiple blocks::
+
+            url = block_kit_builder_url([
+                SectionBlock("Heading"),
+                DividerBlock(),
+            ])
+
+        Existing message::
+
+            url = block_kit_builder_url(my_message)
+
+        Targeting a specific workspace::
+
+            url = block_kit_builder_url(my_message, team_id="T0123ABCD")
+    """
+    body: dict[str, Any]
+    if isinstance(payload, Block):
+        body = {"blocks": [resolve(payload)]}
+    elif isinstance(payload, list):
+        body = {"blocks": [resolve(item) for item in payload]}
+    elif isinstance(payload, dict):
+        body = payload
+    else:
+        # Anything else with a _resolve() method (Message, View, etc.).
+        # resolve() raises TypeError downstream if the object is unsupported.
+        resolved = resolve(payload)
+        if not isinstance(resolved, dict):
+            raise TypeError(
+                f"block_kit_builder_url payload must resolve to a dict; got {type(resolved)}."
+            )
+        body = resolved
+
+    encoded = quote(dumps(body, separators=(",", ":")), safe="")
+    prefix = f"{_BUILDER_URL_PREFIX}{team_id}" if team_id else _BUILDER_URL_PREFIX
+    return f"{prefix}#{encoded}"

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -1,0 +1,125 @@
+"""Tests for ``slackblocks.builder.block_kit_builder_url``."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import unquote
+
+import pytest
+
+from slackblocks import (
+    DividerBlock,
+    HomeTabView,
+    Message,
+    ModalView,
+    SectionBlock,
+    WebhookMessage,
+    block_kit_builder_url,
+)
+
+
+def _decode(url: str) -> dict[str, object]:
+    """Pull the JSON payload back out of a Builder URL fragment."""
+    fragment = url.split("#", 1)[1]
+    return json.loads(unquote(fragment))
+
+
+def test_returns_block_kit_builder_url() -> None:
+    url = block_kit_builder_url(SectionBlock("Hi"))
+    assert url.startswith("https://app.slack.com/block-kit-builder/#")
+
+
+def test_single_block_is_wrapped_in_blocks_envelope() -> None:
+    block = SectionBlock("Hi", block_id="b1")
+    decoded = _decode(block_kit_builder_url(block))
+    assert "blocks" in decoded
+    assert len(decoded["blocks"]) == 1
+    assert decoded["blocks"][0]["type"] == "section"
+    assert decoded["blocks"][0]["block_id"] == "b1"
+
+
+def test_list_of_blocks_is_wrapped_in_blocks_envelope() -> None:
+    blocks = [
+        SectionBlock("Heading", block_id="b1"),
+        DividerBlock(block_id="b2"),
+    ]
+    decoded = _decode(block_kit_builder_url(blocks))
+    assert "blocks" in decoded
+    assert len(decoded["blocks"]) == 2
+    assert [b["type"] for b in decoded["blocks"]] == ["section", "divider"]
+
+
+def test_message_passes_through_unchanged() -> None:
+    msg = Message(channel="#g", blocks=SectionBlock("Hi", block_id="b1"))
+    decoded = _decode(block_kit_builder_url(msg))
+    assert decoded["channel"] == "#g"
+    assert decoded["mrkdwn"] is True
+    assert len(decoded["blocks"]) == 1
+
+
+def test_webhook_message_passes_through_unchanged() -> None:
+    msg = WebhookMessage(text="hi", blocks=[SectionBlock("Hi", block_id="b1")])
+    decoded = _decode(block_kit_builder_url(msg))
+    assert decoded["text"] == "hi"
+    assert len(decoded["blocks"]) == 1
+
+
+def test_modal_view_passes_through_unchanged() -> None:
+    view = ModalView(title="My modal", blocks=[SectionBlock("Hi", block_id="b1")])
+    decoded = _decode(block_kit_builder_url(view))
+    assert decoded["type"] == "modal"
+    assert decoded["title"]["text"] == "My modal"
+
+
+def test_home_tab_view_passes_through_unchanged() -> None:
+    view = HomeTabView(blocks=[SectionBlock("Hi", block_id="b1")])
+    decoded = _decode(block_kit_builder_url(view))
+    assert decoded["type"] == "home"
+
+
+def test_raw_dict_is_used_verbatim() -> None:
+    """The escape hatch: pass any dict and it appears in the URL as-is."""
+    raw = {"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "Hi"}}]}
+    decoded = _decode(block_kit_builder_url(raw))
+    assert decoded == raw
+
+
+def test_team_id_produces_workspace_specific_url() -> None:
+    url = block_kit_builder_url(SectionBlock("Hi"), team_id="T0123ABCD")
+    assert url.startswith("https://app.slack.com/block-kit-builder/T0123ABCD#")
+
+
+def test_team_id_omitted_produces_generic_url() -> None:
+    url = block_kit_builder_url(SectionBlock("Hi"))
+    # No team ID between the slash and the '#' fragment delimiter.
+    assert url.startswith("https://app.slack.com/block-kit-builder/#")
+
+
+def test_payload_round_trips_through_url_decode() -> None:
+    """The payload going in must equal the payload coming out, modulo
+    block_id auto-generation (we pass an explicit one to make the test
+    deterministic)."""
+    msg = Message(channel="#g", blocks=SectionBlock("Special: <>&\"'", block_id="b1"))
+    decoded = _decode(block_kit_builder_url(msg))
+    # The block_id is preserved, the special characters in text survive
+    # URL encoding intact.
+    assert decoded["blocks"][0]["text"]["text"] == "Special: <>&\"'"
+    assert decoded["blocks"][0]["block_id"] == "b1"
+
+
+def test_unsupported_payload_type_raises() -> None:
+    """Passing something that doesn't resolve to a dict (e.g. a string)
+    should raise TypeError rather than produce garbage."""
+    with pytest.raises(TypeError):
+        block_kit_builder_url("just a string")  # type: ignore[arg-type]
+
+
+def test_json_payload_uses_compact_separators() -> None:
+    """The encoded JSON must use compact separators (no spaces) to keep
+    URLs short. Verified by absence of '%20' (encoded space) in the
+    fragment."""
+    url = block_kit_builder_url(SectionBlock("Hi"))
+    fragment = url.split("#", 1)[1]
+    # The Hi text contains no space, so any %20 in the fragment would
+    # come from JSON separator whitespace.
+    assert "%20" not in fragment


### PR DESCRIPTION
Closes #204

## Summary
Adds a top-level utility that turns any slackblocks payload into a [Slack Block Kit Builder](https://app.slack.com/block-kit-builder) URL for browser-based preview.

```python
from slackblocks import SectionBlock, block_kit_builder_url

url = block_kit_builder_url(SectionBlock('Hi'))                # single
url = block_kit_builder_url([SectionBlock('A'), DividerBlock()]) # list
url = block_kit_builder_url(my_message)                        # Message
url = block_kit_builder_url(my_modal_view)                     # View
url = block_kit_builder_url({'blocks': [...]})                 # dict escape hatch
url = block_kit_builder_url(payload, team_id='T0123ABCD')      # workspace URL
```

## Behaviour
- A single `Block` is wrapped in `{'blocks': [block]}`.
- A list of `Block` is wrapped in `{'blocks': [...]}`.
- Anything with a `_resolve` method (`Message`, `WebhookMessage`, `MessageResponse`, `View`, `ModalView`, `HomeTabView`) is passed through.
- A raw `dict` is used verbatim (escape hatch).
- Anything that doesn't resolve to a dict raises `TypeError`.
- JSON is encoded with compact separators to keep URLs short.

The helper lives in a new `slackblocks/builder.py` module to keep `_core.py` strictly focused on the shared rendering protocol.

## Tests
13 new tests in `test/unit/test_builder.py` covering every input shape, the `team_id` branch, special-character round-tripping, and the `TypeError` contract for unsupported payloads.

Test count: 194 -> 207.