### PR TITLE
Report required checks on every pull request

### DIFF
--- a/.github/workflows/ruff-format.yml
+++ b/.github/workflows/ruff-format.yml
@@ -8,10 +8,6 @@ on:
       - "docs/scripts/**"
       - ".github/workflows/ruff-format.yml"
   pull_request:
-    paths:
-      - "python/**"
-      - "docs/scripts/**"
-      - ".github/workflows/ruff-format.yml"
 
 permissions:
   contents: read
@@ -21,7 +17,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Compare changed files against this workflow's scope
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename') || files=""
+          if [ -z "$files" ]; then
+            # Fail open: if the file list cannot be read, run the real checks.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -qE '^(python/|docs/scripts/|\.github/workflows/ruff-format\.yml$)' <<<"$files"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   formatting:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     name: Ruff Format
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ruff-lint.yml
+++ b/.github/workflows/ruff-lint.yml
@@ -8,10 +8,6 @@ on:
       - "docs/scripts/**"
       - ".github/workflows/ruff-lint.yml"
   pull_request:
-    paths:
-      - "python/**"
-      - "docs/scripts/**"
-      - ".github/workflows/ruff-lint.yml"
 
 permissions:
   contents: read
@@ -21,7 +17,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Compare changed files against this workflow's scope
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename') || files=""
+          if [ -z "$files" ]; then
+            # Fail open: if the file list cannot be read, run the real checks.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -qE '^(python/|docs/scripts/|\.github/workflows/ruff-lint\.yml$)' <<<"$files"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   linting:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     name: Ruff Lint
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,12 +10,6 @@ on:
       - "docs/examples/section_hello.json"
       - ".github/workflows/unit-tests.yml"
   pull_request:
-    paths:
-      - "python/**"
-      - "spec/**"
-      - "docs/examples/python/**"
-      - "docs/examples/section_hello.json"
-      - ".github/workflows/unit-tests.yml"
 
 permissions:
   contents: read
@@ -25,7 +19,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Compare changed files against this workflow's scope
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename') || files=""
+          if [ -z "$files" ]; then
+            # Fail open: if the file list cannot be read, run the real checks.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -qE '^(python/|spec/|docs/examples/python/|docs/examples/section_hello\.json$|\.github/workflows/unit-tests\.yml$)' <<<"$files"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   unit-tests:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     name: Unit Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
## Scope

Fixes the required-check deadlock: master requires the two Python 3.11 unit-test contexts and both Ruff contexts, but those workflows were path-filtered to `python/**`, so any PR not touching Python could never merge compliantly (this bit during the train merge). The `pull_request` triggers now run unconditionally with a first-party change-detection gate (GitHub API file listing, fail-open); out-of-scope PRs report the required jobs as skipped, which branch protection treats as satisfied. Push triggers keep their path filters.

## Validation

Workflows parse as YAML; the gate's behaviour is exercised by this PR itself (in-scope: workflow files changed → real jobs run) and will be re-verified on the follow-up dependency PR (out-of-scope for Python → jobs skip but report).
