### PR TITLE
feat: add Workflow.from_url() convenience factory

### DIFF
--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -627,6 +627,42 @@ class Workflow(CompositionObject):
         # Workflow does not include "type" in its rendered JSON.
         return resolve({"trigger": self.trigger})
 
+    @classmethod
+    def from_url(cls, url: str, **input_parameters: str) -> Workflow:
+        """Build a `Workflow` from a trigger URL and input parameters in one call.
+
+        ``Workflow.from_url(url, a='1', b='2')`` is equivalent to::
+
+            Workflow(
+                trigger=Trigger(
+                    url=url,
+                    customizable_input_parameters=[
+                        InputParameter(name='a', value='1'),
+                        InputParameter(name='b', value='2'),
+                    ],
+                ),
+            )
+
+        When no input parameters are supplied, the resulting trigger has
+        ``customizable_input_parameters=None`` (the key is omitted from JSON).
+
+        Args:
+            url: the link trigger URL.
+            **input_parameters: zero or more ``name=value`` pairs that become
+                ``InputParameter`` entries on the trigger.
+
+        Returns:
+            A new ``Workflow`` instance.
+        """
+        params: list[InputParameter] | None
+        if input_parameters:
+            params = [
+                InputParameter(name=name, value=value) for name, value in input_parameters.items()
+            ]
+        else:
+            params = None
+        return cls(trigger=Trigger(url=url, customizable_input_parameters=params))
+
 
 class RawText:
     """

--- a/test/unit/test_objects.py
+++ b/test/unit/test_objects.py
@@ -266,3 +266,46 @@ def test_markdown_exported_at_top_level() -> None:
     from slackblocks import Markdown as TopLevel
 
     assert TopLevel is Markdown
+
+
+# -- Workflow.from_url convenience factory --------------------------------
+
+
+def test_workflow_from_url_matches_verbose_form() -> None:
+    """``Workflow.from_url(url, **params)`` must produce identical JSON to
+    the equivalent verbose construction."""
+    import json
+
+    verbose = Workflow(
+        trigger=Trigger(
+            url="https://slack.com/x",
+            customizable_input_parameters=[
+                InputParameter(name="a", value="1"),
+                InputParameter(name="b", value="2"),
+            ],
+        )
+    )
+    concise = Workflow.from_url("https://slack.com/x", a="1", b="2")
+    assert json.loads(repr(verbose)) == json.loads(repr(concise))
+
+
+def test_workflow_from_url_no_params_omits_input_parameters() -> None:
+    """No keyword arguments -> no ``customizable_input_parameters`` in JSON."""
+    workflow = Workflow.from_url("https://slack.com/x")
+    resolved = workflow._resolve()
+    assert resolved == {"trigger": {"url": "https://slack.com/x"}}
+
+
+def test_workflow_from_url_preserves_param_order_and_values() -> None:
+    workflow = Workflow.from_url("https://slack.com/x", first="one", second="two")
+    resolved = workflow._resolve()
+    params = resolved["trigger"]["customizable_input_parameters"]
+    assert params == [
+        {"name": "first", "value": "one"},
+        {"name": "second", "value": "two"},
+    ]
+
+
+def test_workflow_from_url_returns_workflow_instance() -> None:
+    workflow = Workflow.from_url("https://slack.com/x", a="1")
+    assert isinstance(workflow, Workflow)


### PR DESCRIPTION
Closes #206

## Summary
Collapses the most common `Workflow` construction pattern from four nested objects to a single classmethod call:

```python
Workflow.from_url('https://slack.com/x', a='1', b='2')
```

is equivalent to the verbose form:

```python
Workflow(
    trigger=Trigger(
        url='https://slack.com/x',
        customizable_input_parameters=[
            InputParameter(name='a', value='1'),
            InputParameter(name='b', value='2'),
        ],
    ),
)
```

## Behaviour
- Each keyword pair becomes one `InputParameter`.
- No keyword args -> trigger has `customizable_input_parameters=None`; the field is omitted from JSON.
- Parameter insertion order is preserved.

The verbose `Workflow(trigger=Trigger(...))` form continues to work unchanged.

## Tests
4 new tests covering equivalence to the verbose form, the empty-params branch, parameter ordering, and return type.

Test count: 207 -> 211.

ruff lint/format clean; mypy clean.