### PR TITLE
Pin hatchling below 1.28 for twine compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,9 @@ docs = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+# Hatchling 1.28 emits Core Metadata 2.5, which Twine 6.2 cannot yet
+# validate. Keep package checks reproducible until Twine adds 2.5 support.
+requires = ["hatchling<1.28"]
 build-backend = "hatchling.build"
 
 [tool.ruff]


### PR DESCRIPTION
## Scope

Fixes the failing `Package Check` on master: hatchling 1.28 began emitting Core Metadata 2.5, which twine 6.2 cannot validate. Pins the build backend exactly as the incoming monorepo train does in #242, so the two changes merge cleanly.

## Validation

`uv build` + `twine check` pass locally on both wheel and sdist with the pin.
