### PR TITLE
feat(typescript): add fluent paginator component

### DIFF
--- a/typescript/src/fluent/components.ts
+++ b/typescript/src/fluent/components.ts
@@ -1,0 +1,125 @@
+/** Higher-level fluent components that render ordinary Block Kit blocks. */
+import { actionsBlock, contextBlock } from "../blocks.js";
+import { button } from "../elements.js";
+import { MissingRequiredError, OutOfRangeError } from "../errors.js";
+import { mrkdwn } from "../objects.js";
+import type { FactorySettings, JsonObject } from "../types.js";
+import {
+  createFluentGroupBuilder,
+  type FluentGroupBuilder,
+} from "./core.js";
+
+/** Configuration accepted by {@link Paginator}. */
+export interface PaginatorInput {
+  /** Blocks to paginate, in display order. */
+  blocks: JsonObject[];
+  /** Prefix used for the generated previous and next action identifiers. */
+  actionIdPrefix: string;
+  /** One-based page to render. Defaults to 1. */
+  page?: number;
+  /** Blocks displayed per page. Defaults to 5. */
+  pageSize?: number;
+  /** Label for the previous-page button. Defaults to `Previous`. */
+  previousText?: string;
+  /** Label for the next-page button. Defaults to `Next`. */
+  nextText?: string;
+  /** Whether to render `Page n of m` above the controls. Defaults to `true`. */
+  showPageIndicator?: boolean;
+  /** Optional identifier for the generated actions block. */
+  blockId?: string;
+}
+
+function positiveInteger(path: string, value: number): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new OutOfRangeError(path, "expected a positive integer");
+  }
+}
+
+function renderPaginator(
+  input: PaginatorInput,
+  settings: FactorySettings = {},
+): JsonObject[] {
+  if (input.blocks.length === 0) {
+    throw new MissingRequiredError("Paginator.blocks", "expected at least one block");
+  }
+  if (input.actionIdPrefix.length === 0) {
+    throw new MissingRequiredError(
+      "Paginator.actionIdPrefix",
+      "expected a non-empty prefix",
+    );
+  }
+
+  const page = input.page ?? 1;
+  const pageSize = input.pageSize ?? 5;
+  positiveInteger("Paginator.page", page);
+  positiveInteger("Paginator.pageSize", pageSize);
+
+  const pageCount = Math.ceil(input.blocks.length / pageSize);
+  if (page > pageCount) {
+    throw new OutOfRangeError(
+      "Paginator.page",
+      `expected a value between 1 and ${pageCount}`,
+    );
+  }
+
+  const visible = input.blocks.slice((page - 1) * pageSize, page * pageSize);
+  if (pageCount === 1) return visible;
+
+  const controls: JsonObject[] = [];
+  if (page > 1) {
+    controls.push(
+      button(
+        {
+          text: input.previousText ?? "Previous",
+          actionId: `${input.actionIdPrefix}.previous`,
+          value: String(page - 1),
+        },
+        settings,
+      ),
+    );
+  }
+  if (page < pageCount) {
+    controls.push(
+      button(
+        {
+          text: input.nextText ?? "Next",
+          actionId: `${input.actionIdPrefix}.next`,
+          value: String(page + 1),
+        },
+        settings,
+      ),
+    );
+  }
+
+  return [
+    ...visible,
+    ...(input.showPageIndicator === false
+      ? []
+      : [
+          contextBlock(
+            { elements: [mrkdwn(`Page ${page} of ${pageCount}`, {}, settings)] },
+            settings,
+          ),
+        ]),
+    actionsBlock(
+      {
+        elements: controls,
+        ...(input.blockId === undefined ? {} : { blockId: input.blockId }),
+      },
+      settings,
+    ),
+  ];
+}
+
+/**
+ * Starts a pure paginator component.
+ *
+ * The component renders the selected page plus ordinary context and action
+ * blocks. Generated button values contain the one-based page to render next;
+ * interaction handling remains in the application.
+ */
+export function Paginator(): FluentGroupBuilder<PaginatorInput, JsonObject> {
+  return createFluentGroupBuilder(renderPaginator, {
+    collections: { blocks: "flat" },
+  });
+}

