### PR TITLE
feat: add from_dict parsers for composition objects and basic blocks

### DIFF
--- a/slackblocks/__init__.py
+++ b/slackblocks/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .attachments import Attachment, Color, Field
 from .blocks import (
     ActionsBlock,
+    Block,
     ContextBlock,
     DividerBlock,
     FileBlock,

--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -137,6 +137,51 @@ class Block(RenderableMixin, ABC):
     def _resolve(self) -> dict[str, Any]:
         pass
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Block:
+        """Parse a Slack block payload back into the appropriate ``Block`` subclass.
+
+        Reads ``data["type"]`` and dispatches to the matching subclass's
+        ``from_dict``.
+
+        Throws:
+            MissingRequiredError: if ``data["type"]`` is absent.
+            TypeMismatchError: if ``data["type"]`` is not a recognised
+                block type.
+            NotImplementedError: when the block type is recognised but its
+                round-trip parser depends on a part of the API that is not
+                yet implemented (currently: ``RichTextBlock`` and any block
+                containing elements -- see Phase 7.4b and 7.4c).
+        """
+        if "type" not in data:
+            raise MissingRequiredError("Block payload is missing required `type` field.")
+        type_str = data["type"]
+        registry = _block_from_dict_registry()
+        if type_str not in registry:
+            raise TypeMismatchError(
+                f"Unknown block type {type_str!r}; expected one of {sorted(registry)}."
+            )
+        return registry[type_str](data)
+
+
+def _block_from_dict_registry() -> dict[str, Any]:
+    """Lazy registry mapping ``BlockType`` values to subclass ``from_dict``
+    callables. Built on first call to avoid forward-reference issues."""
+    return {
+        BlockType.ACTIONS.value: ActionsBlock.from_dict,
+        BlockType.CONTEXT.value: ContextBlock.from_dict,
+        BlockType.DIVIDER.value: DividerBlock.from_dict,
+        BlockType.FILE.value: FileBlock.from_dict,
+        BlockType.HEADER.value: HeaderBlock.from_dict,
+        BlockType.IMAGE.value: ImageBlock.from_dict,
+        BlockType.INPUT.value: InputBlock.from_dict,
+        BlockType.MARKDOWN.value: MarkdownBlock.from_dict,
+        BlockType.RICH_TEXT.value: RichTextBlock.from_dict,
+        BlockType.SECTION.value: SectionBlock.from_dict,
+        BlockType.TABLE.value: TableBlock.from_dict,
+        BlockType.VIDEO.value: VideoBlock.from_dict,
+    }
+
 
 class ActionsBlock(Block):
     """
@@ -163,6 +208,19 @@ class ActionsBlock(Block):
 
     def _resolve(self) -> dict[str, Any]:
         return resolve({**self._attributes(), "elements": self.elements})
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ActionsBlock:
+        """Parse a Slack ``actions`` block payload.
+
+        Currently raises ``NotImplementedError`` because round-tripping
+        depends on parsing nested elements; ``Element.from_dict`` will land
+        in Phase 7.4b.
+        """
+        raise NotImplementedError(
+            "ActionsBlock.from_dict requires Element.from_dict, which is not yet "
+            "implemented (see issue #208 and the planned Phase 7.4b)."
+        )
 
 
 class ContextBlock(Block):
@@ -198,6 +256,26 @@ class ContextBlock(Block):
     def _resolve(self) -> dict[str, Any]:
         return resolve({**self._attributes(), "elements": self.elements})
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ContextBlock:
+        """Parse a Slack ``context`` block payload.
+
+        Text elements within the block are parsed back to ``Text``; image
+        elements raise ``NotImplementedError`` because ``Element.from_dict``
+        has not yet shipped (Phase 7.4b).
+        """
+        elements: list[Element | CompositionObject] = []
+        for raw in data.get("elements", []):
+            etype = raw.get("type")
+            if etype in {TextType.MARKDOWN.value, TextType.PLAINTEXT.value}:
+                elements.append(Text.from_dict(raw))
+            else:
+                raise NotImplementedError(
+                    f"ContextBlock.from_dict cannot parse element of type {etype!r}; "
+                    "non-Text elements depend on Element.from_dict (Phase 7.4b)."
+                )
+        return cls(elements=elements or None, block_id=data.get("block_id"))
+
 
 class DividerBlock(Block):
     """
@@ -213,6 +291,11 @@ class DividerBlock(Block):
 
     def _resolve(self) -> dict[str, Any]:
         return self._attributes()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DividerBlock:
+        """Parse a Slack ``divider`` block payload."""
+        return cls(block_id=data.get("block_id"))
 
 
 class FileBlock(Block):
@@ -245,6 +328,17 @@ class FileBlock(Block):
             "source": self.source,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FileBlock:
+        """Parse a Slack ``file`` block payload."""
+        if "external_id" not in data:
+            raise MissingRequiredError("FileBlock payload is missing required `external_id` field.")
+        return cls(
+            external_id=data["external_id"],
+            block_id=data.get("block_id"),
+            source=data.get("source", "remote"),
+        )
+
 
 class HeaderBlock(Block):
     """
@@ -264,6 +358,13 @@ class HeaderBlock(Block):
 
     def _resolve(self) -> dict[str, Any]:
         return resolve({**self._attributes(), "text": self.text})
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HeaderBlock:
+        """Parse a Slack ``header`` block payload."""
+        if "text" not in data:
+            raise MissingRequiredError("HeaderBlock payload is missing required `text` field.")
+        return cls(text=Text.from_dict(data["text"]), block_id=data.get("block_id"))
 
 
 class ImageBlock(Block):
@@ -316,6 +417,19 @@ class ImageBlock(Block):
                 "alt_text": self.alt_text if self.alt_text else None,
                 "title": getattr(self, "title", None),
             }
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ImageBlock:
+        """Parse a Slack ``image`` block payload."""
+        if "image_url" not in data:
+            raise MissingRequiredError("ImageBlock payload is missing required `image_url` field.")
+        title_raw = data.get("title")
+        return cls(
+            image_url=data["image_url"],
+            alt_text=data.get("alt_text", " "),
+            title=Text.from_dict(title_raw) if title_raw is not None else None,
+            block_id=data.get("block_id"),
         )
 
 
@@ -371,6 +485,18 @@ class InputBlock(Block):
             }
         )
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InputBlock:
+        """Parse a Slack ``input`` block payload.
+
+        Currently raises ``NotImplementedError`` because the nested
+        ``element`` requires ``Element.from_dict``, which lands in Phase 7.4b.
+        """
+        raise NotImplementedError(
+            "InputBlock.from_dict requires Element.from_dict, which is not yet "
+            "implemented (see issue #208 and the planned Phase 7.4b)."
+        )
+
 
 class MarkdownBlock(Block):
     """
@@ -406,6 +532,13 @@ class MarkdownBlock(Block):
 
     def _resolve(self) -> dict[str, Any]:
         return {**self._attributes(), "text": self.text}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MarkdownBlock:
+        """Parse a Slack ``markdown`` block payload."""
+        if "text" not in data:
+            raise MissingRequiredError("MarkdownBlock payload is missing required `text` field.")
+        return cls(text=data["text"], block_id=data.get("block_id"))
 
 
 class RichTextBlock(Block):
@@ -447,6 +580,19 @@ class RichTextBlock(Block):
 
     def _resolve(self) -> dict[str, Any]:
         return resolve({**self._attributes(), "elements": self.elements})
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RichTextBlock:
+        """Parse a Slack ``rich_text`` block payload.
+
+        Currently raises ``NotImplementedError`` because the rich-text
+        object hierarchy has a deeply nested element graph; round-tripping
+        is deferred to Phase 7.4c.
+        """
+        raise NotImplementedError(
+            "RichTextBlock.from_dict is not yet implemented; rich-text "
+            "round-tripping is scheduled for Phase 7.4c (see issue #208)."
+        )
 
 
 class SectionBlock(Block):
@@ -511,6 +657,29 @@ class SectionBlock(Block):
                 else None,
                 "accessory": self.accessory if self.accessory else None,
             }
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SectionBlock:
+        """Parse a Slack ``section`` block payload.
+
+        Round-trips ``text`` and ``fields``. Raises ``NotImplementedError``
+        if an ``accessory`` is present, because the accessory is an
+        ``Element`` and ``Element.from_dict`` is not yet implemented
+        (Phase 7.4b).
+        """
+        if data.get("accessory") is not None:
+            raise NotImplementedError(
+                "SectionBlock.from_dict cannot yet parse an `accessory`; "
+                "this requires Element.from_dict (Phase 7.4b)."
+            )
+        text_raw = data.get("text")
+        fields_raw = data.get("fields")
+        return cls(
+            text=Text.from_dict(text_raw) if text_raw is not None else None,
+            fields=[Text.from_dict(f) for f in fields_raw] if fields_raw else None,
+            accessory=None,
+            block_id=data.get("block_id"),
         )
 
 
