### PR TITLE
feat(typescript): add fluent block builders

### DIFF
--- a/typescript/src/fluent/blocks.ts
+++ b/typescript/src/fluent/blocks.ts
@@ -1,0 +1,203 @@
+/** Fluent builders for messages, modal, and App Home blocks. */
+import {
+  actionsBlock as createActionsBlock,
+  alertBlock as createAlertBlock,
+  cardBlock as createCardBlock,
+  carouselBlock as createCarouselBlock,
+  containerBlock as createContainerBlock,
+  contextActionsBlock as createContextActionsBlock,
+  contextBlock as createContextBlock,
+  dataTableBlock as createDataTableBlock,
+  dataVisualizationBlock as createDataVisualizationBlock,
+  dividerBlock as createDividerBlock,
+  fileBlock as createFileBlock,
+  headerBlock as createHeaderBlock,
+  imageBlock as createImageBlock,
+  inputBlock as createInputBlock,
+  markdownBlock as createMarkdownBlock,
+  planBlock as createPlanBlock,
+  richTextBlock as createRichTextBlock,
+  sectionBlock as createSectionBlock,
+  tableBlock as createTableBlock,
+  taskCardBlock as createTaskCardBlock,
+  videoBlock as createVideoBlock,
+  type CardBlockInput,
+  type SectionBlockInput,
+} from "../blocks.js";
+import { createFluentBuilder, type FluentBuilder } from "./core.js";
+
+type FirstInput<Factory extends (...args: never[]) => unknown> = Parameters<Factory>[0];
+type Output<Factory extends (...args: never[]) => unknown> = ReturnType<Factory>;
+
+/** Starts a fluent severity-labelled notice. */
+export function AlertBlock(): FluentBuilder<
+  FirstInput<typeof createAlertBlock>,
+  Output<typeof createAlertBlock>
+> {
+  return createFluentBuilder(createAlertBlock);
+}
+
+/** Starts a fluent compact content card. */
+export function CardBlock(): FluentBuilder<CardBlockInput, Output<typeof createCardBlock>> {
+  return createFluentBuilder(createCardBlock, { collections: { actions: "flat" } });
+}
+
+/** Starts a fluent horizontally scrolling collection of cards. */
+export function CarouselBlock(): FluentBuilder<
+  FirstInput<typeof createCarouselBlock>,
+  Output<typeof createCarouselBlock>
+> {
+  return createFluentBuilder(createCarouselBlock, {
+    collections: { elements: "flat" },
+  });
+}
+
+/** Starts a fluent titled container of related blocks. */
+export function ContainerBlock(): FluentBuilder<
+  FirstInput<typeof createContainerBlock>,
+  Output<typeof createContainerBlock>
+> {
+  return createFluentBuilder(createContainerBlock, {
+    collections: { childBlocks: "flat" },
+  });
+}
+
+/** Starts a fluent row of contextual feedback or icon controls. */
+export function ContextActionsBlock(): FluentBuilder<
+  FirstInput<typeof createContextActionsBlock>,
+  Output<typeof createContextActionsBlock>
+> {
+  return createFluentBuilder(createContextActionsBlock, {
+    collections: { elements: "flat" },
+  });
+}
+
+/** Starts a fluent sortable data table. Add each row with one `rows()` call. */
+export function DataTableBlock(): FluentBuilder<
+  FirstInput<typeof createDataTableBlock>,
+  Output<typeof createDataTableBlock>
+> {
+  return createFluentBuilder(createDataTableBlock, { collections: { rows: "nested" } });
+}
+
+/** Starts a fluent Slack-rendered data visualization. */
+export function DataVisualizationBlock(): FluentBuilder<
+  FirstInput<typeof createDataVisualizationBlock>,
+  Output<typeof createDataVisualizationBlock>
+> {
+  return createFluentBuilder(createDataVisualizationBlock);
+}
+
+/** Starts a fluent task card used inside a plan. */
+export function TaskCardBlock(): FluentBuilder<
+  FirstInput<typeof createTaskCardBlock>,
+  Output<typeof createTaskCardBlock>
+> {
+  return createFluentBuilder(createTaskCardBlock, { collections: { sources: "flat" } });
+}
+
+/** Starts a fluent titled sequence of task cards. */
+export function PlanBlock(): FluentBuilder<
+  FirstInput<typeof createPlanBlock>,
+  Output<typeof createPlanBlock>
+> {
+  return createFluentBuilder(createPlanBlock, { collections: { tasks: "flat" } });
+}
+
+/** Starts a fluent flexible text block with optional fields or accessory. */
+export function SectionBlock(): FluentBuilder<
+  SectionBlockInput,
+  Output<typeof createSectionBlock>
+> {
+  return createFluentBuilder(createSectionBlock, { collections: { fields: "flat" } });
+}
+
+/** Starts a fluent row of interactive elements. */
+export function ActionsBlock(): FluentBuilder<
+  FirstInput<typeof createActionsBlock>,
+  Output<typeof createActionsBlock>
+> {
+  return createFluentBuilder(createActionsBlock, { collections: { elements: "flat" } });
+}
+
+/** Starts a fluent compact context block of text and images. */
+export function ContextBlock(): FluentBuilder<
+  FirstInput<typeof createContextBlock>,
+  Output<typeof createContextBlock>
+> {
+  return createFluentBuilder(createContextBlock, { collections: { elements: "flat" } });
+}
+
+/** Starts a fluent visual divider. */
+export function DividerBlock(): FluentBuilder<
+  NonNullable<FirstInput<typeof createDividerBlock>>,
+  Output<typeof createDividerBlock>
+> {
+  return createFluentBuilder((input, settings) => createDividerBlock(input, settings));
+}
+
+/** Starts a fluent Slack remote-file block. */
+export function FileBlock(): FluentBuilder<
+  FirstInput<typeof createFileBlock>,
+  Output<typeof createFileBlock>
+> {
+  return createFluentBuilder(createFileBlock);
+}
+
+/** Starts a fluent prominent plain-text heading. */
+export function HeaderBlock(): FluentBuilder<
+  FirstInput<typeof createHeaderBlock>,
+  Output<typeof createHeaderBlock>
+> {
+  return createFluentBuilder(createHeaderBlock);
+}
+
+/** Starts a fluent image block with optional title text. */
+export function ImageBlock(): FluentBuilder<
+  FirstInput<typeof createImageBlock>,
+  Output<typeof createImageBlock>
+> {
+  return createFluentBuilder(createImageBlock);
+}
+
+/** Starts a fluent labelled form control. */
+export function InputBlock(): FluentBuilder<
+  FirstInput<typeof createInputBlock>,
+  Output<typeof createInputBlock>
+> {
+  return createFluentBuilder(createInputBlock);
+}
+
+/** Starts a fluent GitHub-flavored Markdown block. */
+export function MarkdownBlock(): FluentBuilder<
+  FirstInput<typeof createMarkdownBlock>,
+  Output<typeof createMarkdownBlock>
+> {
+  return createFluentBuilder(createMarkdownBlock);
+}
+
+/** Starts a fluent rich-text block. */
+export function RichTextBlock(): FluentBuilder<
+  FirstInput<typeof createRichTextBlock>,
+  Output<typeof createRichTextBlock>
+> {
+  return createFluentBuilder(createRichTextBlock, { collections: { elements: "flat" } });
+}
+
+/** Starts a fluent table. Add each row with one `rows()` call. */
+export function TableBlock(): FluentBuilder<
+  FirstInput<typeof createTableBlock>,
+  Output<typeof createTableBlock>
+> {
+  return createFluentBuilder(createTableBlock, {
+    collections: { rows: "nested", columnSettings: "flat" },
+  });
+}
+
+/** Starts a fluent embedded video block. */
+export function VideoBlock(): FluentBuilder<
+  FirstInput<typeof createVideoBlock>,
+  Output<typeof createVideoBlock>
+> {
+  return createFluentBuilder(createVideoBlock);
+}

