### PR TITLE
docs: docstring polish (View, ??? placeholders, typo fixes)

### DIFF
--- a/slackblocks/blocks.py
+++ b/slackblocks/blocks.py
@@ -446,7 +446,7 @@ class InputBlock(Block):
         dispatch_action: whether the [Element](/slackblocks/latest/reference/elements)
             should trigger the sending of a `block_actions` payload.
         block_id: you can use this field to provide a deterministic identifier for the block.
-        hint: an optional additional guide on what input the user should prodive.
+        hint: an optional additional guide on what input the user should provide.
         optional: whether this input field may be empty when the user submits e.g. the modal.
 
     Throws:

--- a/slackblocks/elements.py
+++ b/slackblocks/elements.py
@@ -481,7 +481,7 @@ class StaticMultiSelectMenu(Element):
             (max 100). Only one of `options` or `option_groups` can be
             provided.
         initial_options: the [`Options`](/slackblocks/latest/reference/objects/#objects.Option)
-            to be intially selected when the element is first rendered.
+            to be initially selected when the element is first rendered.
         confirm: a `ConfirmationDialogue` object that will be presented when
             the menu is used.
         max_selected_items: the
@@ -589,7 +589,7 @@ class ExternalMultiSelectMenu(Element):
         min_query_length: minimum number of characters entered before the query
             is dispactched (defaults to 3 if not provided).
         initial_options: the [`Options`](/slackblocks/latest/reference/objects/#objects.Option)
-            to be intially selected when the element is first rendered.
+            to be initially selected when the element is first rendered.
         confirm: a `ConfirmationDialogue` object that will be presented when
             the menu is used.
         max_selected_items: the highest number of items from the list that
@@ -653,7 +653,7 @@ class UserMultiSelectMenu(Element):
 
     Args:
         action_id: an identifier so the source of the action can be known.
-        initial_users: a list of string user IDs to be intially selected
+        initial_users: a list of string user IDs to be initially selected
             when the element is first rendered.
         confirm: a `ConfirmationDialogue` object that will be presented when
             the menu is used.
@@ -1298,7 +1298,7 @@ class ConversationSelectMenu(Element):
 
     Args:
         action_id: an identifier so the source of the action can be known.
-        initial_conversation: the single (string) coversation ID that will be initially
+        initial_conversation: the single (string) conversation ID that will be initially
             selected when first presented to the user.
         default_to_current_conversation: Pre-populates the select menu with the
             conversation that the user was viewing when they opened the modal

--- a/slackblocks/objects.py
+++ b/slackblocks/objects.py
@@ -67,7 +67,7 @@ class TextType(Enum):
     """
     Allowable types for Slack Text objects.
 
-    MARKDOWN: tradional markdown formatting, see
+    MARKDOWN: traditional markdown formatting, see
         <https://api.slack.com/reference/surfaces/formatting#basic-formatting>
     PLAINTEXT: simple Unicode text with no formatting (e.g. bold) features.
 

--- a/slackblocks/rich_text/elements.py
+++ b/slackblocks/rich_text/elements.py
@@ -112,7 +112,10 @@ class RichTextChannel(RichTextElement):
         italic: whether to render the given channel in italics.
         strike: whether to render the given channel with a "strikethrough".
         highlight: whether to give the channel a distinct highlight when rendered.
-        client_highlight: ???
+        client_highlight: a Slack-internal rendering hint accompanying
+            mention-style elements. Rarely needed by app developers; pass
+            ``None`` (the default) unless you have a specific reason to set
+            it.
         unlink: whether to remove the link to the channel from the channel when
             rendered.
     """
@@ -241,7 +244,10 @@ class RichTextUser(RichTextElement):
         italic: whether to render the given user in italics.
         strike: whether to render the given user with a "strikethrough".
         highlight: whether to give the user a distinct highlight when rendered.
-        client_highlight: ???
+        client_highlight: a Slack-internal rendering hint accompanying
+            mention-style elements. Rarely needed by app developers; pass
+            ``None`` (the default) unless you have a specific reason to set
+            it.
         unlink: whether to remove the link to the user from the channel when
             rendered.
     """
@@ -295,7 +301,10 @@ class RichTextUserGroup(RichTextElement):
         italic: whether to render the given user in italics.
         strike: whether to render the given user with a "strikethrough".
         highlight: whether to give the user a distinct highlight when rendered.
-        client_highlight: ???
+        client_highlight: a Slack-internal rendering hint accompanying
+            mention-style elements. Rarely needed by app developers; pass
+            ``None`` (the default) unless you have a specific reason to set
+            it.
         unlink: whether to remove the link to the user from the channel when
             rendered.
     """

--- a/slackblocks/rich_text/objects.py
+++ b/slackblocks/rich_text/objects.py
@@ -1,7 +1,7 @@
 """
 Rich text objects are containers for rich text elements.
 
-These obejects form the contents of the
+These objects form the contents of the
     [`RichTextBlock`](/slackblocks/latest/reference/blocks/#blocks.RichTextBlock).
 """
 

--- a/slackblocks/views.py
+++ b/slackblocks/views.py
@@ -22,7 +22,33 @@ class ViewType(Enum):
 
 
 class View:
-    """ """
+    """
+    Base class for Slack app surfaces -- the visual areas an app can populate
+    with blocks. Concrete subclasses are
+    [`ModalView`](/slackblocks/latest/reference/views/#views.ModalView) (for
+    pop-up modals) and
+    [`HomeTabView`](/slackblocks/latest/reference/views/#views.HomeTabView)
+    (for the per-user App Home tab).
+
+    See: <https://api.slack.com/reference/surfaces/views>.
+
+    Args:
+        type: one of the `ViewType` enum members. Concrete subclasses set
+            this for you; in practice you should construct `ModalView` or
+            `HomeTabView` rather than `View` directly.
+        blocks: 1-100 blocks that make up the contents of the view.
+        private_metadata: a string (max 3000 characters) that will be sent
+            back to your app in any view-related interaction payloads.
+            Useful for stashing per-view server-side context.
+        callback_id: an identifier (max 255 characters) for distinguishing
+            this view's submissions from other views your app exposes.
+        external_id: a custom identifier that is unique within the views of
+            a given Slack team. Slack uses it to find views your app has
+            previously published.
+
+    Throws:
+        InvalidUsageError: if any of the validation checks fail.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
Closes #214

## Summary
Cleans up docstring quality issues surfaced in the original code audit.

## Changes
- **`View` docstring** (`slackblocks/views.py`) — was empty (`""" """`); now contains a description, link to the concrete subclasses, Slack-API reference URL, and an Args block.
- **`???` placeholders** for `client_highlight` in `rich_text/elements.py` (3 occurrences across `RichTextChannel`, `RichTextUser`, `RichTextUserGroup`) replaced with a real description: it is a rarely-needed Slack-internal rendering hint.
- **Typos**: `tradional` -> `traditional`, `intially` -> `initially` (x3), `coversation` -> `conversation`, `prodive` -> `provide`, `obejects` -> `objects`.

## Verification
- `mkdocs build --strict` passes.
- 254 tests pass.
- ruff format/lint clean; mypy clean.