### PR TITLE
docs: extend prose docs to cover the 2.0 API additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 pip install slackblocks
 ```
 
-Requires Python 3.8.1 or newer.
+`slackblocks 2.x` requires Python 3.10 or newer. Users on Python 3.8 / 3.9 should pin to the `1.x` line — see the [Compatibility](https://nicklambourne.github.io/slackblocks/latest/usage/compatibility/) page.
 
 ## Quickstart
 
@@ -84,22 +84,41 @@ The `**` operator unpacks `slackblocks` `Message` objects directly into the SDK 
 
 | Surface             | Status |
 |---------------------|:------:|
-| Blocks              | ✅ All current block types (Section, Header, Divider, Image, Context, Actions, Input, RichText, File, Table) |
+| Blocks              | ✅ All current block types (Section, Header, Divider, Image, Context, Actions, Input, RichText, File, Table, **Markdown**, **Video**) |
 | Elements            | ✅ Buttons, all select menus, date/time pickers, checkboxes, radio groups, all input types, overflow menus, workflow buttons |
-| Composition Objects | ✅ Text, Option, Confirm, Conversation/Dispatch filters, Workflow, Trigger |
+| Composition Objects | ✅ Text (+ `PlainText` / `Markdown` aliases), Option, Confirm, Conversation/Dispatch filters, Workflow, Trigger |
 | Rich Text           | ✅ Sections, lists, quotes, code blocks, inline links/users/channels/emoji |
 | Modals & Home Tabs  | ✅ Full views API |
 | Messages            | ✅ `chat.postMessage`, webhook messages, slash-command/interaction responses, threaded replies, ephemeral messages |
 | Attachments         | ⚠️ Supported but [deprecated by Slack](https://api.slack.com/reference/messaging/attachments) |
+| Round-tripping      | ✅ `Block.from_dict(data)` and per-class `from_dict` for parsing incoming Slack JSON back into objects |
+
+## What's new in 2.0
+
+`slackblocks 2.x` is the first major release in the modernised line. Highlights:
+
+- **Two new block types**: `MarkdownBlock` (GitHub-flavored Markdown) and `VideoBlock`.
+- **`PlainText` and `Markdown`** thin aliases for `Text(type_=...)`.
+- **`block_kit_builder_url(payload)`** — turn any block, message, or view into a [Block Kit Builder](https://app.slack.com/block-kit-builder) URL for browser preview.
+- **`Workflow.from_url(url, **params)`** — one-line workflow construction.
+- **`Block.from_dict(data)`** + per-class `from_dict` parsers — round-trip incoming Slack JSON back into `slackblocks` objects.
+- **Typed exception subclasses** of `InvalidUsageError` (`LengthError`, `RangeError`, `TypeMismatchError`, `MutualExclusivityError`, `MissingRequiredError`) — existing `except InvalidUsageError` blocks continue to work.
+- **Tighter type signatures**: `Literal` narrowing on `Button.style`, `ColumnSettings.align`, `ConversationFilter.include`; `@overload` on `Text.to_text` so the return type narrows on `allow_none`.
+- **Modern annotation syntax** (`list[X]`, `X | Y`) throughout.
+
+Existing 1.x code continues to work unchanged; see the [Migration Guide](https://nicklambourne.github.io/slackblocks/latest/usage/migration/) for the full diff.
 
 ## Documentation
 
 - **Full docs:** <https://nicklambourne.github.io/slackblocks/>
 - [Installation](https://nicklambourne.github.io/slackblocks/latest/usage/installation/)
+- [Compatibility](https://nicklambourne.github.io/slackblocks/latest/usage/compatibility/) — which Python versions each release line supports.
 - [Using Blocks](https://nicklambourne.github.io/slackblocks/latest/usage/using_blocks/) — every block type with code, JSON, and screenshots.
 - [Sending Messages](https://nicklambourne.github.io/slackblocks/latest/usage/sending_messages/)
 - [Cookbook](https://nicklambourne.github.io/slackblocks/latest/usage/cookbook/) — end-to-end recipes for build notifications, approval requests, modals, and more.
+- [Migrating from 1.x](https://nicklambourne.github.io/slackblocks/latest/usage/migration/) — upgrade guide for `1.x` users.
 - [Troubleshooting & FAQ](https://nicklambourne.github.io/slackblocks/latest/usage/troubleshooting/)
+- [Changelog](https://github.com/nicklambourne/slackblocks/blob/master/CHANGELOG.md)
 
 ## Comparison with `slack-sdk` block classes
 
@@ -129,8 +148,8 @@ cd slackblocks
 uv sync --all-groups
 
 uv run pytest test/unit
-uv run black . --check
-uv run flake8 slackblocks
+uv run ruff format --check .
+uv run ruff check .
 uv run mypy slackblocks
 ```
 

