### PR TITLE
release: 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to `slackblocks` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] — Unreleased
+## [2.0.0] — 2026-05-15
 
-The 2.0 development series.
+The 2.0 release. First final release of the modernised line.
 
 `slackblocks 2.x` requires **Python 3.10 or newer**. Users on Python 3.8 or 3.9
 should pin to the `1.x` release line; see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slackblocks"
-version = "2.0.0rc1"
+version = "2.0.0"
 description = "Python wrapper for the Slack Blocks API"
 authors = [
     { name = "Nicholas Lambourne", email = "dev@ndl.im" },

--- a/uv.lock
+++ b/uv.lock
@@ -1819,7 +1819,7 @@ wheels = [
 
 [[package]]
 name = "slackblocks"
-version = "2.0.0rc1"
+version = "2.0.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #231

## Summary
Promotes slackblocks from `2.0.0rc1` to `2.0.0` (final). After this lands and the `v2.0.0` tag is pushed, `pip install slackblocks` resolves to `2.0.0` for all users by default.

## Changes
- `pyproject.toml`: version `2.0.0rc1` -> `2.0.0`.
- `uv.lock`: regenerated to match.
- `CHANGELOG.md`: `[2.0.0] — Unreleased` -> `[2.0.0] — 2026-05-15`.

## Verification
- 369 tests pass; coverage 93.49%; ruff lint/format clean; mypy clean.
- `uv build` produces `slackblocks-2.0.0.tar.gz` and `-py3-none-any.whl`.