@@ -594,6 +763,19 @@ class TableBlock(Block):
         else:
             # Wrap RichTextObject in rich_text structure
             return {"type": "rich_text", "elements": [cell._resolve()]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TableBlock:
+        """Parse a Slack ``table`` block payload.
+
+        Currently raises ``NotImplementedError`` because table cells may
+        contain rich-text objects whose round-trip parser is deferred to
+        Phase 7.4c.
+        """
+        raise NotImplementedError(
+            "TableBlock.from_dict is not yet implemented; round-tripping requires "
+            "the rich-text parsers planned for Phase 7.4c (see issue #208)."
+        )
 
 
 class VideoBlock(Block):
@@ -681,4 +863,27 @@ class VideoBlock(Block):
                 "provider_name": self.provider_name,
                 "title_url": self.title_url,
             }
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> VideoBlock:
+        """Parse a Slack ``video`` block payload."""
+        required = ("alt_text", "thumbnail_url", "title", "video_url")
+        for field in required:
+            if field not in data:
+                raise MissingRequiredError(
+                    f"VideoBlock payload is missing required `{field}` field."
+                )
+        description_raw = data.get("description")
+        return cls(
+            alt_text=data["alt_text"],
+            thumbnail_url=data["thumbnail_url"],
+            title=Text.from_dict(data["title"]),
+            video_url=data["video_url"],
+            author_name=data.get("author_name"),
+            block_id=data.get("block_id"),
+            description=Text.from_dict(description_raw) if description_raw is not None else None,
+            provider_icon_url=data.get("provider_icon_url"),
+            provider_name=data.get("provider_name"),
+            title_url=data.get("title_url"),
         )

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -221,6 +221,41 @@ class Text(CompositionObject):
         else:
             raise TypeMismatchError("This field must be a string or Text object")
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Text:
+        """Parse a Slack-shaped ``text`` composition object back into a ``Text``.
+
+        Unknown fields are ignored so that future Slack additions do not
+        break round-tripping.
+
+        Args:
+            data: a dict matching the Slack ``text`` composition-object shape,
+                e.g. ``{"type": "mrkdwn", "text": "hi", "verbatim": True}``.
+
+        Returns:
+            A ``Text`` instance.
+
+        Throws:
+            MissingRequiredError: if ``data["text"]`` is absent.
+            TypeMismatchError: if ``data["type"]`` is not one of the
+                allowable ``TextType`` values.
+        """
+        if "text" not in data:
+            raise MissingRequiredError("Text payload is missing required `text` field.")
+        type_str = data.get("type", TextType.MARKDOWN.value)
+        try:
+            text_type = TextType(type_str)
+        except ValueError as exc:
+            raise TypeMismatchError(
+                f"Text `type` must be one of {[t.value for t in TextType]}, got {type_str!r}."
+            ) from exc
+        return cls(
+            text=data["text"],
+            type_=text_type,
+            emoji=bool(data.get("emoji", False)),
+            verbatim=bool(data.get("verbatim", False)),
+        )
+
     def __str__(self) -> str:
         return dumps(self._resolve())
 
