### PR TITLE
feat(typescript): add fluent composition builders

### DIFF
--- a/typescript/src/fluent/core.ts
+++ b/typescript/src/fluent/core.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared machinery for the public fluent Block Kit API.
+ *
+ * @module fluent
+ */
+import type { FactorySettings } from "../types.js";
+
+const FLUENT_BUILDER = Symbol("slackblocks.fluent-builder");
+
+type NonNullish<Value> = Exclude<Value, null | undefined>;
+
+/** A value accepted by a fluent parent: either wire data or another builder. */
+export type Buildable<Value> = Value | FluentBuilder<object, Value>;
+
+type CollectionArgument<Value> =
+  | Buildable<NonNullish<Value>>
+  | readonly Buildable<NonNullish<Value>>[];
+
+type FluentMethods<Input extends object, Output> = {
+  [Key in keyof Input]-?: NonNullish<Input[Key]> extends readonly (infer Item)[]
+    ? (...values: CollectionArgument<Item>[]) => FluentBuilder<Input, Output>
+    : (value: Buildable<NonNullish<Input[Key]>>) => FluentBuilder<Input, Output>;
+};
+
+/** Typed, chainable construction of a plain Slack wire object. */
+export type FluentBuilder<Input extends object, Output> = FluentMethods<Input, Output> & {
+  /** Materialises and validates the completed Slack object. */
+  build(settings?: FactorySettings): Output;
+};
+
+type FluentFactory<Input extends object, Output> = (
+  input: Input,
+  settings?: FactorySettings,
+) => Output;
+
+type CollectionMode = "flat" | "nested";
+
+interface FluentBuilderOptions<Input extends object> {
+  collections?: Partial<Record<keyof Input, CollectionMode>>;
+}
+
+interface FluentBuilderRuntime {
+  [FLUENT_BUILDER]: true;
+  build(settings?: FactorySettings): unknown;
+}
+
+function isFluentBuilder(value: unknown): value is FluentBuilderRuntime {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    FLUENT_BUILDER in value &&
+    value[FLUENT_BUILDER] === true
+  );
+}
+
+function materialise(value: unknown, settings: FactorySettings): unknown {
+  if (isFluentBuilder(value)) return value.build(settings);
+  if (Array.isArray(value)) return value.map((item) => materialise(item, settings));
+  return value;
+}
+
+/** @internal */
+export function createFluentBuilder<Input extends object, Output>(
+  factory: FluentFactory<Input, Output>,
+  options: FluentBuilderOptions<Input> = {},
+): FluentBuilder<Input, Output> {
+  const state = new Map<keyof Input, unknown>();
+  let proxy: FluentBuilder<Input, Output>;
+
+  const runtime: FluentBuilderRuntime = {
+    [FLUENT_BUILDER]: true,
+    build(settings: FactorySettings = {}) {
+      const input = Object.fromEntries(
+        [...state.entries()].map(([key, value]) => [
+          key,
+          materialise(value, settings),
+        ]),
+      ) as Input;
+      return factory(input, settings);
+    },
+  };
+
+  proxy = new Proxy(runtime, {
+    get(target, property, receiver) {
+      if (Reflect.has(target, property)) {
+        return Reflect.get(target, property, receiver);
+      }
+      if (typeof property !== "string") return undefined;
+
+      return (...values: unknown[]) => {
+        if (values.length === 0) {
+          throw new TypeError(`${property}() expects a value`);
+        }
+
+        const key = property as keyof Input;
+        const collectionMode = options.collections?.[key];
+        if (collectionMode === undefined) {
+          if (values.length !== 1) {
+            throw new TypeError(`${property}() expects one value`);
+          }
+          state.set(key, values[0]);
+          return proxy;
+        }
+
+        const appended =
+          collectionMode === "flat" && values.length === 1 && Array.isArray(values[0])
+            ? values[0]
+            : values;
+        const existing = state.get(key);
+        state.set(key, [...(Array.isArray(existing) ? existing : []), ...appended]);
+        return proxy;
+      };
+    },
+  }) as unknown as FluentBuilder<Input, Output>;
+
+  return proxy;
+}