--- a/docs_src/index.md
+++ b/docs_src/index.md
@@ -45,6 +45,8 @@ The [Slack Block Kit API](https://api.slack.com/block-kit) defines several resou
 
 [Objects](reference/objects.md) (e.g. [`Text`](reference/objects.md#objects.Text), [`Option`](reference/objects.md#objects.Option), [`Confirm`](reference/objects.md#objects.Confirm)) are the lowest-level primitives — small composable pieces that populate [Elements](reference/elements.md) and [Blocks](reference/blocks.md).
 
+For convenience, [`PlainText`](reference/objects.md#objects.PlainText) and [`Markdown`](reference/objects.md#objects.Markdown) are thin subclasses of `Text` that you can use anywhere a `Text` is expected — `PlainText("Hi", emoji=True)` reads more naturally than `Text("Hi", type_=TextType.PLAINTEXT, emoji=True)`.
+
 ### Elements
 
 [Elements](reference/elements.md) are typically interactive UI controls that go *inside* blocks. The [`CheckboxGroup`](reference/elements.md#elements.CheckboxGroup) element, for instance, takes one or more [`Option`](reference/objects.md#objects.Option) items and presents a checkbox menu.
@@ -56,8 +58,10 @@ The [Slack Block Kit API](https://api.slack.com/block-kit) defines several resou
 - [`SectionBlock`](reference/blocks.md#blocks.SectionBlock) — a chunk of markdown text, optionally with an accessory element.
 - [`HeaderBlock`](reference/blocks.md#blocks.HeaderBlock) — a large bold title.
 - [`DividerBlock`](reference/blocks.md#blocks.DividerBlock) — a visual separator (like an HTML `<hr>`).
+- [`MarkdownBlock`](reference/blocks.md#blocks.MarkdownBlock) — GitHub-flavored Markdown (Slack 2024+; richer formatting than `mrkdwn`).
 - [`RichTextBlock`](reference/blocks.md#blocks.RichTextBlock) — formatted text with inline styling, lists, code blocks, and quotes.
 - [`ActionsBlock`](reference/blocks.md#blocks.ActionsBlock) — a row of interactive elements like buttons or menus.
+- [`VideoBlock`](reference/blocks.md#blocks.VideoBlock) — embed a video from a Slack-supported provider.
 - [`ImageBlock`](reference/blocks.md#blocks.ImageBlock), [`ContextBlock`](reference/blocks.md#blocks.ContextBlock), [`InputBlock`](reference/blocks.md#blocks.InputBlock), [`FileBlock`](reference/blocks.md#blocks.FileBlock), [`TableBlock`](reference/blocks.md#blocks.TableBlock).
 
 See [Using Blocks](usage/using_blocks.md) for examples of all block types side-by-side with their JSON output and Slack rendering.
@@ -74,11 +78,18 @@ See [Using Blocks](usage/using_blocks.md) for examples of all block types side-b
 
 [Views](reference/views.md) are an alternative usage of blocks that build custom UI surfaces in Slack — modal dialogs and the App Home tab — typically used by interactive Slack apps.
 
+### Utilities
+
+- [`block_kit_builder_url(payload, team_id=None)`](reference/utils.md#builder.block_kit_builder_url) — turn any block, list of blocks, message, or view into a [Block Kit Builder](https://app.slack.com/block-kit-builder) URL for browser-based preview.
+- [`Block.from_dict(data)`](reference/blocks.md#blocks.Block.from_dict) — parse a Slack-shaped block payload back into a `slackblocks` object. Per-class `from_dict` parsers are also available on every composition object.
+
 ## Guides
 
 - [Installation](usage/installation.md)
+- [Compatibility](usage/compatibility.md) — which Python versions each release line supports.
 - [Using Blocks](usage/using_blocks.md)
 - [Sending Messages](usage/sending_messages.md)
 - [Cookbook](usage/cookbook.md) — complete end-to-end recipes for common message patterns.
+- [Migrating from 1.x](usage/migration.md) — upgrade guide for `1.x` users.
 - [Troubleshooting & FAQ](usage/troubleshooting.md)
 - [Contributing](contributing.md) — developing and contributing to `slackblocks` itself.

--- a/docs_src/reference/blocks.md
+++ b/docs_src/reference/blocks.md
@@ -10,5 +10,5 @@ Slack reference: <https://api.slack.com/reference/block-kit/blocks>
 
 ::: blocks
     options:
-        filters: ["!^Block"]
+        filters: ["!^BlockType$", "!^_block_from_dict_registry$"]
         show_bases: false

--- a/docs_src/reference/utils.md
+++ b/docs_src/reference/utils.md
@@ -1,5 +1,27 @@
 # Utilities
 
-Internal helper functions used across `slackblocks` for validation and coercion. Most users won't need to call these directly, but they're documented here for completeness and for anyone extending `slackblocks` with custom block or element types.
+This page documents top-level helper utilities shipped with `slackblocks`.
+
+## Block Kit Builder URL
+
+`block_kit_builder_url(payload, team_id=None)` builds a [Slack Block Kit Builder](https://app.slack.com/block-kit-builder) URL containing the supplied payload, so you can preview a message, view, or block list in the browser.
+
+Accepted payload shapes:
+
+- A single [`Block`](blocks.md) — wrapped in `{"blocks": [block]}` automatically.
+- A list of `Block` — also wrapped.
+- Anything with a `_resolve()` method ([`Message`](messages.md), [`WebhookMessage`](messages.md), [`MessageResponse`](messages.md), [`View`](views.md), [`ModalView`](views.md), [`HomeTabView`](views.md)).
+- A raw `dict` — used verbatim. This is the escape hatch for callers building payloads outside the type hierarchy.
+
+For a `team_id`-specific Builder URL (e.g. `https://app.slack.com/block-kit-builder/T0123#…`), pass `team_id="T0123ABCD"`.
+
+::: builder
+    options:
+        show_root_heading: false
+        show_root_toc_entry: false
+
+## Validation helpers
+
+Lower-level helper functions used across `slackblocks` for validation and coercion. Most users won't need to call these directly, but they're documented here for completeness and for anyone extending `slackblocks` with custom block or element types.
 
 ::: utils

--- a/docs_src/usage/cookbook.md
+++ b/docs_src/usage/cookbook.md
@@ -282,3 +282,125 @@ msg = Message(
 ```
 
 Prefer plain blocks where possible — Slack may drop attachment support in the future.
+
+
+## Preview a message in the browser
+
+Use `block_kit_builder_url` to build a [Block Kit Builder](https://app.slack.com/block-kit-builder) URL and open it in your browser to verify a message before posting it. Useful while iterating on layout — no Slack credentials needed.
+
+```python
+from slackblocks import (
+    block_kit_builder_url,
+    DividerBlock,
+    HeaderBlock,
+    Markdown,
+    SectionBlock,
+)
+
+blocks = [
+    HeaderBlock("Build #482 passed :white_check_mark:"),
+    SectionBlock(text=Markdown("All 1,247 tests green in 3m 12s.")),
+    DividerBlock(),
+    SectionBlock(fields=["*Author*\n@nick", "*Branch*\n`main`"]),
+]
+
+print(block_kit_builder_url(blocks))
+# https://app.slack.com/block-kit-builder/#%7B%22blocks%22%3A%5B...%5D%7D
+```
+
+`block_kit_builder_url` accepts:
+
+- A single `Block`, `Element`, or anything else with a `_resolve()` method.
+- A list of `Block` objects (wrapped in `{"blocks": [...]}` automatically).
+- A `Message`, `WebhookMessage`, `MessageResponse`, or `View`.
+- A raw `dict` (escape hatch).
+
+Pass `team_id="T0123ABCD"` for a workspace-specific URL.
+
+
+## Parse incoming Slack JSON
+
+If your app handles Slack interactivity payloads or events, you can parse the JSON back into `slackblocks` objects with `Block.from_dict`:
+
+```python
+import json
+from slackblocks import Block, SectionBlock
+
+incoming = json.loads(slack_request_body)
+
+for raw_block in incoming.get("blocks", []):
+    block = Block.from_dict(raw_block)
+    if isinstance(block, SectionBlock):
+        print("Section text:", block.text.text if block.text else None)
+```
+
+`Block.from_dict` reads `data["type"]` and dispatches to the right subclass. The composition objects (`Text`, `Option`, `Confirm`, etc.) round-trip fully via their own `from_dict` classmethods.
+
+In the current release, blocks containing interactive elements (`ActionsBlock`, `InputBlock`, `SectionBlock` with an `accessory`, `ContextBlock` with image elements) raise `NotImplementedError` — this is on the roadmap for a follow-up release.
+
+
+## One-line workflow trigger
+
+`Workflow.from_url` collapses the most common workflow construction:
+
+```python
+from slackblocks import (
+    ActionsBlock,
+    Message,
+    SectionBlock,
+    Workflow,
+    WorkflowButton,
+)
+
+msg = Message(
+    channel="#release",
+    blocks=[
+        SectionBlock("Run the release workflow with the parameters below."),
+        ActionsBlock(
+            elements=[
+                WorkflowButton(
+                    text="Release",
+                    workflow=Workflow.from_url(
+                        "https://slack.com/shortcuts/Ft012KXZK1MZ/...",
+                        env="prod",
+                        retries="3",
+                    ),
+                ),
+            ],
+        ),
+    ],
+)
+```
+
+Each keyword pair becomes one `InputParameter` on the underlying `Trigger`. Calling `Workflow.from_url(url)` with no parameters omits the `customizable_input_parameters` field.
+
+
+## Typed exception handling
+
+`InvalidUsageError` is the base type for every validation failure raised by `slackblocks`. As of `2.x`, five subclasses let you `except` for specific failure categories instead of string-matching the message:
+
+```python
+from slackblocks import (
+    Button,
+    LengthError,
+    MutualExclusivityError,
+    SlackFile,
+    Image,
+)
+
+try:
+    Button(text="x" * 100, action_id="b")
+except LengthError as e:
+    # specifically a length violation, not a missing-required or type-mismatch
+    log.warning("button text too long: %s", e)
+
+try:
+    Image(
+        image_url="https://x.png",
+        slack_file=SlackFile(url="https://y.png", id=None),
+    )
+except MutualExclusivityError as e:
+    log.error("image source ambiguous: %s", e)
+```
+
+Existing `except InvalidUsageError` blocks continue to catch every subclass — the new types are purely additive.

--- a/docs_src/usage/using_blocks.md
+++ b/docs_src/usage/using_blocks.md
@@ -171,6 +171,37 @@ For the reverse mapping — looking up a class by name — see the [Blocks refer
     ![An example of the UI output of a Header Block](../img/usage/header.png)
 
 
+## Markdown Block
+:::blocks.MarkdownBlock
+    options:
+        show_bases: false
+        show_source: false
+
+
+Slack added the `markdown` block type in 2024, primarily for AI / agentic apps. Unlike the `mrkdwn` text inside a [Section Block](#section-block), `MarkdownBlock` renders **GitHub-flavored Markdown**, supporting tables, code blocks, and richer list semantics.
+
+`text` is required (1 - 12,000 characters).
+
+=== "`slackblocks`"
+    ```python
+    from slackblocks import MarkdownBlock
+
+    MarkdownBlock(
+        text="**Hello!** Markdown blocks support _GitHub-flavored_ syntax.",
+    )
+    ```
+
+=== "JSON"
+    ```json
+    {
+        "type": "markdown",
+        "text": "**Hello!** Markdown blocks support _GitHub-flavored_ syntax."
+    }
+    ```
+
+See the [Slack reference](https://api.slack.com/reference/block-kit/blocks#markdown) for the supported Markdown features.
+
+
 ## Image Block
 :::blocks.ImageBlock
     options:
@@ -550,3 +581,54 @@ For the reverse mapping — looking up a class by name — see the [Blocks refer
 
 === "Slack UI"
     ![An example of the UI output of a Table Block](../img/usage/table.png)
+
+
+## Video Block
+:::blocks.VideoBlock
+    options:
+        show_bases: false
+        show_source: false
+
+
+Embeds a video from a Slack-supported provider (e.g. YouTube, Vimeo). The `title` accepts either a `str` (coerced to plain-text) or a `Text` instance; `description` works the same way.
+
+Required: `alt_text`, `thumbnail_url`, `title`, `video_url`. Slack restricts which domains may be embedded — supplying an unsupported URL will produce a Slack API error rather than an `InvalidUsageError` at construction.
+
+=== "`slackblocks`"
+    ```python
+    from slackblocks import VideoBlock
+
+    VideoBlock(
+        alt_text="How to use slackblocks",
+        thumbnail_url="https://example.com/thumb.png",
+        title="Getting Started",
+        video_url="https://example.com/video.mp4",
+        author_name="The slackblocks docs",
+        description="A short walkthrough.",
+        provider_name="example.com",
+        title_url="https://example.com",
+    )
+    ```
+
+=== "JSON"
+    ```json
+    {
+        "type": "video",
+        "alt_text": "How to use slackblocks",
+        "thumbnail_url": "https://example.com/thumb.png",
+        "title": {
+            "type": "plain_text",
+            "text": "Getting Started"
+        },
+        "video_url": "https://example.com/video.mp4",
+        "author_name": "The slackblocks docs",
+        "description": {
+            "type": "plain_text",
+            "text": "A short walkthrough."
+        },
+        "provider_name": "example.com",
+        "title_url": "https://example.com"
+    }
+    ```
+
+See the [Slack reference](https://api.slack.com/reference/block-kit/blocks#video) for the full list of optional fields and provider requirements.


### PR DESCRIPTION
Closes #216

## Summary
The reference docs auto-update via mkdocstrings, but the prose docs still described only the 1.x surface. This PR extends them to cover everything Phase 1-7 added.

## Changes
- **README.md**: Python 3.10+ note, 'What's new in 2.0' section, updated supported-surfaces table (Markdown / Video blocks; round-tripping), updated Documentation links list, ruff in the contributing checklist.
- **docs_src/index.md**: Markdown / Video blocks listed; PlainText / Markdown aliases; new Utilities section; Compatibility and Migration links in the Guides list.
- **docs_src/usage/using_blocks.md**: new Markdown Block and Video Block sections following the existing per-section template.
- **docs_src/usage/cookbook.md**: four new recipes — browser preview via `block_kit_builder_url`, parsing incoming Slack JSON via `Block.from_dict`, one-line workflow trigger via `Workflow.from_url`, typed exception handling via the Phase 5 subclasses.
- **docs_src/reference/blocks.md**: adjusted mkdocstrings filter so `Block.from_dict` renders.
- **docs_src/reference/utils.md**: added a top section autodoccing `block_kit_builder_url`; the existing validation helpers stay underneath.

## Verification
- `uv run mkdocs build --strict` passes; no new warnings.
- All anchors referenced by index/utils render correctly in the built site.
- 254 unit tests pass; ruff format/lint clean; mypy clean.