### PR TITLE
feat: validate complete Block Kit payload surfaces

### DIFF
--- a/python/slackblocks/__init__.py
+++ b/python/slackblocks/__init__.py
@@ -123,4 +123,4 @@ name = "slackblocks"
 
 # The version of the shared conformance spec (spec/SPEC.md) this
 # implementation conforms to.
-SPEC_VERSION: str = "1.0.1"
+SPEC_VERSION: str = "1.1.0"

--- a/python/slackblocks/_surfaces.py
+++ b/python/slackblocks/_surfaces.py
@@ -1,0 +1,89 @@
+"""Internal Block Kit surface compatibility checks."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from ._core import resolve
+from .errors import TypeMismatchError
+
+BlockSurface = Literal["home", "message", "modal"]
+
+_BLOCK_TYPES_BY_SURFACE: dict[BlockSurface, frozenset[str]] = {
+    "message": frozenset(
+        {
+            "actions",
+            "card",
+            "carousel",
+            "container",
+            "context",
+            "context_actions",
+            "data_table",
+            "data_visualization",
+            "divider",
+            "file",
+            "header",
+            "image",
+            "markdown",
+            "plan",
+            "rich_text",
+            "section",
+            "table",
+            "task_card",
+            "video",
+        }
+    ),
+    "modal": frozenset(
+        {
+            "actions",
+            "alert",
+            "card",
+            "context",
+            "divider",
+            "header",
+            "image",
+            "input",
+            "rich_text",
+            "section",
+            "video",
+        }
+    ),
+    "home": frozenset(
+        {
+            "actions",
+            "card",
+            "carousel",
+            "container",
+            "context",
+            "data_table",
+            "divider",
+            "header",
+            "image",
+            "input",
+            "rich_text",
+            "section",
+            "table",
+            "video",
+        }
+    ),
+}
+
+
+def block_type(block: Any) -> str | None:
+    """Return the rendered Slack type for a block-like object."""
+    rendered = resolve(block)
+    if not isinstance(rendered, dict):
+        return None
+    value = rendered.get("type")
+    return value if isinstance(value, str) else None
+
+
+def validate_surface_blocks(blocks: list[Any], surface: BlockSurface) -> None:
+    """Reject block types that Slack does not support on ``surface``."""
+    allowed = _BLOCK_TYPES_BY_SURFACE[surface]
+    for index, block in enumerate(blocks):
+        type_ = block_type(block)
+        if type_ not in allowed:
+            raise TypeMismatchError(
+                f"blocks[{index}] type {type_!r} is not supported on {surface} surfaces"
+            )

--- a/python/slackblocks/messages.py
+++ b/python/slackblocks/messages.py
@@ -12,7 +12,8 @@ from json import dumps
 from typing import Any
 
 from slackblocks._core import resolve
-from slackblocks.utils import coerce_to_list
+from slackblocks._surfaces import validate_surface_blocks
+from slackblocks.utils import coerce_to_list, validate_string_nonnull
 
 from .attachments import Attachment
 from .blocks import Block
@@ -79,12 +80,16 @@ class BaseMessage(_MessagePayloadMixin):
         thread_ts: str | None = None,
         mrkdwn: bool = True,
     ) -> None:
-        self.blocks = coerce_to_list(blocks, class_=Block, allow_none=True)
+        self.blocks = coerce_to_list(blocks, class_=Block, allow_none=True, max_size=50)
         self.channel = channel
         self.text = text
-        self.attachments = coerce_to_list(attachments, class_=Attachment, allow_none=True)
+        self.attachments = coerce_to_list(
+            attachments, class_=Attachment, allow_none=True, max_size=100
+        )
         self.thread_ts = thread_ts
         self.mrkdwn = mrkdwn
+        if self.blocks is not None:
+            validate_surface_blocks(self.blocks, "message")
 
     def _resolve(self) -> dict[str, Any]:
         # The 'text' field is intentionally emitted even when it is an empty
@@ -141,6 +146,7 @@ class Message(BaseMessage):
         unfurl_links: bool | None = None,
         unfurl_media: bool | None = None,
     ) -> None:
+        channel = validate_string_nonnull(channel, field_name="channel", min_length=1)
         super().__init__(channel, text, blocks, attachments, thread_ts, mrkdwn)
         self.unfurl_links = unfurl_links
         self.unfurl_media = unfurl_media
@@ -239,9 +245,13 @@ class WebhookMessage(_MessagePayloadMixin):
     ) -> None:
         self.text = text
         self.attachments: list[Attachment] | None = coerce_to_list(
-            attachments, Attachment, allow_none=True
+            attachments, Attachment, allow_none=True, max_size=100
         )
-        self.blocks: list[Block] | None = coerce_to_list(blocks, Block, allow_none=True)
+        self.blocks: list[Block] | None = coerce_to_list(
+            blocks, Block, allow_none=True, max_size=50
+        )
+        if self.blocks is not None:
+            validate_surface_blocks(self.blocks, "message")
         self.response_type = (
             ResponseType.get_value(response_type) if response_type is not None else None
         )

--- a/python/slackblocks/views.py
+++ b/python/slackblocks/views.py
@@ -11,7 +11,9 @@ from json import dumps
 from typing import Any
 
 from slackblocks._core import resolve
+from slackblocks._surfaces import block_type, validate_surface_blocks
 from slackblocks.blocks import Block
+from slackblocks.errors import MissingRequiredError
 from slackblocks.objects import Text, TextLike
 from slackblocks.utils import coerce_to_list, validate_string
 
@@ -59,7 +61,10 @@ class View:
         external_id: str | None = None,
     ) -> None:
         self.type_ = type.value
-        self.blocks = coerce_to_list(blocks, class_=Block, min_size=1, max_size=100)
+        blocks_list = coerce_to_list(blocks, class_=Block, min_size=1, max_size=100)
+        assert blocks_list is not None
+        self.blocks = blocks_list
+        validate_surface_blocks(self.blocks, type.value)
         self.private_metadata = validate_string(
             private_metadata,
             field_name="private_metadata",
@@ -140,6 +145,8 @@ class ModalView(View):
         self.title = Text.to_text_nonnull(title, force_plaintext=True, max_length=24)
         self.close = Text.to_text(close, force_plaintext=True, max_length=24, allow_none=True)
         self.submit = Text.to_text(submit, force_plaintext=True, max_length=24, allow_none=True)
+        if self.submit is None and any(block_type(block) == "input" for block in self.blocks):
+            raise MissingRequiredError("submit is required when a modal contains an input block")
         self.clear_on_close = clear_on_close
         self.notify_on_close = notify_on_close
         self.submit_disabled = submit_disabled

--- a/python/test/conformance/test_conformance.py
+++ b/python/test/conformance/test_conformance.py
@@ -10,6 +10,7 @@ import slackblocks
 from slackblocks import (
     ActionsBlock,
     AlertBlock,
+    Attachment,
     AxisConfig,
     Button,
     CardBlock,
@@ -38,6 +39,7 @@ from slackblocks import (
     LengthError,
     LineChart,
     MarkdownBlock,
+    Message,
     MissingRequiredError,
     ModalView,
     MutualExclusivityError,
@@ -344,6 +346,29 @@ INVALID_CASES: dict[str, Callable[[], object]] = {
     ),
     "video-provider-name-too-long": lambda: video(
         provider_name="x" * (LIMITS["video"]["provider_name"]["max_length"] + 1)
+    ),
+    "message-channel-empty": lambda: Message(channel=""),
+    "message-too-many-blocks": lambda: Message(
+        channel="C123",
+        blocks=[DividerBlock() for _ in range(LIMITS["message"]["blocks"]["max_items"] + 1)],
+    ),
+    "message-too-many-attachments": lambda: Message(
+        channel="C123",
+        attachments=[
+            Attachment(blocks=[DividerBlock()])
+            for _ in range(LIMITS["message"]["attachments"]["max_items"] + 1)
+        ],
+    ),
+    "message-invalid-block-surface": lambda: Message(
+        channel="C123", blocks=[AlertBlock("Modal only")]
+    ),
+    "modal-invalid-block-surface": lambda: ModalView(
+        title="Invalid", blocks=[MarkdownBlock("Message only")]
+    ),
+    "home-invalid-block-surface": lambda: HomeTabView(blocks=[AlertBlock("Modal only")]),
+    "modal-input-requires-submit": lambda: ModalView(
+        title="Missing submit",
+        blocks=[InputBlock(label="Name", element=PlainTextInput(action_id="name"))],
     ),
     "view-missing-blocks": lambda: HomeTabView(blocks=[]),
     "view-too-many-blocks": lambda: HomeTabView(

--- a/python/test/unit/test_exports.py
+++ b/python/test/unit/test_exports.py
@@ -53,4 +53,4 @@ def test_spec_version_is_declared() -> None:
     declare the spec version it conforms to."""
     import slackblocks
 