--- a/typescript/src/fluent/core.ts
+++ b/typescript/src/fluent/core.ts
@@ -9,8 +9,11 @@ const FLUENT_BUILDER = Symbol("slackblocks.fluent-builder");
 
 type NonNullish<Value> = Exclude<Value, null | undefined>;
 
-/** A value accepted by a fluent parent: either wire data or another builder. */
-export type Buildable<Value> = Value | FluentBuilder<object, Value>;
+/** A value accepted by a fluent parent: wire data, nested data, or another builder. */
+export type Buildable<Value> =
+  | Value
+  | FluentBuilder<object, Value>
+  | (Value extends readonly (infer Item)[] ? readonly Buildable<Item>[] : never);
 
 type CollectionArgument<Value> =
   | Buildable<NonNullish<Value>>

--- a/typescript/src/fluent/index.ts
+++ b/typescript/src/fluent/index.ts
@@ -1,4 +1,5 @@
 /** Preferred fluent API for constructing Block Kit payloads. */
 export type { Buildable, FluentBuilder } from "./core.js";
+export * from "./blocks.js";
 export * from "./elements.js";
 export * from "./objects.js";

--- a/typescript/test/fluent-blocks.test.ts
+++ b/typescript/test/fluent-blocks.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ActionsBlock,
+  BarChart,
+  Button,
+  CardBlock,
+  CarouselBlock,
+  ContainerBlock,
+  DataPoint,
+  DataSeries,
+  DataTableBlock,
+  DataVisualizationBlock,
+  HeaderBlock,
+  PlanBlock,
+  RawNumber,
+  RawText,
+  SectionBlock,
+  TaskCardBlock,
+  UrlSource,
+  actionsBlock,
+  axisConfig,
+  barChart,
+  button,
+  cardBlock,
+  carouselBlock,
+  containerBlock,
+  dataPoint,
+  dataSeries,
+  dataTableBlock,
+  dataVisualizationBlock,
+  headerBlock,
+  planBlock,
+  rawNumber,
+  rawText,
+  sectionBlock,
+  taskCardBlock,
+  urlSource,
+} from "../src/index.js";
+
+describe("fluent blocks", () => {
+  it("composes section and action blocks from nested elements", () => {
+    expect(
+      SectionBlock()
+        .text("Choose an action")
+        .fields("Owner: Jane")
+        .fields("Status: Ready")
+        .accessory(Button().text("Open").actionId("open"))
+        .build(),
+    ).toEqual(
+      sectionBlock({
+        text: "Choose an action",
+        fields: ["Owner: Jane", "Status: Ready"],
+        accessory: button({ text: "Open", actionId: "open" }),
+      }),
+    );
+
+    expect(
+      ActionsBlock()
+        .elements(Button().text("Approve").actionId("approve"))
+        .build(),
+    ).toEqual(
+      actionsBlock({
+        elements: [button({ text: "Approve", actionId: "approve" })],
+      }),
+    );
+  });
+
+  it("composes cards, carousels, and containers", () => {
+    const card = CardBlock()
+      .title("Release")
+      .body("Version 2.2 is ready")
+      .actions(Button().text("Review").actionId("review"));
+
+    expect(CarouselBlock().elements(card).build()).toEqual(
+      carouselBlock({
+        elements: [
+          cardBlock({
+            title: "Release",
+            body: "Version 2.2 is ready",
+            actions: [button({ text: "Review", actionId: "review" })],
+          }),
+        ],
+      }),
+    );
+
+    expect(
+      ContainerBlock()
+        .title("Summary")
+        .childBlocks(HeaderBlock().text("Release"))
+        .build(),
+    ).toEqual(
+      containerBlock({
+        title: "Summary",
+        childBlocks: [headerBlock({ text: "Release" })],
+      }),
+    );
+  });
+
+  it("builds nested tables one row at a time", () => {
+    expect(
+      DataTableBlock()
+        .caption("Results")
+        .rows([RawText().text("Name"), RawText().text("Score")])
+        .rows([RawText().text("Ada"), RawNumber().value(10).text("10")])
+        .build(),
+    ).toEqual(
+      dataTableBlock({
+        caption: "Results",
+        rows: [
+          [rawText("Name"), rawText("Score")],
+          [rawText("Ada"), rawNumber(10, "10")],
+        ],
+      }),
+    );
+  });
+
+  it("composes charts and plan task cards", () => {
+    const chart = BarChart()
+      .series(
+        DataSeries()
+          .name("Requests")
+          .data(DataPoint().label("Monday").value(12)),
+      )
+      .axisConfig(axisConfig({ categories: ["Monday"] }));
+
+    expect(DataVisualizationBlock().title("Traffic").chart(chart).build()).toEqual(
+      dataVisualizationBlock({
+        title: "Traffic",
+        chart: barChart(
+          [
+            dataSeries({
+              name: "Requests",
+              data: [dataPoint({ label: "Monday", value: 12 })],
+            }),
+          ],
+          axisConfig({ categories: ["Monday"] }),
+        ),
+      }),
+    );
+
+    expect(
+      PlanBlock()
+        .title("Launch")
+        .tasks(
+          TaskCardBlock()
+            .taskId("docs")
+            .title("Publish docs")
+            .sources(UrlSource().url("https://example.com").text("Preview")),
+        )
+        .build(),
+    ).toEqual(
+      planBlock({
+        title: "Launch",
+        tasks: [
+          taskCardBlock({
+            taskId: "docs",
+            title: "Publish docs",
+            sources: [urlSource({ url: "https://example.com", text: "Preview" })],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("validates incomplete blocks only at build time", () => {
+    expect(() => SectionBlock().blockId("empty").build()).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add PascalCase fluent builders for every supported Block Kit block
- cover newer alert, card, carousel, container, table, visualization, task, and plan blocks
- allow deeply nested builders, including table rows and charts
- preserve exact wire behavior and validation by delegating build() to the existing factories

## Train
Stacked on #292, which is stacked on #291. Keep draft and unmerged until the complete train is approved.

## Validation
- TypeScript typecheck
- 307 TypeScript tests
- package build, publint, and Are The Types Wrong