### PR TITLE
refactor(typescript): isolate legacy factories

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -225,12 +225,12 @@ const config: Config = {
       {
         name: "TypeScript API reference",
         entryPoints: [
-          "../typescript/src/blocks.ts",
-          "../typescript/src/elements.ts",
-          "../typescript/src/objects.ts",
-          "../typescript/src/rich-text.ts",
-          "../typescript/src/messages.ts",
-          "../typescript/src/views.ts",
+          "../typescript/src/legacy/blocks.ts",
+          "../typescript/src/legacy/elements.ts",
+          "../typescript/src/legacy/objects.ts",
+          "../typescript/src/legacy/rich-text.ts",
+          "../typescript/src/legacy/messages.ts",
+          "../typescript/src/legacy/views.ts",
           "../typescript/src/utilities-reference.ts",
           "../typescript/src/errors.ts",
         ],

--- a/docs/scripts/check_typescript_api_docs.mjs
+++ b/docs/scripts/check_typescript_api_docs.mjs
@@ -3,12 +3,12 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 const SOURCE_FILES = [
-  "../../typescript/src/blocks.ts",
-  "../../typescript/src/elements.ts",
-  "../../typescript/src/objects.ts",
-  "../../typescript/src/rich-text.ts",
-  "../../typescript/src/messages.ts",
-  "../../typescript/src/views.ts",
+  "../../typescript/src/legacy/blocks.ts",
+  "../../typescript/src/legacy/elements.ts",
+  "../../typescript/src/legacy/objects.ts",
+  "../../typescript/src/legacy/rich-text.ts",
+  "../../typescript/src/legacy/messages.ts",
+  "../../typescript/src/legacy/views.ts",
   "../../typescript/src/builder.ts",
   "../../typescript/src/types.ts",
   "../../typescript/src/validation.ts",
@@ -16,10 +16,10 @@ const SOURCE_FILES = [
 ];
 
 const THROWS_REQUIRED_FILES = new Set([
-  "../../typescript/src/blocks.ts",
-  "../../typescript/src/elements.ts",
-  "../../typescript/src/messages.ts",
-  "../../typescript/src/views.ts",
+  "../../typescript/src/legacy/blocks.ts",
+  "../../typescript/src/legacy/elements.ts",
+  "../../typescript/src/legacy/messages.ts",
+  "../../typescript/src/legacy/views.ts",
 ]);
 
 const failures = [];

--- a/typescript/src/fluent/blocks.ts
+++ b/typescript/src/fluent/blocks.ts
@@ -23,7 +23,7 @@ import {
   videoBlock as createVideoBlock,
   type CardBlockInput,
   type SectionBlockInput,
-} from "../blocks.js";
+} from "../legacy/blocks.js";
 import { createFluentBuilder, type FluentBuilder } from "./core.js";
 
 type FirstInput<Factory extends (...args: never[]) => unknown> = Parameters<Factory>[0];

--- a/typescript/src/fluent/components.ts
+++ b/typescript/src/fluent/components.ts
@@ -4,14 +4,14 @@ import {
   containerBlock,
   contextBlock,
   type ContainerWidth,
-} from "../blocks.js";
-import { button } from "../elements.js";
+} from "../legacy/blocks.js";
+import { button } from "../legacy/elements.js";
 import {
   MissingRequiredError,
   OutOfRangeError,
   TypeMismatchError,
 } from "../errors.js";
-import { mrkdwn, type TextLike } from "../objects.js";
+import { mrkdwn, type TextLike } from "../legacy/objects.js";
 import type { FactorySettings, JsonObject } from "../types.js";
 import {
   createFluentBuilder,

--- a/typescript/src/fluent/elements.ts
+++ b/typescript/src/fluent/elements.ts
@@ -54,7 +54,7 @@ import {
   type UserMultiSelectInput,
   type UserSelectInput,
   type WorkflowButtonInput,
-} from "../elements.js";
+} from "../legacy/elements.js";
 import type { JsonObject, SlackObject } from "../types.js";
 import { createFluentBuilder, type FluentBuilder } from "./core.js";
 

--- a/typescript/src/fluent/objects.ts
+++ b/typescript/src/fluent/objects.ts
@@ -34,7 +34,7 @@ import {
   type PlainTextOptions,
   type SlackIconName,
   type TextObject,
-} from "../objects.js";
+} from "../legacy/objects.js";
 import {
   richText as createRichText,
   richTextChannel as createRichTextChannel,
@@ -47,7 +47,7 @@ import {
   richTextUser as createRichTextUser,
   richTextUserGroup as createRichTextUserGroup,
   type RichTextStyle,
-} from "../rich-text.js";
+} from "../legacy/rich-text.js";
 import type { FactorySettings, JsonObject, SlackObject } from "../types.js";
 import { createFluentBuilder, type FluentBuilder } from "./core.js";
 

