### PR TITLE
Gate unit-test steps rather than the matrix job

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,7 +48,6 @@ jobs:
 
   unit-tests:
     needs: changes
-    if: needs.changes.outputs.relevant == 'true'
     name: Unit Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     defaults:
@@ -62,9 +61,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out repository
+        if: needs.changes.outputs.relevant == 'true'
         uses: actions/checkout@v7
 
       - name: Install uv and Python ${{ matrix.python-version }}
+        if: needs.changes.outputs.relevant == 'true'
         uses: astral-sh/setup-uv@v10.0.0
         with:
           enable-cache: true
@@ -72,7 +73,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        if: needs.changes.outputs.relevant == 'true'
         run: uv sync --frozen --group dev
 
       - name: Run unit, conformance, and docs-example tests
+        if: needs.changes.outputs.relevant == 'true'
         run: uv run --frozen pytest test/unit test/conformance test/docs


### PR DESCRIPTION
## Scope

Completes #276: a skipped matrix job does not expand its matrix, so the two required `Unit Tests (…, Python 3.11)` contexts never reported on out-of-scope PRs (observed on #277, which remains blocked). Each step is now gated individually — out-of-scope PRs run every leg as a fast no-op that reports success under its expanded name.

## Validation

YAML parses; this PR itself exercises the in-scope path (workflow file changed → steps run for real); #277 will confirm the out-of-scope path reports and unblocks.
