### PR TITLE
feat(typescript): add fluent accordion component

### DIFF
--- a/typescript/src/fluent/components.ts
+++ b/typescript/src/fluent/components.ts
@@ -1,13 +1,106 @@
 /** Higher-level fluent components that render ordinary Block Kit blocks. */
-import { actionsBlock, contextBlock } from "../blocks.js";
+import {
+  actionsBlock,
+  containerBlock,
+  contextBlock,
+  type ContainerWidth,
+} from "../blocks.js";
 import { button } from "../elements.js";
-import { MissingRequiredError, OutOfRangeError } from "../errors.js";
-import { mrkdwn } from "../objects.js";
+import {
+  MissingRequiredError,
+  OutOfRangeError,
+  TypeMismatchError,
+} from "../errors.js";
+import { mrkdwn, type TextLike } from "../objects.js";
 import type { FactorySettings, JsonObject } from "../types.js";
 import {
+  createFluentBuilder,
   createFluentGroupBuilder,
+  type FluentBuilder,
   type FluentGroupBuilder,
 } from "./core.js";
+
+/** Configuration accepted by {@link AccordionSection}. */
+export interface AccordionSectionInput {
+  /** Plain-text heading shown above the collapsible content. */
+  title: TextLike;
+  /** Blocks revealed when the section is expanded. */
+  blocks: JsonObject[];
+  /** Optional supporting copy below the heading. */
+  subtitle?: TextLike;
+  /** Optional image displayed in the header. */
+  icon?: JsonObject;
+  /** Whether this section starts expanded. Defaults to `false`. */
+  expanded?: boolean;
+  /** Horizontal width of this section. Defaults to `standard`. */
+  width?: ContainerWidth;
+  /** Whether Slack draws a divider below the header. */
+  hasHeaderDivider?: boolean;
+  /** Optional deterministic identifier for this section. */
+  blockId?: string;
+}
+
+function renderAccordionSection(
+  input: AccordionSectionInput,
+  settings: FactorySettings = {},
+): JsonObject {
+  const { blocks, expanded, ...container } = input;
+  return containerBlock(
+    {
+      ...container,
+      childBlocks: blocks,
+      isCollapsible: true,
+      defaultCollapsed: !(expanded ?? false),
+    },
+    settings,
+  );
+}
+
+/** Starts one native collapsible section for an {@link Accordion}. */
+export function AccordionSection(): FluentBuilder<
+  AccordionSectionInput,
+  JsonObject
+> {
+  return createFluentBuilder(renderAccordionSection, {
+    collections: { blocks: "flat" },
+  });
+}
+
+/** Configuration accepted by {@link Accordion}. */
+export interface AccordionInput {
+  /** Sections created with {@link AccordionSection}, in display order. */
+  sections: JsonObject[];
+}
+
+function renderAccordion(input: AccordionInput): JsonObject[] {
+  if (!Array.isArray(input.sections) || input.sections.length === 0) {
+    throw new MissingRequiredError(
+      "Accordion.sections",
+      "expected at least one section",
+    );
+  }
+  input.sections.forEach((section, index) => {
+    if (section.type !== "container" || section.is_collapsible !== true) {
+      throw new TypeMismatchError(
+        `Accordion.sections[${index}]`,
+        "expected an AccordionSection",
+      );
+    }
+  });
+  return input.sections;
+}
+
+/**
+ * Starts an accordion made from Slack-native collapsible containers.
+ *
+ * Each section expands independently in Slack and requires no application-side
+ * interaction handler.
+ */
+export function Accordion(): FluentGroupBuilder<AccordionInput, JsonObject> {
+  return createFluentGroupBuilder(renderAccordion, {
+    collections: { sections: "flat" },
+  });
+}
 
 /** Configuration accepted by {@link Paginator}. */
 export interface PaginatorInput {
@@ -39,10 +132,10 @@ function renderPaginator(
   input: PaginatorInput,
   settings: FactorySettings = {},
 ): JsonObject[] {
-  if (input.blocks.length === 0) {
+  if (!Array.isArray(input.blocks) || input.blocks.length === 0) {
     throw new MissingRequiredError("Paginator.blocks", "expected at least one block");
   }
-  if (input.actionIdPrefix.length === 0) {
+  if (typeof input.actionIdPrefix !== "string" || input.actionIdPrefix.length === 0) {
     throw new MissingRequiredError(
       "Paginator.actionIdPrefix",
       "expected a non-empty prefix",

--- a/typescript/test/fluent-accordion.test.ts
+++ b/typescript/test/fluent-accordion.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  Accordion,
+  AccordionSection,
+  Message,
+  SectionBlock,
+  containerBlock,
+  message,
+  sectionBlock,
+} from "../src/index.js";
+
+describe("Accordion", () => {
+  it("renders Slack-native collapsible containers", () => {
+    expect(
+      Accordion()
+        .sections(
+          AccordionSection()
+            .title("Details")
+            .subtitle("More information")
+            .blocks(SectionBlock().text("Hidden initially")),
+        )
+        .sections(
+          AccordionSection()
+            .title("Summary")
+            .expanded(true)
+            .blocks(SectionBlock().text("Visible initially")),
+        )
+        .build(),
+    ).toEqual([
+      containerBlock({
+        title: "Details",
+        subtitle: "More information",
+        childBlocks: [sectionBlock({ text: "Hidden initially" })],
+        isCollapsible: true,
+        defaultCollapsed: true,
+      }),
+      containerBlock({
+        title: "Summary",
+        childBlocks: [sectionBlock({ text: "Visible initially" })],
+        isCollapsible: true,
+        defaultCollapsed: false,
+      }),
+    ]);
+  });
+
+  it("expands directly inside a fluent message", () => {
+    expect(
+      Message()
+        .channel("C123")
+        .blocks(
+          Accordion().sections(
+            AccordionSection()
+              .title("Details")
+              .blocks(SectionBlock().text("Content")),
+          ),
+        )
+        .build(),
+    ).toEqual(
+      message({
+        channel: "C123",
+        blocks: [
+          containerBlock({
+            title: "Details",
+            childBlocks: [sectionBlock({ text: "Content" })],
+            isCollapsible: true,
+            defaultCollapsed: true,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("rejects empty and non-accordion content", () => {
+    expect(() => Accordion().build()).toThrow(/at least one section/);
+    expect(() =>
+      Accordion().sections(SectionBlock().text("Not collapsible")).build(),
+    ).toThrow(/AccordionSection/);
+  });
+});


### PR DESCRIPTION
## Summary
- add AccordionSection builders backed by Slack native collapsible containers
- add an Accordion block group that expands directly inside messages and views
- support initially expanded sections, subtitles, icons, widths, dividers, and block IDs
- validate empty and non-accordion content with typed library errors
- require no custom interaction handler for expand and collapse behavior

## Train
Stacked on #295 and the earlier fluent API PRs. Keep draft and unmerged until the complete train is approved.

## Validation
- TypeScript typecheck
- 318 TypeScript tests
- package build, publint, and Are The Types Wrong