--- a/typescript/src/fluent/payloads.ts
+++ b/typescript/src/fluent/payloads.ts
@@ -5,9 +5,9 @@ import {
   messageResponse as createMessageResponse,
   webhookMessage as createWebhookMessage,
   type MessageInput,
-} from "../messages.js";
+} from "../legacy/messages.js";
 import type { JsonObject } from "../types.js";
-import { homeTab as createHomeTab, modal as createModal } from "../views.js";
+import { homeTab as createHomeTab, modal as createModal } from "../legacy/views.js";
 import { createFluentBuilder, type FluentBuilder } from "./core.js";
 
 type FirstInput<Factory extends (...args: never[]) => unknown> = Parameters<Factory>[0];

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,13 +1,8 @@
-export * from "./blocks.js";
 export * from "./builder.js";
-export * from "./elements.js";
 export * from "./errors.js";
-export * from "./messages.js";
-export * from "./objects.js";
-export * from "./rich-text.js";
 export * from "./types.js";
 export * from "./validation.js";
-export * from "./views.js";
 export * from "./fluent/index.js";
+export * from "./legacy/index.js";
 
 export const specVersion = "1.1.0";

--- a/typescript/src/legacy/blocks.ts
+++ b/typescript/src/legacy/blocks.ts
@@ -21,10 +21,10 @@ import type {
   VideoBlock,
 } from "@slack/types";
 
-import { create, dropEmpty } from "./internal.js";
+import { create, dropEmpty } from "../internal.js";
 import { asText, type TextLike } from "./objects.js";
-import type { FactorySettings, JsonObject, SlackWire } from "./types.js";
-import type { SlackObject } from "./types.js";
+import type { FactorySettings, JsonObject, SlackWire } from "../types.js";
+import type { SlackObject } from "../types.js";
 
 /** Severity shown by an alert block. */
 export type AlertLevel = "default" | "info" | "warning" | "error" | "success";

--- a/typescript/src/legacy/elements.ts
+++ b/typescript/src/legacy/elements.ts
@@ -5,12 +5,12 @@
  *
  * @module elements
  */
-import limits from "../../spec/limits.json" with { type: "json" };
+import limits from "../../../spec/limits.json" with { type: "json" };
 
-import { LengthError, OutOfRangeError, TypeMismatchError } from "./errors.js";
-import { create, createObject, dropEmpty } from "./internal.js";
+import { LengthError, OutOfRangeError, TypeMismatchError } from "../errors.js";
+import { create, createObject, dropEmpty } from "../internal.js";
 import { asText, type TextLike } from "./objects.js";