-    assert slackblocks.SPEC_VERSION == "1.0.1"
+    assert slackblocks.SPEC_VERSION == "1.1.0"

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Spec changelog
 
+## 1.1.0 - 2026-08-28
+
+- Enforce Slack surface compatibility for message, modal, and App Home block collections.
+- Enforce the 50-block message limit, 100-attachment message limit, and non-empty message channel.
+- Require submit text when a modal contains an input block.
+
 ## 1.0.1 - 2026-08-14
 
 - Correct `option.value.max_length` from 75 to 150 to match the current Slack

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,6 +1,6 @@
 # slackblocks conformance specification
 
-Version 1.0.1 defines the language-neutral contract for slackblocks implementations.
+Version 1.1.0 defines the language-neutral contract for slackblocks implementations.
 
 ## Valid fixtures
 
@@ -9,6 +9,11 @@ Version 1.0.1 defines the language-neutral contract for slackblocks implementati
 ## Invalid cases
 
 `fixtures/invalid/manifest.json` names invalid constructions and their required error category. Each language owns the code that attempts the construction. Implementations may use language-native error types and messages.
+
+Payload-level cases also enforce the official 50-block message limit, the
+100-attachment message limit, block compatibility for message, modal, and App
+Home surfaces, and the requirement for submit text when a modal contains an
+input block.
 
 The normative categories are `length-exceeded`, `out-of-range`, `mutually-exclusive`, `type-mismatch`, `missing-required`, and `invalid-usage`.
 

