### PR TITLE
Release 2.1.1

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to `slackblocks` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] — 2026-08-16
+
+A documentation and packaging-metadata patch; no library behaviour changes.
+
+### Changed
+
+- The PyPI page now carries Homepage, Repository, Documentation, and Changelog
+  links (`[project.urls]` was previously misplaced and silently dropped from
+  the wheel metadata).
+- The README leads with the new language-neutral project logo, links to the
+  current documentation site paths, and shows the quickstart's rendered
+  message.
+- Wheels are built with current Hatchling again (Core Metadata 2.5), now that
+  Twine 7 validates it; the temporary `hatchling<1.28` pin is retired.
+
 ## [2.1.0] — 2026-08-14
 
 The 2.1 release adds the current generation of Block Kit blocks while keeping

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slackblocks"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python wrapper for the Slack Blocks API"
 authors = [
     { name = "Nicholas Lambourne", email = "dev@ndl.im" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1603,7 +1603,7 @@ wheels = [
 
 [[package]]
 name = "slackblocks"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the TypeScript package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] — 2026-08-16
+
+A documentation-only patch; no library behaviour changes.
+
+### Changed
+
+- The npm page README now matches the PyPI treatment: project logo, badges,
+  a why-section, the CI-notification quickstart with one-line sending via
+  `@slack/web-api`, its rendered message, and full documentation links.
+
 ## [2.1.0] — 2026-08-14
 
 The first public TypeScript/JavaScript release of

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicklambourne/slackblocks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Typed Block Kit construction with eager, path-aware validation",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Scope

Coordinated documentation/metadata patch release: bumps both packages to 2.1.1 with dated changelog entries so the refreshed READMEs (logo, badges, quickstart with rendered message), the PyPI `[project.urls]` metadata, and the retired hatchling pin reach the registry pages. No library behaviour changes.

## Validation

663 Python tests, strict twine on the built 2.1.1 wheel/sdist, TypeScript typecheck + 291 tests, full docs build (version-parity assertion green), and the GitHub-Release changelog extraction simulated non-empty for both packages.