-import type { FactorySettings, JsonObject, SlackObject } from "./types.js";
+import type { FactorySettings, JsonObject, SlackObject } from "../types.js";
 
 /** Fields accepted by {@link checkboxes}. */
 export interface CheckboxesInput {

--- a/typescript/src/legacy/index.ts
+++ b/typescript/src/legacy/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Compatibility exports for the pre-fluent TypeScript API.
+ *
+ * @deprecated Prefer the PascalCase fluent builders exported from the package
+ * root. These lowercase factories remain only for v2 compatibility and are
+ * scheduled for removal in v3.
+ */
+export * from "./blocks.js";
+export * from "./elements.js";
+export * from "./messages.js";
+export * from "./objects.js";
+export * from "./rich-text.js";
+export * from "./views.js";

--- a/typescript/src/legacy/messages.ts
+++ b/typescript/src/legacy/messages.ts
@@ -3,12 +3,12 @@
  *
  * @module messages
  */
-import limits from "../../spec/limits.json" with { type: "json" };
+import limits from "../../../spec/limits.json" with { type: "json" };
 
-import { LengthError, TypeMismatchError } from "./errors.js";
-import { createObject, dropEmpty } from "./internal.js";
-import { validateSurfaceBlocks } from "./surfaces.js";
-import type { FactorySettings, JsonObject } from "./types.js";
+import { LengthError, TypeMismatchError } from "../errors.js";
+import { createObject, dropEmpty } from "../internal.js";
+import { validateSurfaceBlocks } from "../surfaces.js";
+import type { FactorySettings, JsonObject } from "../types.js";
 
 /**
  * Preset side-border colors for legacy attachments.

--- a/typescript/src/legacy/objects.ts
+++ b/typescript/src/legacy/objects.ts
@@ -6,7 +6,7 @@
  *
  * @module objects
  */
-import limits from "../../spec/limits.json" with { type: "json" };
+import limits from "../../../spec/limits.json" with { type: "json" };
 
 import {
   InvalidUsageError,
@@ -15,9 +15,9 @@ import {
   MutualExclusivityError,
   OutOfRangeError,
   TypeMismatchError,
-} from "./errors.js";
-import { codePointLength, create, createObject, textValue } from "./internal.js";
-import type { FactorySettings, JsonObject, SlackObject } from "./types.js";
+} from "../errors.js";
+import { codePointLength, create, createObject, textValue } from "../internal.js";
+import type { FactorySettings, JsonObject, SlackObject } from "../types.js";
 
 /** A Slack plain-text or mrkdwn composition object. */
 export type TextObject = SlackObject<"plain_text" | "mrkdwn">;

--- a/typescript/src/legacy/rich-text.ts
+++ b/typescript/src/legacy/rich-text.ts
@@ -6,8 +6,8 @@
  *
  * @module rich-text
  */
-import { create } from "./internal.js";
-import type { FactorySettings, JsonObject } from "./types.js";
+import { create } from "../internal.js";
+import type { FactorySettings, JsonObject } from "../types.js";
 
 /** Inline formatting supported by rich-text text, links, users, and channels. */
 export interface RichTextStyle {

--- a/typescript/src/legacy/views.ts
+++ b/typescript/src/legacy/views.ts
@@ -3,11 +3,11 @@
  *
  * @module views
  */
-import { MissingRequiredError } from "./errors.js";
-import { create } from "./internal.js";
+import { MissingRequiredError } from "../errors.js";
+import { create } from "../internal.js";
 import { asText, type TextLike } from "./objects.js";
-import { validateSurfaceBlocks } from "./surfaces.js";
-import type { FactorySettings, JsonObject } from "./types.js";
+import { validateSurfaceBlocks } from "../surfaces.js";
+import type { FactorySettings, JsonObject } from "../types.js";
 
 /**
  * Creates a modal view payload.


### PR DESCRIPTION
## Summary
- move the lowercase factory implementation under src/legacy
- make the fluent modules the primary TypeScript source tree
- preserve existing root imports through one compatibility re-export module
- mark that compatibility module for v3 removal
- update transitional TypeDoc source paths so this intermediate train PR remains green

The next stacked docs PR removes the legacy API from generated documentation entirely; these transitional TypeDoc paths are not the final documentation state.

## Train
Stacked on #297 and the fluent API train. Keep draft and unmerged until the complete train is approved.

## Validation
- TypeScript typecheck
- 325 TypeScript tests
- package build, publint, and Are The Types Wrong
- production Docusaurus build and API rendering checks