@@ -323,6 +358,26 @@ class ConfirmationDialogue(CompositionObject):
             }
         )
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConfirmationDialogue:
+        """Parse a Slack ``confirm`` composition object back into an instance.
+
+        Throws:
+            MissingRequiredError: if any of ``title``, ``text``, ``confirm``,
+                ``deny`` is absent.
+        """
+        for field in ("title", "text", "confirm", "deny"):
+            if field not in data:
+                raise MissingRequiredError(
+                    f"Confirmation dialogue payload is missing required `{field}` field."
+                )
+        return cls(
+            title=Text.from_dict(data["title"]),
+            text=Text.from_dict(data["text"]),
+            confirm=Text.from_dict(data["confirm"]),
+            deny=Text.from_dict(data["deny"]),
+        )
+
 
 class Confirm(ConfirmationDialogue):
     """
@@ -382,6 +437,24 @@ class Option(CompositionObject):
             }
         )
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Option:
+        """Parse a Slack ``option`` composition object back into an ``Option``.
+
+        Throws:
+            MissingRequiredError: if ``text`` or ``value`` is absent.
+        """
+        for field in ("text", "value"):
+            if field not in data:
+                raise MissingRequiredError(f"Option payload is missing required `{field}` field.")
+        description = data.get("description")
+        return cls(
+            text=Text.from_dict(data["text"]),
+            value=data["value"],
+            description=Text.from_dict(description) if description is not None else None,
+            url=data.get("url"),
+        )
+
     def __eq__(self, other) -> bool:
         return (
             self.type == other.type
@@ -420,6 +493,23 @@ class OptionGroup(CompositionObject):
         # OptionGroup does not include "type" in its rendered JSON.
         return resolve({"label": self.label, "options": self.options})
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OptionGroup:
+        """Parse a Slack ``option_group`` composition object.
+
+        Throws:
+            MissingRequiredError: if ``label`` or ``options`` is absent.
+        """
+        for field in ("label", "options"):
+            if field not in data:
+                raise MissingRequiredError(
+                    f"OptionGroup payload is missing required `{field}` field."
+                )
+        return cls(
+            label=Text.from_dict(data["label"]),
+            options=[Option.from_dict(item) for item in data["options"]],
+        )
+
 
 ALLOWABLE_TRIGGERS = ["on_enter_pressed", "on_character_entered"]
 
@@ -452,6 +542,11 @@ class DispatchActionConfiguration(CompositionObject):
     def _resolve(self) -> dict[str, Any]:
         # DispatchActionConfiguration does not include "type" in its rendered JSON.
         return {"trigger_actions_on": self.trigger_actions_on}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DispatchActionConfiguration:
+        """Parse a Slack ``dispatch_action_config`` composition object."""
+        return cls(trigger_actions_on=data.get("trigger_actions_on"))
 
 
 ConversationType: TypeAlias = Literal["im", "mpim", "private", "public"]
@@ -511,6 +606,20 @@ class ConversationFilter(CompositionObject):
             }
         )
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConversationFilter:
+        """Parse a Slack ``filter`` composition object.
+
+        At least one of ``include``, ``exclude_external_shared_channels``,
+        or ``exclude_bot_users`` must be present; otherwise the underlying
+        constructor raises ``MissingRequiredError``.
+        """
+        return cls(
+            include=data.get("include"),
+            exclude_external_shared_channels=data.get("exclude_external_shared_channels"),
+            exclude_bot_users=data.get("exclude_bot_users"),
+        )
+
 
 class InputParameter(CompositionObject):
     """