--- a/spec/coverage.json
+++ b/spec/coverage.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.1",
+  "spec_version": "1.1.0",
   "capabilities": {
     "blocks.actions": ["blocks/actions_block_checkboxes"],
     "blocks.alert": ["blocks/alert_block"],

--- a/spec/fixtures/invalid/manifest.json
+++ b/spec/fixtures/invalid/manifest.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.1",
+  "spec_version": "1.1.0",
   "cases": [
     {
       "id": "text-empty",
@@ -312,6 +312,48 @@
       "category": "length-exceeded",
       "constraint": "video.provider_name.max_length",
       "description": "A video provider name longer than 50 characters must be rejected"
+    },
+    {
+      "id": "message-channel-empty",
+      "category": "length-exceeded",
+      "constraint": "message.channel.min_length",
+      "description": "A Web API message must name a non-empty destination channel"
+    },
+    {
+      "id": "message-too-many-blocks",
+      "category": "length-exceeded",
+      "constraint": "message.blocks.max_items",
+      "description": "A message with more than 50 blocks must be rejected"
+    },
+    {
+      "id": "message-too-many-attachments",
+      "category": "length-exceeded",
+      "constraint": "message.attachments.max_items",
+      "description": "A message with more than 100 attachments must be rejected"
+    },
+    {
+      "id": "message-invalid-block-surface",
+      "category": "type-mismatch",
+      "constraint": "message.blocks.surface",
+      "description": "A message cannot contain a modal-only alert block"
+    },
+    {
+      "id": "modal-invalid-block-surface",
+      "category": "type-mismatch",
+      "constraint": "view.modal.blocks.surface",
+      "description": "A modal cannot contain a message-only markdown block"
+    },
+    {
+      "id": "home-invalid-block-surface",
+      "category": "type-mismatch",
+      "constraint": "view.home.blocks.surface",
+      "description": "An App Home tab cannot contain a modal-only alert block"
+    },
+    {
+      "id": "modal-input-requires-submit",
+      "category": "missing-required",
+      "constraint": "view.modal.submit_for_input",
+      "description": "A modal containing an input block must define submit text"
     },
     {
       "id": "view-missing-blocks",

--- a/spec/limits.json
+++ b/spec/limits.json
@@ -101,6 +101,11 @@
     "description": { "max_length": 200 },
     "provider_name": { "max_length": 50 }
   },
+  "message": {
+    "channel": { "min_length": 1 },
+    "blocks": { "max_items": 50 },
+    "attachments": { "max_items": 100 }
+  },
   "view": {
     "blocks": { "min_items": 1, "max_items": 100 },
     "private_metadata": { "max_length": 3000 },

--- a/spec/manifest.json
+++ b/spec/manifest.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.1",
+  "spec_version": "1.1.0",
   "fixtures": [
     {
       "id": "attachments/attachment_multi_block",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -42,7 +42,7 @@
     "typescript",
     "validation"
   ],
-  "slackblocksSpecVersion": "1.0.1",
+  "slackblocksSpecVersion": "1.1.0",
   "dependencies": {
     "@slack/types": "^3.0.0"
   },

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -10,4 +10,4 @@ export * from "./validation.js";
 export * from "./views.js";
 export * from "./fluent/index.js";
 
-export const specVersion = "1.0.1";
+export const specVersion = "1.1.0";

--- a/typescript/src/messages.ts
+++ b/typescript/src/messages.ts
@@ -3,8 +3,11 @@
  *
  * @module messages
  */
-import { TypeMismatchError } from "./errors.js";
+import limits from "../../spec/limits.json" with { type: "json" };
+
+import { LengthError, TypeMismatchError } from "./errors.js";
 import { createObject, dropEmpty } from "./internal.js";
+import { validateSurfaceBlocks } from "./surfaces.js";
 import type { FactorySettings, JsonObject } from "./types.js";
 
 /**
@@ -27,6 +30,39 @@ export const Color = {
 } as const;
 
 const COLOR_ALIASES = new Set<string>([Color.GOOD, Color.WARNING, Color.DANGER]);
+
+function validateMessageCollections(
+  input: { blocks?: JsonObject[]; attachments?: JsonObject[] },
+  path: string,
+): void {
+  if (input.blocks !== undefined) {
+    if (!Array.isArray(input.blocks)) {
+      throw new TypeMismatchError(`${path}.blocks`, "expected an array");
+    }
+    if (input.blocks.length > limits.message.blocks.max_items) {
+      throw new LengthError(
+        `${path}.blocks`,
+        `exceeds maximum ${limits.message.blocks.max_items}`,
+      );
+    }
+    validateSurfaceBlocks(input.blocks, "message", `${path}.blocks`);
+  }
+  if (
+    input.attachments !== undefined &&
+    !Array.isArray(input.attachments)
+  ) {
+    throw new TypeMismatchError(`${path}.attachments`, "expected an array");
+  }
+  if (
+    input.attachments !== undefined &&
+    input.attachments.length > limits.message.attachments.max_items
+  ) {
+    throw new LengthError(
+      `${path}.attachments`,
+      `exceeds maximum ${limits.message.attachments.max_items}`,
+    );
+  }
+}
 
 function normalizeColor(color: string): string {
   if (COLOR_ALIASES.has(color)) {
@@ -110,6 +146,16 @@ export function message(
   input: MessageInput,
   settings: FactorySettings = {},
 ): JsonObject {
+  if (typeof input.channel !== "string") {
+    throw new TypeMismatchError("message.channel", "expected a string");
+  }
+  if (input.channel.length < limits.message.channel.min_length) {
+    throw new LengthError(
+      "message.channel",
+      `expected at least ${limits.message.channel.min_length} character`,
+    );
+  }
+  validateMessageCollections(input, "message");
   return createObject(
     {
       mrkdwn: true,
@@ -147,6 +193,7 @@ export function messageResponse(
   },
   settings: FactorySettings = {},
 ): JsonObject {
+  validateMessageCollections(input, "messageResponse");
   return createObject(
     {
       mrkdwn: true,
@@ -192,5 +239,6 @@ export function webhookMessage(
   },
   settings: FactorySettings = {},
 ): JsonObject {
+  validateMessageCollections(input, "webhookMessage");
   return createObject(input, settings);
 }

--- a/typescript/src/surfaces.ts
+++ b/typescript/src/surfaces.ts
@@ -1,0 +1,77 @@
+import { TypeMismatchError } from "./errors.js";
+import type { JsonValue } from "./types.js";
+
+export type BlockSurface = "home" | "message" | "modal";
+
+const BLOCK_TYPES_BY_SURFACE: Record<BlockSurface, ReadonlySet<string>> = {
+  message: new Set([
+    "actions",
+    "card",
+    "carousel",
+    "container",
+    "context",
+    "context_actions",
+    "data_table",
+    "data_visualization",
+    "divider",
+    "file",
+    "header",
+    "image",
+    "markdown",
+    "plan",
+    "rich_text",
+    "section",
+    "table",
+    "task_card",
+    "video",
+  ]),
+  modal: new Set([
+    "actions",
+    "alert",
+    "card",
+    "context",
+    "divider",
+    "header",
+    "image",
+    "input",
+    "rich_text",
+    "section",
+    "video",
+  ]),
+  home: new Set([
+    "actions",
+    "card",
+    "carousel",
+    "container",
+    "context",
+    "data_table",
+    "divider",
+    "header",
+    "image",
+    "input",
+    "rich_text",
+    "section",
+    "table",
+    "video",
+  ]),
+};
+
+export function validateSurfaceBlocks(
+  blocks: readonly JsonValue[],
+  surface: BlockSurface,
+  path: string,
+): void {
+  const allowed = BLOCK_TYPES_BY_SURFACE[surface];
+  blocks.forEach((block, index) => {
+    if (block === null || Array.isArray(block) || typeof block !== "object") {
+      throw new TypeMismatchError(`${path}[${index}]`, "expected a block object");
+    }
+    const type = block.type;
+    if (typeof type !== "string" || !allowed.has(type)) {
+      throw new TypeMismatchError(
+        `${path}[${index}].type`,
+        `block type ${String(type)} is not supported on ${surface} surfaces`,
+      );
+    }
+  });
+}

--- a/typescript/src/validation.ts
+++ b/typescript/src/validation.ts
@@ -8,6 +8,7 @@ import {
   OutOfRangeError,
   TypeMismatchError,
 } from "./errors.js";
+import { validateSurfaceBlocks } from "./surfaces.js";
 import type { BlockKitPayload, JsonObject, JsonValue } from "./types.js";
 
 function textValue(value: unknown): string | undefined {
@@ -1028,6 +1029,7 @@ function validateKnownObject(object: JsonObject, path: string): void {
         limits.view.blocks.min_items,
         limits.view.blocks.max_items,
       );
+      validateSurfaceBlocks(object.blocks, type, child(path, "blocks"));
       length(
         typeof object.private_metadata === "string" ? object.private_metadata : undefined,
         child(path, "private_metadata"),
@@ -1041,6 +1043,21 @@ function validateKnownObject(object: JsonObject, path: string): void {
         limits.view.callback_id.max_length,
       );
       if (type === "modal") {
+        if (
+          object.submit === undefined &&
+          object.blocks.some(
+            (block) =>
+              block !== null &&
+              !Array.isArray(block) &&
+              typeof block === "object" &&
+              block.type === "input",
+          )
+        ) {
+          throw new MissingRequiredError(
+            child(path, "submit"),
+            "required when the modal contains an input block",
+          );
+        }
         length(
           textValue(object.title),
           child(path, "title.text"),

--- a/typescript/src/views.ts
+++ b/typescript/src/views.ts
@@ -3,8 +3,10 @@
  *
  * @module views
  */
+import { MissingRequiredError } from "./errors.js";
 import { create } from "./internal.js";
 import { asText, type TextLike } from "./objects.js";
+import { validateSurfaceBlocks } from "./surfaces.js";
 import type { FactorySettings, JsonObject } from "./types.js";
 
 /**
@@ -40,6 +42,16 @@ export function modal(
   },
   settings: FactorySettings = {},
 ) {
+  validateSurfaceBlocks(input.blocks, "modal", "modal.blocks");
+  if (
+    input.submit === undefined &&
+    input.blocks.some((block) => block.type === "input")
+  ) {
+    throw new MissingRequiredError(
+      "modal.submit",
+      "required when the modal contains an input block",
+    );
+  }
   return create(
     "modal",
     {
@@ -74,5 +86,6 @@ export function homeTab(
   },
   settings: FactorySettings = {},
 ) {
+  validateSurfaceBlocks(input.blocks, "home", "homeTab.blocks");
   return create("home", input, settings);
 }

--- a/typescript/test/conformance.test.ts
+++ b/typescript/test/conformance.test.ts
@@ -613,6 +613,39 @@ const invalidCases: Record<string, () => unknown> = {
     video({ description: "x".repeat(limits.video.description.max_length + 1) }),
   "video-provider-name-too-long": () =>
     video({ providerName: "x".repeat(limits.video.provider_name.max_length + 1) }),
+  "message-channel-empty": () => message({ channel: "" }),
+  "message-too-many-blocks": () =>
+    message({
+      channel: "C123",
+      blocks: Array.from(
+        { length: limits.message.blocks.max_items + 1 },
+        () => dividerBlock(),
+      ),
+    }),
+  "message-too-many-attachments": () =>
+    message({
+      channel: "C123",
+      attachments: Array.from(
+        { length: limits.message.attachments.max_items + 1 },
+        () => attachment({ blocks: [dividerBlock()] }),
+      ),
+    }),
+  "message-invalid-block-surface": () =>
+    message({ channel: "C123", blocks: [alertBlock({ text: "Modal only" })] }),
+  "modal-invalid-block-surface": () =>
+    modal({ title: "Invalid", blocks: [markdownBlock({ text: "Message only" })] }),
+  "home-invalid-block-surface": () =>
+    homeTab({ blocks: [alertBlock({ text: "Modal only" })] }),
+  "modal-input-requires-submit": () =>
+    modal({
+      title: "Missing submit",
+      blocks: [
+        inputBlock({
+          label: "Name",
+          element: plainTextInput({ actionId: "name" }),
+        }),
+      ],
+    }),
   "view-missing-blocks": () => homeTab({ blocks: [] }),
   "view-too-many-blocks": () =>
     homeTab({


### PR DESCRIPTION
## Summary
- extend the shared conformance contract to payload-level rules
- enforce 50 message blocks, 100 message attachments, and non-empty channels
- enforce official block compatibility for messages, modals, and App Home tabs
- require submit text when a modal contains an input block
- implement and test identical behavior in TypeScript and Python

The surface matrix and limits were checked against the current official Slack Block Kit and chat.postMessage documentation before adding the cases.

## Train
Stacked on #296 and the fluent API train. Keep draft and unmerged until the complete train is approved.

## Validation
- 325 TypeScript tests and typecheck
- 670 Python unit, conformance, and docs tests
- mypy, Ruff lint, and Ruff format
- TypeScript package build, publint, and Are The Types Wrong

Live Slack integration tests require SLACK_BOT_TOKEN and are not part of the credential-free CI test command.