### PR TITLE
release: cut 2.0.0rc1 and harden publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,19 @@
 name: Publish SlackBlocks Python Package
 on:
   push:
+    # Trigger on every version tag: final releases (v2.0.0) and pre-releases
+    # (v2.0.0rc1, v2.0.0b1, v2.0.0a1, v2.0.0.dev0, etc.). PyPI itself classifies
+    # pre-releases per PEP 440 from the version string in pyproject.toml, so
+    # 'pip install slackblocks' continues to skip them by default.
     tags:
-      - "v*.*.*"
+      - "v*"
+
+permissions:
+  contents: read
+
 jobs:
-  build:
+  publish:
+    name: Build and publish to PyPI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -19,6 +28,20 @@ jobs:
 
       - name: Build Package
         run: uv build
+
+      - name: Verify tag matches package version
+        # Guards against publishing if a tag is pushed without the
+        # corresponding pyproject.toml bump. Fail loudly rather than upload
+        # the wrong version.
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(uv run python -c "import importlib.metadata; print(importlib.metadata.version('slackblocks'))")
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag '$tag' does not match package version '$pkg' in pyproject.toml."
+            exit 1
+          fi
+          echo "Tag $tag matches package version $pkg."
 
       - name: Publish Package
         run: uv publish --token ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slackblocks"
-version = "2.0.0.dev0"
+version = "2.0.0rc1"
 description = "Python wrapper for the Slack Blocks API"
 authors = [
     { name = "Nicholas Lambourne", email = "dev@ndl.im" },

--- a/uv.lock
+++ b/uv.lock
@@ -1819,7 +1819,7 @@ wheels = [
 
 [[package]]
 name = "slackblocks"
-version = "2.0.0.dev0"
+version = "2.0.0rc1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #224

## Summary
First publishable release of the 2.0 line.

## Changes
- **`pyproject.toml`**: bump `version` from `2.0.0.dev0` to `2.0.0rc1`.
- **`.github/workflows/publish.yml`**:
  - Broaden the tag trigger from `v*.*.*` to `v*`. The previous pattern only matched final releases like `v2.0.0` — pre-release tags (`v2.0.0rc1`, `v2.0.0b1`, etc.) were silently dropped.
  - Add a `Verify tag matches package version` step so a tag push without a corresponding `pyproject.toml` bump fails fast instead of uploading the wrong version to PyPI.
  - Name the job `Build and publish to PyPI` (was unnamed, defaulting to `build`).
  - Add `permissions: contents: read` block.

## How users get this release

| Install command | Resolves to |
|---|---|
| `pip install slackblocks` | latest `1.x` stable |
| `pip install --pre slackblocks` | `2.0.0rc1` |
| `pip install 'slackblocks==2.0.0rc1'` | `2.0.0rc1` |

## Verification (local)
- `uv build` produces `slackblocks-2.0.0rc1.tar.gz` + matching wheel.
- 369 tests pass; coverage 93.49%; ruff + mypy clean.
- Workflow YAML parses with PyYAML.

## Next step (after merge)
Push the tag to trigger the publish workflow:

```bash
git tag v2.0.0rc1
git push origin v2.0.0rc1
```