@@ -531,6 +640,16 @@ class InputParameter(CompositionObject):
     def _resolve(self) -> dict[str, Any]:
         # InputParameter does not include "type" in its rendered JSON.
         return {"name": self.name, "value": self.value}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InputParameter:
+        """Parse a Slack ``input_parameter`` composition object."""
+        for field in ("name", "value"):
+            if field not in data:
+                raise MissingRequiredError(
+                    f"InputParameter payload is missing required `{field}` field."
+                )
+        return cls(name=data["name"], value=data["value"])
 
 
 class SlackFile(CompositionObject):
@@ -566,6 +685,11 @@ class SlackFile(CompositionObject):
     def _resolve(self) -> dict[str, Any]:
         # SlackFile does not include "type" in its rendered JSON.
         return omit_none({"url": self.url, "id": self.id})
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SlackFile:
+        """Parse a Slack ``slack_file`` composition object."""
+        return cls(url=data.get("url"), id=data.get("id"))
 
 
 class Trigger(CompositionObject):
@@ -607,6 +731,19 @@ class Trigger(CompositionObject):
                 else None,
             }
         )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Trigger:
+        """Parse a Slack ``trigger`` composition object."""
+        if "url" not in data:
+            raise MissingRequiredError("Trigger payload is missing required `url` field.")
+        raw_params = data.get("customizable_input_parameters")
+        params: list[InputParameter] | None
+        if raw_params is None:
+            params = None
+        else:
+            params = [InputParameter.from_dict(p) for p in raw_params]
+        return cls(url=data["url"], customizable_input_parameters=params)
 
 
 class Workflow(CompositionObject):