--- a/typescript/src/fluent/index.ts
+++ b/typescript/src/fluent/index.ts
@@ -1,0 +1,3 @@
+/** Preferred fluent API for constructing Block Kit payloads. */
+export type { Buildable, FluentBuilder } from "./core.js";
+export * from "./objects.js";

--- a/typescript/src/fluent/objects.ts
+++ b/typescript/src/fluent/objects.ts
@@ -1,0 +1,318 @@
+/** Fluent builders for Block Kit composition and rich-text objects. */
+import {
+  areaChart as createAreaChart,
+  axisConfig as createAxisConfig,
+  barChart as createBarChart,
+  chartSegment as createChartSegment,
+  columnSettings as createColumnSettings,
+  confirmation as createConfirmation,
+  conversationFilter as createConversationFilter,
+  dataPoint as createDataPoint,
+  dataSeries as createDataSeries,
+  dispatchActionConfiguration as createDispatchActionConfiguration,
+  inputParameter as createInputParameter,
+  lineChart as createLineChart,
+  mrkdwn as createMarkdown,
+  option as createOption,
+  optionGroup as createOptionGroup,
+  pieChart as createPieChart,
+  plainText as createPlainText,
+  rawNumber as createRawNumber,
+  rawText as createRawText,
+  slackFile as createSlackFile,
+  slackIcon as createSlackIcon,
+  trigger as createTrigger,
+  workflow as createWorkflow,
+  type AxisConfigInput,
+  type ChartSegmentInput,
+  type ConfirmationInput,
+  type DataPointInput,
+  type DataSeriesInput,
+  type MarkdownOptions,
+  type OptionGroupInput,
+  type OptionInput,
+  type PlainTextOptions,
+  type SlackIconName,
+  type TextObject,
+} from "../objects.js";
+import {
+  richText as createRichText,
+  richTextChannel as createRichTextChannel,
+  richTextCodeBlock as createRichTextCodeBlock,
+  richTextEmoji as createRichTextEmoji,
+  richTextLink as createRichTextLink,
+  richTextList as createRichTextList,
+  richTextQuote as createRichTextQuote,
+  richTextSection as createRichTextSection,
+  richTextUser as createRichTextUser,
+  richTextUserGroup as createRichTextUserGroup,
+  type RichTextStyle,
+} from "../rich-text.js";
+import type { FactorySettings, JsonObject, SlackObject } from "../types.js";
+import { createFluentBuilder, type FluentBuilder } from "./core.js";
+
+type FirstInput<Factory extends (...args: never[]) => unknown> = Parameters<Factory>[0];
+
+interface PlainTextBuilderInput extends PlainTextOptions {
+  text: string;
+}
+
+/** Starts a fluent plain-text composition object. */
+export function PlainText(): FluentBuilder<PlainTextBuilderInput, TextObject> {
+  return createFluentBuilder(({ text, ...options }, settings) =>
+    createPlainText(text, options, settings),
+  );
+}
+
+interface MarkdownBuilderInput extends MarkdownOptions {
+  text: string;
+}
+
+/** Starts a fluent Slack mrkdwn composition object. */
+export function Markdown(): FluentBuilder<MarkdownBuilderInput, TextObject> {
+  return createFluentBuilder(({ text, ...options }, settings) =>
+    createMarkdown(text, options, settings),
+  );
+}
+
+/** Starts a fluent confirmation-dialog object. */
+export function Confirmation(): FluentBuilder<ConfirmationInput, JsonObject> {
+  return createFluentBuilder(createConfirmation);
+}
+
+/** Starts a fluent selectable option. */
+export function Option(): FluentBuilder<OptionInput, JsonObject> {
+  return createFluentBuilder(createOption);
+}
+
+/** Starts a fluent labelled option group. */
+export function OptionGroup(): FluentBuilder<OptionGroupInput, JsonObject> {
+  return createFluentBuilder(createOptionGroup, { collections: { options: "flat" } });
+}
+
+/** Starts a fluent conversation filter. */
+export function ConversationFilter(): FluentBuilder<
+  FirstInput<typeof createConversationFilter>,
+  JsonObject
+> {
+  return createFluentBuilder(createConversationFilter, { collections: { include: "flat" } });
+}
+
+/** Starts a fluent dispatch-action configuration. */
+export function DispatchActionConfiguration(): FluentBuilder<
+  FirstInput<typeof createDispatchActionConfiguration>,
+  JsonObject
+> {
+  return createFluentBuilder(createDispatchActionConfiguration, {
+    collections: { triggerActionsOn: "flat" },
+  });
+}
+
+/** Starts a fluent workflow input parameter. */
+export function InputParameter(): FluentBuilder<
+  FirstInput<typeof createInputParameter>,
+  JsonObject
+> {
+  return createFluentBuilder(createInputParameter);
+}
+
+/** Starts a fluent workflow trigger. */
+export function Trigger(): FluentBuilder<FirstInput<typeof createTrigger>, JsonObject> {
+  return createFluentBuilder(createTrigger, {
+    collections: { customizableInputParameters: "flat" },
+  });
+}
+
+/** Starts a fluent workflow object. */
+export function Workflow(): FluentBuilder<FirstInput<typeof createWorkflow>, JsonObject> {
+  return createFluentBuilder(createWorkflow);
+}
+
+/** Starts a fluent Slack-hosted file reference. */
+export function SlackFile(): FluentBuilder<FirstInput<typeof createSlackFile>, JsonObject> {
+  return createFluentBuilder(createSlackFile);
+}
+
+/** Starts fluent display settings for one table column. */
+export function ColumnSettings(): FluentBuilder<
+  FirstInput<typeof createColumnSettings>,
+  JsonObject
+> {
+  return createFluentBuilder(createColumnSettings);
+}
+
+/** Starts a fluent raw-text table cell. */
+export function RawText(): FluentBuilder<{ text: string }, SlackObject<"raw_text">> {
+  return createFluentBuilder(({ text }, settings) => createRawText(text, settings));
+}
+
+/** Starts a fluent sortable numeric table cell. */
+export function RawNumber(): FluentBuilder<
+  { value: number; text: string },
+  SlackObject<"raw_number">
+> {
+  return createFluentBuilder(({ value, text }, settings) =>
+    createRawNumber(value, text, settings),
+  );
+}
+
+/** Starts a fluent Slack-provided icon. */
+export function SlackIcon(): FluentBuilder<{ name: SlackIconName }, SlackObject<"icon">> {
+  return createFluentBuilder(({ name }, settings) => createSlackIcon(name, settings));
+}
+
+/** Starts a fluent pie-chart segment. */
+export function ChartSegment(): FluentBuilder<ChartSegmentInput, JsonObject> {
+  return createFluentBuilder(createChartSegment);
+}
+
+/** Starts a fluent axis-chart data point. */
+export function DataPoint(): FluentBuilder<DataPointInput, JsonObject> {
+  return createFluentBuilder(createDataPoint);
+}
+
+/** Starts a fluent named chart series. */
+export function DataSeries(): FluentBuilder<DataSeriesInput, JsonObject> {
+  return createFluentBuilder(createDataSeries, { collections: { data: "flat" } });
+}
+
+/** Starts fluent axis labels and categories. */
+export function AxisConfig(): FluentBuilder<AxisConfigInput, JsonObject> {
+  return createFluentBuilder(createAxisConfig, { collections: { categories: "flat" } });
+}
+
+/** Starts a fluent pie chart. */
+export function PieChart(): FluentBuilder<
+  { segments: JsonObject[] },
+  SlackObject<"pie">
+> {
+  return createFluentBuilder<{ segments: JsonObject[] }, SlackObject<"pie">>(
+    ({ segments }, settings) => createPieChart(segments, settings),
+    { collections: { segments: "flat" } },
+  );
+}
+
+interface AxisChartBuilderInput {
+  series: JsonObject[];
+  axisConfig: JsonObject;
+}
+
+function axisChart<Type extends "bar" | "area" | "line">(
+  factory: (
+    series: JsonObject[],
+    axis: JsonObject,
+    settings?: FactorySettings,
+  ) => SlackObject<Type>,
+): FluentBuilder<AxisChartBuilderInput, SlackObject<Type>> {
+  return createFluentBuilder<AxisChartBuilderInput, SlackObject<Type>>(
+    ({ series, axisConfig }, settings) => factory(series, axisConfig, settings),
+    { collections: { series: "flat" } },
+  );
+}
+
+/** Starts a fluent grouped bar chart. */
+export function BarChart(): FluentBuilder<AxisChartBuilderInput, SlackObject<"bar">> {
+  return axisChart(createBarChart);
+}
+
+/** Starts a fluent area chart. */
+export function AreaChart(): FluentBuilder<AxisChartBuilderInput, SlackObject<"area">> {
+  return axisChart(createAreaChart);
+}
+
+/** Starts a fluent line chart. */
+export function LineChart(): FluentBuilder<AxisChartBuilderInput, SlackObject<"line">> {
+  return axisChart(createLineChart);
+}
+
+interface RichTextBuilderInput {
+  text: string;
+  style?: RichTextStyle;
+}
+
+/** Starts a fluent styled rich-text run. */
+export function RichText(): FluentBuilder<RichTextBuilderInput, JsonObject> {
+  return createFluentBuilder(({ text, style }, settings) =>
+    createRichText(text, style, settings),
+  );
+}
+
+interface RichTextMentionBuilderInput {
+  id: string;
+  style?: RichTextStyle;
+}
+
+/** Starts a fluent rich-text channel mention. */
+export function RichTextChannel(): FluentBuilder<RichTextMentionBuilderInput, JsonObject> {
+  return createFluentBuilder(({ id, style }, settings) =>
+    createRichTextChannel(id, style, settings),
+  );
+}
+
+/** Starts a fluent rich-text emoji. */
+export function RichTextEmoji(): FluentBuilder<{ name: string }, JsonObject> {
+  return createFluentBuilder(({ name }, settings) => createRichTextEmoji(name, settings));
+}
+
+/** Starts a fluent rich-text link. */
+export function RichTextLink(): FluentBuilder<FirstInput<typeof createRichTextLink>, JsonObject> {
+  return createFluentBuilder(createRichTextLink);
+}
+
+/** Starts a fluent rich-text user mention. */
+export function RichTextUser(): FluentBuilder<RichTextMentionBuilderInput, JsonObject> {
+  return createFluentBuilder(({ id, style }, settings) =>
+    createRichTextUser(id, style, settings),
+  );
+}
+
+/** Starts a fluent rich-text user-group mention. */
+export function RichTextUserGroup(): FluentBuilder<RichTextMentionBuilderInput, JsonObject> {
+  return createFluentBuilder(({ id, style }, settings) =>
+    createRichTextUserGroup(id, style, settings),
+  );
+}
+
+/** Starts a fluent paragraph-like rich-text section. */
+export function RichTextSection(): FluentBuilder<{ elements: JsonObject[] }, JsonObject> {
+  return createFluentBuilder<{ elements: JsonObject[] }, JsonObject>(
+    ({ elements }, settings) => createRichTextSection(elements, settings),
+    { collections: { elements: "flat" } },
+  );
+}
+
+/** Starts a fluent ordered or bulleted rich-text list. */
+export function RichTextList(): FluentBuilder<FirstInput<typeof createRichTextList>, JsonObject> {
+  return createFluentBuilder(createRichTextList, { collections: { elements: "flat" } });
+}
+
+interface RichTextLayoutBuilderInput {
+  elements: JsonObject[];
+  border?: number;
+}
+
+/** Starts a fluent preformatted rich-text code block. */
+export function RichTextCodeBlock(): FluentBuilder<RichTextLayoutBuilderInput, JsonObject> {
+  return createFluentBuilder<RichTextLayoutBuilderInput, JsonObject>(
+    ({ elements, border }, settings) =>
+      createRichTextCodeBlock(
+        elements,
+        border === undefined ? {} : { border },
+        settings,
+      ),
+    { collections: { elements: "flat" } },
+  );
+}
+
+/** Starts a fluent rich-text block quote. */
+export function RichTextQuote(): FluentBuilder<RichTextLayoutBuilderInput, JsonObject> {
+  return createFluentBuilder<RichTextLayoutBuilderInput, JsonObject>(
+    ({ elements, border }, settings) =>
+      createRichTextQuote(
+        elements,
+        border === undefined ? {} : { border },
+        settings,
+      ),
+    { collections: { elements: "flat" } },
+  );
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -8,5 +8,6 @@ export * from "./rich-text.js";
 export * from "./types.js";
 export * from "./validation.js";
 export * from "./views.js";
+export * from "./fluent/index.js";
 
 export const specVersion = "1.0.1";

--- a/typescript/test/conformance.test.ts
+++ b/typescript/test/conformance.test.ts
@@ -967,7 +967,12 @@ describe("capability registry", () => {
     const exported = Object.entries(api)
       .filter(([, value]) => typeof value === "function")
       .map(([exportName]) => exportName)
-      .filter((exportName) => !FACTORY_EXCLUSIONS.has(exportName));
+      // Fluent builders are PascalCase and produce builders rather than wire JSON.
+      .filter(
+        (exportName) =>
+          !FACTORY_EXCLUSIONS.has(exportName) &&
+          !/^[A-Z]/.test(exportName),
+      );
     expect(new Set(exported)).toEqual(new Set(Object.keys(CAPABILITY_BY_FACTORY)));
   });
 

--- a/typescript/test/fluent-objects.test.ts
+++ b/typescript/test/fluent-objects.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AxisConfig,
+  BarChart,
+  DataPoint,
+  DataSeries,
+  Markdown,
+  Option,
+  OptionGroup,
+  PlainText,
+  RichText,
+  RichTextSection,
+  barChart,
+  dataPoint,
+  dataSeries,
+  mrkdwn,
+  option,
+  optionGroup,
+  plainText,
+  axisConfig,
+} from "../src/index.js";
+
+describe("fluent composition objects", () => {
+  it("matches the functional text factories", () => {
+    expect(PlainText().text("Hello").emoji(true).build()).toEqual(
+      plainText("Hello", { emoji: true }),
+    );
+    expect(Markdown().text("*Hello*").verbatim(true).build()).toEqual(
+      mrkdwn("*Hello*", { verbatim: true }),
+    );
+  });
+
+  it("materialises nested builders and appends collection setters", () => {
+    const first = Option().text("First").value("first");
+    const second = Option().text("Second").value("second");
+
+    expect(OptionGroup().label("Choices").options(first).options(second).build()).toEqual(
+      optionGroup({
+        label: "Choices",
+        options: [
+          option({ text: "First", value: "first" }),
+          option({ text: "Second", value: "second" }),
+        ],
+      }),
+    );
+  });
+
+  it("supports nested chart construction", () => {
+    const point = DataPoint().label("Mon").value(12);
+    const series = DataSeries().name("Requests").data(point);
+    const axis = AxisConfig().categories("Mon").xLabel("Day");
+
+    expect(BarChart().series(series).axisConfig(axis).build()).toEqual(
+      barChart(
+        [dataSeries({ name: "Requests", data: [dataPoint({ label: "Mon", value: 12 })] })],
+        axisConfig({ categories: ["Mon"], xLabel: "Day" }),
+      ),
+    );
+  });
+
+  it("builds rich-text trees", () => {
+    expect(
+      RichTextSection()
+        .elements(RichText().text("Hello").style({ bold: true }))
+        .build(),
+    ).toEqual({
+      type: "rich_text_section",
+      elements: [{ type: "text", text: "Hello", style: { bold: true } }],
+    });
+  });
+
+  it("validates only when the complete object is built", () => {
+    const incomplete = Option().text("Missing a value");
+    expect(() => incomplete.build()).toThrow(/value/);
+  });
+
+  it("lets the last singular setter win", () => {
+    expect(PlainText().text("first").text("second").build()).toEqual(
+      plainText("second"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add the internal fluent builder engine
- expose PascalCase composition and rich-text builders as the preferred API
- preserve exact wire compatibility by delegating build() to the existing factories
- add parity, nesting, append, overwrite, and deferred-validation tests

## Train
Base PR for the fluent API train. Later draft PRs will target this branch or its descendants. Do not merge until the full train is approved.

## Validation
- TypeScript typecheck
- 297 TypeScript tests
- package build, publint, and Are The Types Wrong
- production Docusaurus build and API rendering checks