--- a/typescript/src/fluent/core.ts
+++ b/typescript/src/fluent/core.ts
@@ -6,6 +6,7 @@
 import type { FactorySettings } from "../types.js";
 
 const FLUENT_BUILDER = Symbol("slackblocks.fluent-builder");
+const FLUENT_GROUP = Symbol("slackblocks.fluent-group");
 
 type NonNullish<Value> = Exclude<Value, null | undefined>;
 
@@ -17,7 +18,11 @@ export type Buildable<Value> =
 
 type CollectionArgument<Value> =
   | Buildable<NonNullish<Value>>
-  | readonly Buildable<NonNullish<Value>>[];
+  | FluentGroupBuilder<object, NonNullish<Value>>
+  | readonly (
+      | Buildable<NonNullish<Value>>
+      | FluentGroupBuilder<object, NonNullish<Value>>
+    )[];
 
 type FluentMethods<Input extends object, Output> = {
   [Key in keyof Input]-?: NonNullish<Input[Key]> extends readonly (infer Item)[]
@@ -31,6 +36,12 @@ export type FluentBuilder<Input extends object, Output> = FluentMethods<Input, O
   build(settings?: FactorySettings): Output;
 };
 
+/** A fluent component that expands to multiple values in a parent collection. */
+export type FluentGroupBuilder<Input extends object, Output> = FluentBuilder<
+  Input,
+  Output[]
+>;
+
 type FluentFactory<Input extends object, Output> = (
   input: Input,
   settings?: FactorySettings,
@@ -40,10 +51,12 @@ type CollectionMode = "flat" | "nested";
 
 interface FluentBuilderOptions<Input extends object> {
   collections?: Partial<Record<keyof Input, CollectionMode>>;
+  groupOutput?: boolean;
 }
 
 interface FluentBuilderRuntime {
   [FLUENT_BUILDER]: true;
+  [FLUENT_GROUP]?: true;
   build(settings?: FactorySettings): unknown;
 }
 
@@ -56,10 +69,31 @@ function isFluentBuilder(value: unknown): value is FluentBuilderRuntime {
   );
 }
 
+function isFluentGroup(value: unknown): value is FluentBuilderRuntime {
+  return isFluentBuilder(value) && value[FLUENT_GROUP] === true;
+}
+
 function materialise(value: unknown, settings: FactorySettings): unknown {
   if (isFluentBuilder(value)) return value.build(settings);
   if (Array.isArray(value)) return value.map((item) => materialise(item, settings));
   return value;
+}
+
+function materialiseFlatCollection(
+  value: unknown,
+  settings: FactorySettings,
+): unknown[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (isFluentGroup(item)) {
+      const built = item.build(settings);
+      if (!Array.isArray(built)) {
+        throw new TypeError("A fluent group must build an array");
+      }
+      return built.map((nested) => materialise(nested, settings));
+    }
+    return [materialise(item, settings)];
+  });
 }
 
 /** @internal */