@@ -662,6 +799,13 @@ class Workflow(CompositionObject):
         else:
             params = None
         return cls(trigger=Trigger(url=url, customizable_input_parameters=params))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Workflow:
+        """Parse a Slack ``workflow`` composition object."""
+        if "trigger" not in data:
+            raise MissingRequiredError("Workflow payload is missing required `trigger` field.")
+        return cls(trigger=Trigger.from_dict(data["trigger"]))
 
 
 class RawText:

--- a/test/unit/test_from_dict.py
+++ b/test/unit/test_from_dict.py
@@ -1,0 +1,339 @@
+"""Tests for the ``from_dict`` parsers added in Phase 7.4.
+
+These verify the round-trip contract: for every supported class,
+``Foo.from_dict(Foo(...)._resolve())`` produces an instance whose
+``_resolve()`` equals the original.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from slackblocks import (
+    ActionsBlock,
+    Block,
+    Button,
+    ConfirmationDialogue,
+    ContextBlock,
+    ConversationFilter,
+    DispatchActionConfiguration,
+    DividerBlock,
+    FileBlock,
+    HeaderBlock,
+    ImageBlock,
+    InputBlock,
+    InputParameter,
+    MarkdownBlock,
+    MissingRequiredError,
+    Option,
+    OptionGroup,
+    PlainTextInput,
+    RichTextBlock,
+    SectionBlock,
+    SlackFile,
+    TableBlock,
+    Text,
+    TextType,
+    Trigger,
+    TypeMismatchError,
+    VideoBlock,
+    Workflow,
+)
+
+# -- Composition objects ---------------------------------------------------
+
+
+def test_text_round_trip_markdown() -> None:
+    t = Text("hi", type_=TextType.MARKDOWN, verbatim=True)
+    assert Text.from_dict(t._resolve())._resolve() == t._resolve()
+
+
+def test_text_round_trip_plaintext_with_emoji() -> None:
+    t = Text("hi", type_=TextType.PLAINTEXT, emoji=True)
+    assert Text.from_dict(t._resolve())._resolve() == t._resolve()
+
+
+def test_text_from_dict_missing_text_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        Text.from_dict({"type": "mrkdwn"})
+
+
+def test_text_from_dict_unknown_type_raises() -> None:
+    with pytest.raises(TypeMismatchError):
+        Text.from_dict({"type": "weird", "text": "hi"})
+
+
+def test_text_from_dict_ignores_unknown_fields() -> None:
+    """Forward-compat: unknown fields in the payload do not break parsing."""
+    t = Text.from_dict({"type": "mrkdwn", "text": "hi", "future_field": "x"})
+    assert t.text == "hi"
+
+
+def test_confirmation_dialogue_round_trip() -> None:
+    c = ConfirmationDialogue(
+        title="T",
+        text="Body",
+        confirm="OK",
+        deny="Cancel",
+    )
+    assert ConfirmationDialogue.from_dict(c._resolve())._resolve() == c._resolve()
+
+
+def test_confirmation_dialogue_missing_field_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        ConfirmationDialogue.from_dict(
+            {
+                "title": {"type": "plain_text", "text": "T"},
+                "text": {"type": "plain_text", "text": "x"},
+            }
+        )
+
+
+def test_option_round_trip_minimal() -> None:
+    o = Option(text="A", value="a")
+    assert Option.from_dict(o._resolve())._resolve() == o._resolve()
+
+
+def test_option_round_trip_full() -> None:
+    o = Option(text="A", value="a", description="desc", url="https://x.com")
+    assert Option.from_dict(o._resolve())._resolve() == o._resolve()
+
+
+def test_option_missing_value_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        Option.from_dict({"text": {"type": "plain_text", "text": "A"}})
+
+
+def test_option_group_round_trip() -> None:
+    og = OptionGroup(label="G", options=[Option("A", "a"), Option("B", "b")])
+    assert OptionGroup.from_dict(og._resolve())._resolve() == og._resolve()
+
+
+def test_dispatch_action_configuration_round_trip() -> None:
+    dac = DispatchActionConfiguration(trigger_actions_on=["on_enter_pressed"])
+    assert DispatchActionConfiguration.from_dict(dac._resolve())._resolve() == dac._resolve()
+
+
+def test_conversation_filter_round_trip() -> None:
+    cf = ConversationFilter(include=["public"], exclude_bot_users=True)
+    assert ConversationFilter.from_dict(cf._resolve())._resolve() == cf._resolve()
+
+
+def test_input_parameter_round_trip() -> None:
+    ip = InputParameter(name="n", value="v")
+    assert InputParameter.from_dict(ip._resolve())._resolve() == ip._resolve()
+
+
+def test_input_parameter_missing_field_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        InputParameter.from_dict({"name": "x"})
+
+
+def test_slack_file_round_trip_url() -> None:
+    sf = SlackFile(url="https://x.png", id=None)
+    assert SlackFile.from_dict(sf._resolve())._resolve() == sf._resolve()
+
+
+def test_slack_file_round_trip_id() -> None:
+    sf = SlackFile(url=None, id="F123")
+    assert SlackFile.from_dict(sf._resolve())._resolve() == sf._resolve()
+
+
+def test_trigger_round_trip_with_params() -> None:
+    tr = Trigger(
+        url="https://slack.com/x",
+        customizable_input_parameters=[InputParameter("a", "1")],
+    )
+    assert Trigger.from_dict(tr._resolve())._resolve() == tr._resolve()
+
+
+def test_trigger_round_trip_no_params() -> None:
+    tr = Trigger(url="https://slack.com/x", customizable_input_parameters=None)
+    assert Trigger.from_dict(tr._resolve())._resolve() == tr._resolve()
+
+
+def test_trigger_missing_url_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        Trigger.from_dict({})
+
+
+def test_workflow_round_trip() -> None:
+    w = Workflow.from_url("https://slack.com/x", a="1", b="2")
+    assert Workflow.from_dict(w._resolve())._resolve() == w._resolve()
+
+
+def test_workflow_missing_trigger_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        Workflow.from_dict({})
+
+
+# -- Block dispatcher and supported blocks --------------------------------
+
+
+def test_block_from_dict_missing_type_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        Block.from_dict({})
+
+
+def test_block_from_dict_unknown_type_raises() -> None:
+    with pytest.raises(TypeMismatchError):
+        Block.from_dict({"type": "no_such_block"})
+
+
+def test_divider_block_round_trip() -> None:
+    d = DividerBlock(block_id="b1")
+    parsed = Block.from_dict(d._resolve())
+    assert isinstance(parsed, DividerBlock)
+    assert parsed._resolve() == d._resolve()
+
+
+def test_file_block_round_trip() -> None:
+    fb = FileBlock(external_id="F1", block_id="b1")
+    parsed = Block.from_dict(fb._resolve())
+    assert isinstance(parsed, FileBlock)
+    assert parsed._resolve() == fb._resolve()
+
+
+def test_file_block_missing_external_id_raises() -> None:
+    with pytest.raises(MissingRequiredError):
+        FileBlock.from_dict({"type": "file", "block_id": "b1"})
+
+
+def test_header_block_round_trip() -> None:
+    hb = HeaderBlock(text="Hi", block_id="b1")
+    parsed = Block.from_dict(hb._resolve())
+    assert isinstance(parsed, HeaderBlock)
+    assert parsed._resolve() == hb._resolve()
+
+
+def test_markdown_block_round_trip() -> None:
+    mb = MarkdownBlock(text="**hi**", block_id="b1")
+    parsed = Block.from_dict(mb._resolve())
+    assert isinstance(parsed, MarkdownBlock)
+    assert parsed._resolve() == mb._resolve()
+
+
+def test_image_block_round_trip_with_title() -> None:
+    ib = ImageBlock(image_url="https://x.png", alt_text="alt", title="T", block_id="b1")
+    parsed = Block.from_dict(ib._resolve())
+    assert isinstance(parsed, ImageBlock)
+    assert parsed._resolve() == ib._resolve()
+
+
+def test_image_block_round_trip_no_title() -> None:
+    ib = ImageBlock(image_url="https://x.png", alt_text="alt", block_id="b1")
+    parsed = Block.from_dict(ib._resolve())
+    assert isinstance(parsed, ImageBlock)
+    assert parsed._resolve() == ib._resolve()
+
+
+def test_section_block_round_trip_text_only() -> None:
+    sb = SectionBlock("Hi", block_id="b1")
+    parsed = Block.from_dict(sb._resolve())
+    assert isinstance(parsed, SectionBlock)
+    assert parsed._resolve() == sb._resolve()
+
+
+def test_section_block_round_trip_with_fields() -> None:
+    sb = SectionBlock("Hi", block_id="b1", fields=["a", "b"])
+    parsed = Block.from_dict(sb._resolve())
+    assert isinstance(parsed, SectionBlock)
+    assert parsed._resolve() == sb._resolve()
+
+
+def test_section_block_with_accessory_raises_not_implemented() -> None:
+    """SectionBlock with an accessory element is deferred to Phase 7.4b."""
+    sb = SectionBlock("Hi", block_id="b1", accessory=Button("X", action_id="a"))
+    with pytest.raises(NotImplementedError):
+        Block.from_dict(sb._resolve())
+
+
+def test_context_block_round_trip_text_only() -> None:
+    cb = ContextBlock(elements=[Text("hi", type_=TextType.PLAINTEXT)], block_id="b1")
+    parsed = Block.from_dict(cb._resolve())
+    assert isinstance(parsed, ContextBlock)
+    assert parsed._resolve() == cb._resolve()
+
+
+def test_context_block_with_image_element_raises_not_implemented() -> None:
+    """ContextBlock containing an Image element is deferred to Phase 7.4b."""
+    from slackblocks import Image
+
+    cb = ContextBlock(elements=[Image(image_url="https://x.png", alt_text="a")], block_id="b1")
+    with pytest.raises(NotImplementedError):
+        Block.from_dict(cb._resolve())
+
+
+def test_video_block_round_trip_minimal() -> None:
+    vb = VideoBlock(
+        alt_text="alt",
+        thumbnail_url="https://x.png",
+        title="Title",
+        video_url="https://v.mp4",
+        block_id="b1",
+    )
+    parsed = Block.from_dict(vb._resolve())
+    assert isinstance(parsed, VideoBlock)
+    assert parsed._resolve() == vb._resolve()
+
+
+def test_video_block_round_trip_full() -> None:
+    vb = VideoBlock(
+        alt_text="alt",
+        thumbnail_url="https://x.png",
+        title="Title",
+        video_url="https://v.mp4",
+        block_id="b1",
+        author_name="A",
+        description="D",
+        provider_icon_url="https://i.png",
+        provider_name="P",
+        title_url="https://t.com",
+    )
+    parsed = Block.from_dict(vb._resolve())
+    assert parsed._resolve() == vb._resolve()
+
+
+def test_video_block_missing_required_raises() -> None:
+    for missing in ("alt_text", "thumbnail_url", "title", "video_url"):
+        base = {
+            "type": "video",
+            "alt_text": "a",
+            "thumbnail_url": "u",
+            "title": {"type": "plain_text", "text": "T"},
+            "video_url": "u",
+        }
+        del base[missing]
+        with pytest.raises(MissingRequiredError):
+            VideoBlock.from_dict(base)
+
+
+# -- Deferred blocks ------------------------------------------------------
+
+
+def test_actions_block_round_trip_raises_not_implemented() -> None:
+    ab = ActionsBlock(elements=[Button("Go", action_id="a")], block_id="b1")
+    with pytest.raises(NotImplementedError):
+        Block.from_dict(ab._resolve())
+
+
+def test_input_block_round_trip_raises_not_implemented() -> None:
+    ib = InputBlock(label="L", element=PlainTextInput(action_id="t"), block_id="b1")
+    with pytest.raises(NotImplementedError):
+        Block.from_dict(ib._resolve())
+
+
+def test_rich_text_block_round_trip_raises_not_implemented() -> None:
+    from slackblocks import RichText, RichTextSection
+
+    rtb = RichTextBlock(elements=RichTextSection(elements=RichText("hi")), block_id="b1")
+    with pytest.raises(NotImplementedError):
+        Block.from_dict(rtb._resolve())
+
+
+def test_table_block_round_trip_raises_not_implemented() -> None:
+    from slackblocks import RawText
+
+    tb = TableBlock(rows=[[RawText("cell")]], block_id="b1")
+    with pytest.raises(NotImplementedError):
+        Block.from_dict(tb._resolve())


### PR DESCRIPTION
Closes #208

## Summary
Adds `from_dict()` classmethods that turn Slack-shaped JSON dicts back into `slackblocks` objects. Lets users handle incoming Slack events / interactivity payloads using the same library they used to build them.

```python
import json
from slackblocks import Block, Text

payload = json.loads(some_slack_event_body)
block = Block.from_dict(payload['blocks'][0])
text = Text.from_dict({'type': 'mrkdwn', 'text': 'hi'})
```

## Round-trip contract
For every supported class, `Foo.from_dict(Foo(...)._resolve())._resolve() == original`.

## Coverage in this PR

**Composition objects (full):** `Text`, `ConfirmationDialogue` (and `Confirm`), `Option`, `OptionGroup`, `DispatchActionConfiguration`, `ConversationFilter`, `InputParameter`, `SlackFile`, `Trigger`, `Workflow`.

**Blocks (full):** `DividerBlock`, `FileBlock`, `HeaderBlock`, `MarkdownBlock`, `ImageBlock`, `VideoBlock`.

**Blocks (partial):**
- `SectionBlock` -- text + fields work; accessory raises `NotImplementedError`.
- `ContextBlock` -- text-only works; Image elements raise `NotImplementedError`.

**Top-level dispatcher:** `Block.from_dict(d)` reads `d['type']` and routes. `Block` is now exported from the package root.

## Deferred to follow-up PRs
- `ActionsBlock`, `InputBlock`, `SectionBlock(accessory=...)`, `ContextBlock` (Image-containing) -- depend on `Element.from_dict` (Phase 7.4b).
- `RichTextBlock`, `TableBlock` -- depend on rich-text parsers (Phase 7.4c).

Each raises a clear `NotImplementedError` pointing to the future phase.

## Forward compatibility
Unknown fields in the payload are silently ignored so future Slack additions to existing block / object schemas do not break parsing.

## Errors
- Missing required fields -> `MissingRequiredError` (Phase 5).
- Unknown discrete values (e.g. unknown text type) -> `TypeMismatchError`.

## Verification
- Test count: 211 -> 254 (+43).
- ruff lint/format clean; mypy clean.
- Manual round-trip checks against every supported class match exactly.