### PR TITLE
feat(typescript): add fluent payload builders

### DIFF
--- a/typescript/src/fluent/index.ts
+++ b/typescript/src/fluent/index.ts
@@ -3,3 +3,4 @@ export type { Buildable, FluentBuilder } from "./core.js";
 export * from "./blocks.js";
 export * from "./elements.js";
 export * from "./objects.js";
+export * from "./payloads.js";

--- a/typescript/src/fluent/payloads.ts
+++ b/typescript/src/fluent/payloads.ts
@@ -1,0 +1,65 @@
+/** Fluent builders for messages, webhooks, interaction responses, and views. */
+import {
+  attachment as createAttachment,
+  message as createMessage,
+  messageResponse as createMessageResponse,
+  webhookMessage as createWebhookMessage,
+  type MessageInput,
+} from "../messages.js";
+import type { JsonObject } from "../types.js";
+import { homeTab as createHomeTab, modal as createModal } from "../views.js";
+import { createFluentBuilder, type FluentBuilder } from "./core.js";
+
+type FirstInput<Factory extends (...args: never[]) => unknown> = Parameters<Factory>[0];
+type Output<Factory extends (...args: never[]) => unknown> = ReturnType<Factory>;
+
+/** Starts fluent lower-priority content attached to a message. */
+export function Attachment(): FluentBuilder<
+  FirstInput<typeof createAttachment>,
+  JsonObject
+> {
+  return createFluentBuilder(createAttachment, { collections: { blocks: "flat" } });
+}
+
+/** Starts a fluent payload for Slack Web API message methods. */
+export function Message(): FluentBuilder<MessageInput, JsonObject> {
+  return createFluentBuilder(createMessage, {
+    collections: { blocks: "flat", attachments: "flat" },
+  });
+}
+
+/** Starts a fluent response to a slash command or interactive request. */
+export function MessageResponse(): FluentBuilder<
+  FirstInput<typeof createMessageResponse>,
+  JsonObject
+> {
+  return createFluentBuilder(createMessageResponse, {
+    collections: { blocks: "flat", attachments: "flat" },
+  });
+}
+
+/** Starts a fluent incoming-webhook or response-URL payload. */
+export function WebhookMessage(): FluentBuilder<
+  FirstInput<typeof createWebhookMessage>,
+  JsonObject
+> {
+  return createFluentBuilder(createWebhookMessage, {
+    collections: { blocks: "flat", attachments: "flat" },
+  });
+}
+
+/** Starts a fluent modal view payload. */
+export function Modal(): FluentBuilder<
+  FirstInput<typeof createModal>,
+  Output<typeof createModal>
+> {
+  return createFluentBuilder(createModal, { collections: { blocks: "flat" } });
+}
+
+/** Starts a fluent App Home tab payload. */
+export function HomeTab(): FluentBuilder<
+  FirstInput<typeof createHomeTab>,
+  Output<typeof createHomeTab>
+> {
+  return createFluentBuilder(createHomeTab, { collections: { blocks: "flat" } });
+}

--- a/typescript/test/fluent-payloads.test.ts
+++ b/typescript/test/fluent-payloads.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  Attachment,
+  Button,
+  HomeTab,
+  InputBlock,
+  Message,
+  MessageResponse,
+  Modal,
+  PlainTextInput,
+  SectionBlock,
+  WebhookMessage,
+  attachment,
+  button,
+  homeTab,
+  inputBlock,
+  message,
+  messageResponse,
+  modal,
+  plainTextInput,
+  sectionBlock,
+  webhookMessage,
+} from "../src/index.js";
+
+describe("fluent payloads", () => {
+  it("builds a complete Web API message from nested builders", () => {
+    expect(
+      Message()
+        .channel("C123")
+        .text("Approval requested")
+        .blocks(
+          SectionBlock()
+            .text("Please review")
+            .accessory(Button().text("Open").actionId("open")),
+        )
+        .attachments(
+          Attachment()
+            .color("good")
+            .fallback("Approved")
+            .blocks(SectionBlock().text("Ready")),
+        )
+        .build(),
+    ).toEqual(
+      message({
+        channel: "C123",
+        text: "Approval requested",
+        blocks: [
+          sectionBlock({
+            text: "Please review",
+            accessory: button({ text: "Open", actionId: "open" }),
+          }),
+        ],
+        attachments: [
+          attachment({
+            color: "good",
+            fallback: "Approved",
+            blocks: [sectionBlock({ text: "Ready" })],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("builds interaction and webhook responses", () => {
+    expect(
+      MessageResponse()
+        .responseType("ephemeral")
+        .blocks(SectionBlock().text("Only you can see this"))
+        .build(),
+    ).toEqual(
+      messageResponse({
+        responseType: "ephemeral",
+        blocks: [sectionBlock({ text: "Only you can see this" })],
+      }),
+    );
+
+    expect(
+      WebhookMessage()
+        .text("Deployment complete")
+        .blocks(SectionBlock().text("Version 2.2"))
+        .build(),
+    ).toEqual(
+      webhookMessage({
+        text: "Deployment complete",
+        blocks: [sectionBlock({ text: "Version 2.2" })],
+      }),
+    );
+  });
+
+  it("builds modal and App Home views", () => {
+    const input = InputBlock()
+      .label("Name")
+      .element(PlainTextInput().actionId("name"));
+
+    expect(Modal().title("Profile").submit("Save").blocks(input).build()).toEqual(
+      modal({
+        title: "Profile",
+        submit: "Save",
+        blocks: [
+          inputBlock({
+            label: "Name",
+            element: plainTextInput({ actionId: "name" }),
+          }),
+        ],
+      }),
+    );
+
+    expect(HomeTab().blocks(SectionBlock().text("Welcome home")).build()).toEqual(
+      homeTab({ blocks: [sectionBlock({ text: "Welcome home" })] }),
+    );
+  });
+
+  it("validates payload fields only at build time", () => {
+    const attachment = Attachment()
+      .blocks(SectionBlock().text("Status"))
+      .color("not-a-color");
+    expect(() => attachment.build()).toThrow(/color/);
+  });
+});


### PR DESCRIPTION
## Summary
- add fluent builders for messages, attachments, interaction responses, and webhooks
- add fluent builders for modal and App Home views
- compose complete payloads from nested PascalCase builders
- preserve current wire defaults and validation behavior

## Train
Stacked on #293, #292, and #291. Keep draft and unmerged until the complete fluent train is approved.

## Validation
- TypeScript typecheck
- 311 TypeScript tests
- package build, publint, and Are The Types Wrong