@@ -72,11 +106,14 @@ export function createFluentBuilder<Input extends object, Output>(
 
   const runtime: FluentBuilderRuntime = {
     [FLUENT_BUILDER]: true,
+    ...(options.groupOutput === true ? { [FLUENT_GROUP]: true as const } : {}),
     build(settings: FactorySettings = {}) {
       const input = Object.fromEntries(
         [...state.entries()].map(([key, value]) => [
           key,
-          materialise(value, settings),
+          options.collections?.[key] === "flat"
+            ? materialiseFlatCollection(value, settings)
+            : materialise(value, settings),
         ]),
       ) as Input;
       return factory(input, settings);
@@ -117,4 +154,12 @@ export function createFluentBuilder<Input extends object, Output>(
   }) as unknown as FluentBuilder<Input, Output>;
 
   return proxy;
+}
+
+/** @internal */
+export function createFluentGroupBuilder<Input extends object, Output>(
+  factory: FluentFactory<Input, Output[]>,
+  options: Omit<FluentBuilderOptions<Input>, "groupOutput"> = {},
+): FluentGroupBuilder<Input, Output> {
+  return createFluentBuilder(factory, { ...options, groupOutput: true });
 }

--- a/typescript/src/fluent/index.ts
+++ b/typescript/src/fluent/index.ts
@@ -1,6 +1,7 @@
 /** Preferred fluent API for constructing Block Kit payloads. */
-export type { Buildable, FluentBuilder } from "./core.js";
+export type { Buildable, FluentBuilder, FluentGroupBuilder } from "./core.js";
 export * from "./blocks.js";
+export * from "./components.js";
 export * from "./elements.js";
 export * from "./objects.js";
 export * from "./payloads.js";

--- a/typescript/test/fluent-paginator.test.ts
+++ b/typescript/test/fluent-paginator.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  Message,
+  Paginator,
+  SectionBlock,
+  actionsBlock,
+  button,
+  contextBlock,
+  message,
+  mrkdwn,
+  sectionBlock,
+} from "../src/index.js";
+
+describe("Paginator", () => {
+  const pages = ["One", "Two", "Three"].map((text) =>
+    SectionBlock().text(text),
+  );
+
+  it("renders a selected page and navigation as ordinary blocks", () => {
+    expect(
+      Paginator()
+        .blocks(pages)
+        .actionIdPrefix("results")
+        .page(2)
+        .pageSize(1)
+        .build(),
+    ).toEqual([
+      sectionBlock({ text: "Two" }),
+      contextBlock({ elements: [mrkdwn("Page 2 of 3")] }),
+      actionsBlock({
+        elements: [
+          button({ text: "Previous", actionId: "results.previous", value: "1" }),
+          button({ text: "Next", actionId: "results.next", value: "3" }),
+        ],
+      }),
+    ]);
+  });
+
+  it("expands directly inside a fluent block collection", () => {
+    expect(
+      Message()
+        .channel("C123")
+        .blocks(
+          Paginator()
+            .blocks(pages)
+            .actionIdPrefix("results")
+            .pageSize(2),
+        )
+        .build(),
+    ).toEqual(
+      message({
+        channel: "C123",
+        blocks: [
+          sectionBlock({ text: "One" }),
+          sectionBlock({ text: "Two" }),
+          contextBlock({ elements: [mrkdwn("Page 1 of 2")] }),
+          actionsBlock({
+            elements: [
+              button({ text: "Next", actionId: "results.next", value: "2" }),
+            ],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("omits navigation when all content fits", () => {
+    expect(
+      Paginator().blocks(pages).actionIdPrefix("results").pageSize(3).build(),
+    ).toEqual([
+      sectionBlock({ text: "One" }),
+      sectionBlock({ text: "Two" }),
+      sectionBlock({ text: "Three" }),
+    ]);
+  });
+
+  it("rejects invalid page configuration at build time", () => {
+    expect(() =>
+      Paginator()
+        .blocks(pages)
+        .actionIdPrefix("results")
+        .page(4)
+        .pageSize(1)
+        .build(),
+    ).toThrow(/between 1 and 3/);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce composable fluent block groups
- add a pure paginator renderer with one-based pages and configurable page size
- generate conventional context and previous/next action blocks
- flatten paginator output directly inside message and view block collections
- keep interaction and state handling application-owned

## Train
Stacked on #294 and the earlier fluent API PRs. Keep draft and unmerged until the complete train is approved.

## Validation
- TypeScript typecheck
- 315 TypeScript tests
- package build, publint, and Are The Types Wrong