### PR TITLE
docs: make fluent TypeScript API the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ your tests, rather than in production.
 
 ## Why `slackblocks`?
 
-- **Concise** — `SectionBlock("Hello, *world*!")` / `sectionBlock({ text: "Hello, *world*!" })`
+- **Concise** — `SectionBlock("Hello, *world*!")` / `SectionBlock().text("Hello, *world*!").build()`
   instead of a ten-line JSON object.
 - **Validated up front** — character limits, required fields, mutually-exclusive options,
   and element-type restrictions are enforced when you construct the block, so you find
@@ -109,31 +109,32 @@ The same message in TypeScript:
 
 ```ts
 import {
-  actionsBlock,
-  button,
-  dividerBlock,
-  headerBlock,
-  message,
-  sectionBlock,
+  ActionsBlock,
+  Button,
+  DividerBlock,
+  HeaderBlock,
+  Message,
+  SectionBlock,
 } from "@nicklambourne/slackblocks";
 
-const payload = message({
-  channel: "#general",
-  text: "Build #482 passed", // plain-text fallback for notifications
-  blocks: [
-    headerBlock({ text: "Build #482 passed :white_check_mark:" }),
-    sectionBlock({
-      fields: ["*Branch*\n`main`", "*Author*\n@nick", "*Duration*\n3m 12s", "*Tests*\n1,247 passed"],
-    }),
-    dividerBlock(),
-    actionsBlock({
-      elements: [
-        button({ text: "View build", actionId: "view", url: "https://ci.example.com/482" }),
-        button({ text: "Re-run", actionId: "rerun", value: "482", style: "primary" }),
-      ],
-    }),
-  ],
-});
+const payload = Message()
+  .channel("#general")
+  .text("Build #482 passed") // plain-text fallback for notifications
+  .blocks(
+    HeaderBlock().text("Build #482 passed :white_check_mark:"),
+    SectionBlock().fields(
+      "*Branch*\n`main`",
+      "*Author*\n@nick",
+      "*Duration*\n3m 12s",
+      "*Tests*\n1,247 passed",
+    ),
+    DividerBlock(),
+    ActionsBlock().elements(
+      Button().text("View build").actionId("view").url("https://ci.example.com/482"),
+      Button().text("Re-run").actionId("rerun").value("482").style("primary"),
+    ),
+  )
+  .build();
 ```
 
 ```ts
@@ -154,7 +155,7 @@ await client.chat.postMessage(payload);
 - [Using Blocks](https://nicklambourne.github.io/slackblocks/usage/using_blocks) — every
   block type with code in both languages, the JSON it produces, and screenshots.
 - [Sending Messages](https://nicklambourne.github.io/slackblocks/usage/sending_messages)
-- [Cookbook](https://nicklambourne.github.io/slackblocks/usage/cookbook) — end-to-end
+- [Recipe Book](https://nicklambourne.github.io/slackblocks/usage/cookbook) — end-to-end
   recipes for build notifications, approval requests, modals, and more.
 - [API Reference](https://nicklambourne.github.io/slackblocks/reference) —
   [Python](https://nicklambourne.github.io/slackblocks/reference/python) and
@@ -162,6 +163,7 @@ await client.chat.postMessage(payload);
 - [Migrating from 1.x](https://nicklambourne.github.io/slackblocks/usage/migration) ·
   [Troubleshooting & FAQ](https://nicklambourne.github.io/slackblocks/usage/troubleshooting)
 - Changelogs: [Python](python/CHANGELOG.md) · [TypeScript](typescript/CHANGELOG.md)
+- [Roadmap](ROADMAP.md) — including the TypeScript legacy API removal planned for v3.0.
 
 ## Repository layout
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+# Roadmap
+
+This roadmap records planned compatibility boundaries rather than promising release
+dates. Priorities may move, but removals listed here will not happen before their named
+major release.
+
+## 2.2
+
+- Make the fluent PascalCase TypeScript API the default for examples, guides, and API
+  reference material.
+- Add higher-level components that compose ordinary Block Kit blocks, beginning with
+  pagination and Slack-native accordions.
+- Keep the lowercase object-input TypeScript factories available only as a deprecated
+  compatibility layer under `src/legacy`.
+
+## 3.0
+
+- Remove every deprecated lowercase TypeScript factory and its root-package re-export.
+- Remove the `src/legacy` compatibility layer and its compatibility-only tests.
+- Retain the fluent PascalCase builders as the sole TypeScript construction API.
+- Publish a focused migration guide before the first v3 prerelease. The mechanical
+  migration is from one object argument to chained camelCase setters followed by
+  `.build()` at the payload boundary.
+
+The legacy API will remain functional throughout the 2.x line, but it will receive only
+compatibility fixes needed to avoid regressions. New blocks, components, examples, and
+documentation target the fluent API only.

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -84,23 +84,30 @@ See [Using Blocks](usage/using_blocks) for examples of all block types side-by-s
 </Python>
 <TypeScript>
 
-The TypeScript package exposes data-first factories that return typed, Slack-shaped objects.
+The TypeScript package exposes chainable PascalCase builders that produce typed,
+Slack-shaped objects when `.build()` is called.
 
 ### Composition objects
 
-Factories such as [`plainText`](reference/typescript/objects#plaintext), [`mrkdwn`](reference/typescript/objects#mrkdwn), and [`option`](reference/typescript/objects#option) create the small values used throughout Block Kit payloads.
+Builders such as [`PlainText`](reference/typescript/objects#plaintext), [`Markdown`](reference/typescript/objects#markdown), and [`Option`](reference/typescript/objects#option) create the small values used throughout Block Kit payloads.
 
 ### Elements
 
-Interactive controls are built with factories such as [`button`](reference/typescript/elements#button), [`checkboxes`](reference/typescript/elements#checkboxes), [`staticSelect`](reference/typescript/elements#staticselect), and [`datePicker`](reference/typescript/elements#datepicker).
+Interactive controls are built with [`Button`](reference/typescript/elements#button), [`Checkboxes`](reference/typescript/elements#checkboxes), [`StaticSelect`](reference/typescript/elements#staticselect), and [`DatePicker`](reference/typescript/elements#datepicker).
 
 ### Blocks
 
-Every block factory follows the same `<kind>Block` naming pattern. Alongside the familiar [`sectionBlock`](reference/typescript/blocks#sectionblock), [`actionsBlock`](reference/typescript/blocks#actionsblock), and [`videoBlock`](reference/typescript/blocks#videoblock), the API includes [`alertBlock`](reference/typescript/blocks#alertblock), [`cardBlock`](reference/typescript/blocks#cardblock), [`carouselBlock`](reference/typescript/blocks#carouselblock), [`containerBlock`](reference/typescript/blocks#containerblock), [`contextActionsBlock`](reference/typescript/blocks#contextactionsblock), [`dataTableBlock`](reference/typescript/blocks#datatableblock), [`dataVisualizationBlock`](reference/typescript/blocks#datavisualizationblock), [`planBlock`](reference/typescript/blocks#planblock), and [`taskCardBlock`](reference/typescript/blocks#taskcardblock).
+Every block builder follows the same `<Kind>Block` naming pattern. Alongside [`SectionBlock`](reference/typescript/blocks#sectionblock), [`ActionsBlock`](reference/typescript/blocks#actionsblock), and [`VideoBlock`](reference/typescript/blocks#videoblock), the API includes [`AlertBlock`](reference/typescript/blocks#alertblock), [`CardBlock`](reference/typescript/blocks#cardblock), [`CarouselBlock`](reference/typescript/blocks#carouselblock), [`ContainerBlock`](reference/typescript/blocks#containerblock), [`ContextActionsBlock`](reference/typescript/blocks#contextactionsblock), [`DataTableBlock`](reference/typescript/blocks#datatableblock), [`DataVisualizationBlock`](reference/typescript/blocks#datavisualizationblock), [`PlanBlock`](reference/typescript/blocks#planblock), and [`TaskCardBlock`](reference/typescript/blocks#taskcardblock).
 
-### Messages and views
+### Payloads
 
-Use [`message`](reference/typescript/messages#message), [`webhookMessage`](reference/typescript/messages#webhookmessage), and [`messageResponse`](reference/typescript/messages#messageresponse) for message payloads. Use [`modal`](reference/typescript/views#modal) and [`homeTab`](reference/typescript/views#hometab) for Slack views.
+Use [`Message`](reference/typescript/payloads#message), [`WebhookMessage`](reference/typescript/payloads#webhookmessage), and [`MessageResponse`](reference/typescript/payloads#messageresponse) for message payloads. Use [`Modal`](reference/typescript/payloads#modal) and [`HomeTab`](reference/typescript/payloads#hometab) for Slack views.
+
+### Higher-level components
+
+[`Paginator`](reference/typescript/components#paginator) renders a selected page
+with previous and next controls. [`Accordion`](reference/typescript/components#accordion)
+groups Slack-native collapsible sections. Both expand directly inside `.blocks()`.
 
 ### Utilities
 

--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -50,18 +50,19 @@ pnpm add @nicklambourne/slackblocks
 ## Build a message
 
 ```ts
-import { message, sectionBlock } from "@nicklambourne/slackblocks";
+import { Message, SectionBlock } from "@nicklambourne/slackblocks";
 
-const payload = message({
-  channel: "C0123456",
-  text: "Hello from slackblocks!",
-  blocks: [sectionBlock({ text: "Hello, world!" })],
-});
+const payload = Message()
+  .channel("C0123456")
+  .text("Hello from slackblocks!")
+  .blocks(SectionBlock().text("Hello, world!"))
+  .build();
 
 console.log(JSON.stringify(payload, null, 2));
 ```
 
-Each factory validates its input and returns a plain Slack-compatible object. Factory inputs use camelCase; the resulting payload uses the snake_case keys expected by Slack.
+Each builder uses typed camelCase setters. `.build()` validates the completed
+payload and returns the plain snake_case object expected by Slack.
 
 </TypeScript>
 </LanguageContent>

--- a/docs/docs/reference/index.mdx
+++ b/docs/docs/reference/index.mdx
@@ -10,7 +10,7 @@ Looking for the exact class or constructor argument to use? The [Python API refe
 </Python>
 <TypeScript>
 
-Need the precise shape of a factory input or returned payload? The [TypeScript API reference](/reference/typescript) brings together every exported factory, interface, type, and validation error. Use it when you know what you want to build and need the exact TypeScript contract.
+Need the precise setter or returned payload type? The [TypeScript API reference](/reference/typescript) brings together every fluent builder, component, type, and validation error. Use it when you know what you want to build and need the exact TypeScript contract.
 
 </TypeScript>
 </LanguageContent>

--- a/docs/docs/typescript-messages-redirect.mdx
+++ b/docs/docs/typescript-messages-redirect.mdx
@@ -1,0 +1,23 @@
+---
+title: TypeScript Message Builders
+slug: /reference/typescript/messages
+sidebar_class_name: api-redirect
+pagination_next: null
+pagination_prev: null
+---
+
+# TypeScript Message Builders
+
+Message builders now live in the [Payloads reference](./payloads).
+
+## Message
+
+See [`Message()`](./payloads#message).
+
+## WebhookMessage
+
+See [`WebhookMessage()`](./payloads#webhookmessage).
+
+## MessageResponse
+
+See [`MessageResponse()`](./payloads#messageresponse).

--- a/docs/docs/typescript-views-redirect.mdx
+++ b/docs/docs/typescript-views-redirect.mdx
@@ -1,0 +1,19 @@
+---
+title: TypeScript View Builders
+slug: /reference/typescript/views
+sidebar_class_name: api-redirect
+pagination_next: null
+pagination_prev: null
+---
+
+# TypeScript View Builders
+
+View builders now live in the [Payloads reference](./payloads).
+
+## Modal
+
+See [`Modal()`](./payloads#modal).
+
+## HomeTab
+
+See [`HomeTab()`](./payloads#hometab).

--- a/docs/docs/usage/cookbook.mdx
+++ b/docs/docs/usage/cookbook.mdx
@@ -65,12 +65,12 @@ def build_status_message(
 
 ```ts
 import {
-  contextBlock,
-  dividerBlock,
-  headerBlock,
-  message,
-  mrkdwn,
-  sectionBlock,
+  ContextBlock,
+  DividerBlock,
+  HeaderBlock,
+  Markdown,
+  Message,
+  SectionBlock,
 } from "@nicklambourne/slackblocks";
 
 function buildStatusMessage(input: {
@@ -85,25 +85,23 @@ function buildStatusMessage(input: {
   const icon = input.passed ? ":white_check_mark:" : ":x:";
   const status = input.passed ? "passed" : "failed";
 
-  return message({
-    channel: input.channel,
-    text: `Build ${status} for ${input.project}@${input.branch}`,
-    blocks: [
-      headerBlock({ text: `${icon} ${input.project} build ${status}` }),
-      sectionBlock({
-        fields: [
-          `*Branch*\n\`${input.branch}\``,
-          `*Commit*\n\`${input.commit.slice(0, 7)}\``,
-          `*Author*\n${input.author}`,
-          `*Duration*\n${input.duration}`,
-        ],
-      }),
-      dividerBlock(),
-      contextBlock({
-        elements: [mrkdwn(`:calendar: Triggered by push to \`${input.branch}\``)],
-      }),
-    ],
-  });
+  return Message()
+    .channel(input.channel)
+    .text(`Build ${status} for ${input.project}@${input.branch}`)
+    .blocks(
+      HeaderBlock().text(`${icon} ${input.project} build ${status}`),
+      SectionBlock().fields(
+        `*Branch*\n\`${input.branch}\``,
+        `*Commit*\n\`${input.commit.slice(0, 7)}\``,
+        `*Author*\n${input.author}`,
+        `*Duration*\n${input.duration}`,
+      ),
+      DividerBlock(),
+      ContextBlock().elements(
+        Markdown().text(`:calendar: Triggered by push to \`${input.branch}\``),
+      ),
+    )
+    .build();
 }
 ```
 

--- a/docs/docs/usage/installation.mdx
+++ b/docs/docs/usage/installation.mdx
@@ -88,12 +88,14 @@ The package requires Node 20.19 or newer, is ESM-only, and emits no runtime impo
 Verify the installation in `hello.mjs`:
 
 ```ts
-import { message, sectionBlock } from "@nicklambourne/slackblocks";
+import { Message, SectionBlock } from "@nicklambourne/slackblocks";
 
-console.log(message({
-  channel: "C0123456",
-  blocks: [sectionBlock({ text: "Hello, world!" })],
-}));
+console.log(
+  Message()
+    .channel("C0123456")
+    .blocks(SectionBlock().text("Hello, world!"))
+    .build(),
+);
 ```
 
 Run it with `node hello.mjs`. Stay on the 2.x release line with `@nicklambourne/slackblocks@^2.1.0`, and uninstall with `pnpm remove @nicklambourne/slackblocks` (or your package manager's equivalent).

--- a/docs/docs/usage/sending_messages.mdx
+++ b/docs/docs/usage/sending_messages.mdx
@@ -169,17 +169,17 @@ urllib.request.urlopen(req)
 
 ## With `@slack/web-api`
 
-Factories return plain Slack-shaped objects, so pass the payload directly to the official client:
+`.build()` returns a plain Slack-shaped object, so pass the payload directly to the official client:
 
 ```ts
 import { WebClient } from "@slack/web-api";
-import { message, sectionBlock } from "@nicklambourne/slackblocks";
+import { Message, SectionBlock } from "@nicklambourne/slackblocks";
 
 const client = new WebClient(process.env.SLACK_API_TOKEN);
-const payload = message({
-  channel: "C0123456",
-  blocks: [sectionBlock({ text: "Hello, world!" })],
-});
+const payload = Message()
+  .channel("C0123456")
+  .blocks(SectionBlock().text("Hello, world!"))
+  .build();
 
 await client.chat.postMessage(payload);
 ```
@@ -190,12 +190,14 @@ Use a channel ID rather than a display name when possible. Provide a `text` fall
 
 ```ts
 import { IncomingWebhook } from "@slack/webhook";
-import { sectionBlock, webhookMessage } from "@nicklambourne/slackblocks";
+import { SectionBlock, WebhookMessage } from "@nicklambourne/slackblocks";
 
 const webhook = new IncomingWebhook(process.env.SLACK_WEBHOOK_URL!);
-await webhook.send(webhookMessage({
-  blocks: [sectionBlock({ text: "Build complete :white_check_mark:" })],
-}));
+await webhook.send(
+  WebhookMessage()
+    .blocks(SectionBlock().text("Build complete :white_check_mark:"))
+    .build(),
+);
 ```
 
 ## Slash-command and interaction responses
@@ -203,25 +205,25 @@ await webhook.send(webhookMessage({
 Construct the response body, then return it through your web framework:
 
 ```ts
-import { messageResponse, sectionBlock } from "@nicklambourne/slackblocks";
+import { MessageResponse, SectionBlock } from "@nicklambourne/slackblocks";
 
-const responseBody = messageResponse({
-  blocks: [sectionBlock({ text: "Got it! Working on that now..." })],
-  responseType: "ephemeral",
-});
+const responseBody = MessageResponse()
+  .blocks(SectionBlock().text("Got it! Working on that now..."))
+  .responseType("ephemeral")
+  .build();
 ```
 
 ## Modals and home tabs
 
 ```ts
-import { modal, sectionBlock } from "@nicklambourne/slackblocks";
+import { Modal, SectionBlock } from "@nicklambourne/slackblocks";
 
-const view = modal({
-  title: "Confirm action",
-  blocks: [sectionBlock({ text: "Are you sure?" })],
-  submit: "Yes",
-  close: "Cancel",
-});
+const view = Modal()
+  .title("Confirm action")
+  .blocks(SectionBlock().text("Are you sure?"))
+  .submit("Yes")
+  .close("Cancel")
+  .build();
 
 await client.views.open({ trigger_id: triggerId, view });
 ```

--- a/docs/docs/usage/troubleshooting.mdx
+++ b/docs/docs/usage/troubleshooting.mdx
@@ -152,22 +152,22 @@ Use [GitHub Issues](https://github.com/nicklambourne/slackblocks/issues).
 
 ## Why is my message showing literal `*asterisks*` instead of bold text?
 
-Slack supports `mrkdwn` and `plain_text`. The `sectionBlock()` factory turns a string into `mrkdwn` by default, but Slack requires headers, button labels, modal titles, input labels, and option labels to use `plain_text`. Markdown syntax in those fields is displayed literally.
+Slack supports `mrkdwn` and `plain_text`. `SectionBlock().text()` turns a string into `mrkdwn` by default, but Slack requires headers, button labels, modal titles, input labels, and option labels to use `plain_text`. Markdown syntax in those fields is displayed literally.
 
-If styling is missing from a field that supports it, check that you have not wrapped the value with `plainText()`. Use `mrkdwn()` when you need to choose the text type explicitly.
+If styling is missing from a field that supports it, check that you have not wrapped the value with `PlainText()`. Use `Markdown()` when you need to choose the text type explicitly.
 
 ## Why does Slack say `text` is required?
 
 Messages containing blocks should also provide a short plain-text fallback. Slack uses it for push notifications, assistive technology, and clients that cannot render Block Kit.
 
 ```ts
-import { headerBlock, message } from "@nicklambourne/slackblocks";
+import { HeaderBlock, Message } from "@nicklambourne/slackblocks";
 
-const payload = message({
-  channel: "C0123456",
-  text: "Build #482 passed",
-  blocks: [headerBlock({ text: "Build #482 passed :white_check_mark:" })],
-});
+const payload = Message()
+  .channel("C0123456")
+  .text("Build #482 passed")
+  .blocks(HeaderBlock().text("Build #482 passed :white_check_mark:"))
+  .build();
 ```
 
 ## What is `blockId` for? Should I set it?
@@ -177,47 +177,45 @@ const payload = message({
 You can omit it for non-interactive content. For interactive messages and views, use a stable value that your handlers understand:
 
 ```ts
-import { actionsBlock, button } from "@nicklambourne/slackblocks";
+import { ActionsBlock, Button } from "@nicklambourne/slackblocks";
 
-actionsBlock({
-  blockId: "approval:req-123",
-  elements: [
-    button({ text: "Approve", actionId: "approve", value: "req-123" }),
-  ],
-});
+ActionsBlock()
+  .blockId("approval:req-123")
+  .elements(Button().text("Approve").actionId("approve").value("req-123"))
+  .build();
 ```
 
 The same principle applies to `actionId`, which becomes `action_id` on the wire.
 
 ## What do `LengthError` and the other validation errors mean?
 
-`slackblocks` validates payloads while its factories construct them. An error such as `LengthError`, `RangeError`, or `MissingRequiredError` means the input would violate a known Block Kit rule. The error includes a path so you can find the invalid field before sending anything to Slack.
+`slackblocks` validates the complete object when `.build()` is called. An error such as `LengthError`, `OutOfRangeError`, or `MissingRequiredError` means the input would violate a known Block Kit rule. The error includes a path so you can find the invalid field before sending anything to Slack.
 
 Common limits include:
 
-| Factory field                       | Limit |
+| Builder field                       | Limit |
 |-------------------------------------|-------|
-| `sectionBlock().text`               | 3,000 characters |
-| `sectionBlock().fields[i]`          | 2,000 characters |
-| `headerBlock().text`                | 150 characters |
-| `button().text`                     | 75 characters |
-| `button().value`                    | 2,000 characters |
-| `button().url`                      | 3,000 characters |
-| `modal().title` / `submit` / `close`| 24 characters |
+| `SectionBlock().text()`             | 3,000 characters |
+| `SectionBlock().fields()` items     | 2,000 characters |
+| `HeaderBlock().text()`              | 150 characters |
+| `Button().text()`                   | 75 characters |
+| `Button().value()`                  | 2,000 characters |
+| `Button().url()`                    | 3,000 characters |
+| `Modal().title()` / `submit()` / `close()` | 24 characters |
 | `actionId`                          | 255 characters |
 | `privateMetadata`                   | 3,000 characters |
-| `option().url`                      | 3,000 characters |
+| `Option().url()`                    | 3,000 characters |
 
-If Slack adds a field or raises a limit before the package catches up, pass `{ validate: false }` as the final factory argument for that construction only.
+If Slack adds a field or raises a limit before the package catches up, pass `{ validate: false }` to `.build()` for that construction only.
 
 ## How many blocks can a payload contain?
 
 - Channel messages: **50 blocks**.
 - Modals and home tabs: **100 blocks**.
-- `contextBlock()`: up to **10 elements**.
-- `actionsBlock()`: up to **25 elements**.
-- `sectionBlock().fields`: up to **10 items**.
-- `tableBlock()`: up to **100 rows × 20 columns**.
+- `ContextBlock()`: up to **10 elements**.
+- `ActionsBlock()`: up to **25 elements**.
+- `SectionBlock().fields()`: up to **10 items**.
+- `TableBlock()`: up to **100 rows × 20 columns**.
 
 ## Why don't my buttons or selects do anything when clicked?
 
@@ -225,22 +223,22 @@ If Slack adds a field or raises a limit before the package catches up, pass `{ v
 
 [`@slack/bolt`](https://slack.dev/bolt-js/) is the usual starting point for a TypeScript or JavaScript app.
 
-## Why doesn't markdown work inside `headerBlock()`?
+## Why doesn't markdown work inside `HeaderBlock()`?
 
-Slack only accepts `plain_text` in header blocks. Use `sectionBlock()` followed by `dividerBlock()` when you need styled heading text.
+Slack only accepts `plain_text` in header blocks. Use `SectionBlock()` followed by `DividerBlock()` when you need styled heading text.
 
 ## How can I preview a message without sending it?
 
 Generate a Block Kit Builder URL and open it in your browser:
 
 ```ts
-import { blockKitBuilderUrl, message, sectionBlock } from "@nicklambourne/slackblocks";
+import { blockKitBuilderUrl, Message, SectionBlock } from "@nicklambourne/slackblocks";
 
-const payload = message({
-  channel: "C0123456",
-  text: "Preview message",
-  blocks: [sectionBlock({ text: "Hello!" })],
-});
+const payload = Message()
+  .channel("C0123456")
+  .text("Preview message")
+  .blocks(SectionBlock().text("Hello!"))
+  .build();
 
 console.log(blockKitBuilderUrl(payload));
 ```
@@ -249,16 +247,16 @@ You can also paste `JSON.stringify(payload, null, 2)` into Slack's [Block Kit Bu
 
 ## How do I send a payload with `fetch()`?
 
-Factories return plain objects, so no conversion step is required:
+`.build()` returns a plain object, so no conversion step is required:
 
 ```ts
-import { message, sectionBlock } from "@nicklambourne/slackblocks";
+import { Message, SectionBlock } from "@nicklambourne/slackblocks";
 
-const payload = message({
-  channel: "C0123456",
-  text: "Hello!",
-  blocks: [sectionBlock({ text: "Hello!" })],
-});
+const payload = Message()
+  .channel("C0123456")
+  .text("Hello!")
+  .blocks(SectionBlock().text("Hello!"))
+  .build();
 
 const response = await fetch("https://slack.com/api/chat.postMessage", {
   method: "POST",
@@ -274,11 +272,11 @@ if (!response.ok) throw new Error(`Slack returned ${response.status}`);
 
 ## Can I use `slackblocks` in async code?
 
-Yes. The factories are synchronous, side-effect-free functions that return ordinary objects. Construct the payload wherever it is convenient, then `await` your Slack SDK or HTTP client when you send it.
+Yes. The builders are synchronous and side-effect-free. Construct and build the payload wherever it is convenient, then `await` your Slack SDK or HTTP client when you send it.
 
 ## How does this differ from `@slack/types`?
 
-`@slack/types` supplies TypeScript definitions for Slack payloads. `slackblocks` adds small construction helpers, camelCase inputs, snake_case wire output, and eager validation with path-aware errors. The resulting objects remain compatible with Slack's official types and clients.
+`@slack/types` supplies TypeScript definitions for Slack payloads. `slackblocks` adds fluent construction, camelCase setters, snake_case wire output, and build-time validation with path-aware errors. The resulting objects remain compatible with Slack's official types and clients.
 
 ## Where do I report bugs or request features?
 

--- a/docs/docs/usage/using_blocks.mdx
+++ b/docs/docs/usage/using_blocks.mdx
@@ -21,7 +21,7 @@ For the reverse mapping — looking up a class by name — see the [Blocks refer
 </Python>
 <TypeScript>
 
-For exact factory inputs and return types, see the [TypeScript API reference](../reference/typescript). Interactive controls such as buttons, menus, and date pickers are documented alongside the other element factories.
+For exact setters and return types, see the [TypeScript API reference](../reference/typescript). Interactive controls such as buttons, menus, and date pickers are documented alongside the other element builders.
 
 </TypeScript>
 </LanguageContent>
@@ -57,21 +57,17 @@ SectionBlock(
 <TypeScript>
 
 ```ts
-import { checkboxes, mrkdwn, option, sectionBlock } from "@nicklambourne/slackblocks";
+import { Checkboxes, Markdown, Option, SectionBlock } from "@nicklambourne/slackblocks";
 
-sectionBlock({
-  text: "This is a section block with a checkbox accessory.",
-  blockId: "fake_block_id",
-  accessory: checkboxes({
-    actionId: "checkboxes-action",
-    options: [
-      option({
-        text: mrkdwn("*Your Only Option*"),
-        value: "option_one",
-      }),
-    ],
-  }),
-});
+SectionBlock()
+  .text("This is a section block with a checkbox accessory.")
+  .blockId("fake_block_id")
+  .accessory(
+    Checkboxes()
+      .actionId("checkboxes-action")
+      .options(Option().text(Markdown().text("*Your Only Option*")).value("option_one")),
+  )
+  .build();
 ```
 
 </TypeScript>
@@ -150,18 +146,18 @@ RichTextBlock(
 <TypeScript>
 
 ```ts
-import { richText, richTextBlock, richTextSection } from "@nicklambourne/slackblocks";
+import { RichText, RichTextBlock, RichTextSection } from "@nicklambourne/slackblocks";
 
-richTextBlock({
-  blockId: "fake_block_id",
-  elements: [
-    richTextSection([
-      richText("You 'bout to witness hip-hop in its most purest\n", { bold: true }),
-      richText("Most rawest form, flow almost flawless\n", { strike: true }),
-      richText("Most hardest, most honest known artist\n", { italic: true }),
-    ]),
-  ],
-});
+RichTextBlock()
+  .blockId("fake_block_id")
+  .elements(
+    RichTextSection().elements(
+      RichText().text("You 'bout to witness hip-hop in its most purest\n").style({ bold: true }),
+      RichText().text("Most rawest form, flow almost flawless\n").style({ strike: true }),
+      RichText().text("Most hardest, most honest known artist\n").style({ italic: true }),
+    ),
+  )
+  .build();
 ```
 
 </TypeScript>
@@ -237,12 +233,9 @@ HeaderBlock(
 <TypeScript>
 
 ```ts
-import { headerBlock } from "@nicklambourne/slackblocks";
+import { HeaderBlock } from "@nicklambourne/slackblocks";
 
-headerBlock({
-  text: "This is a header block",
-  blockId: "fake_block_id",
-});
+HeaderBlock().text("This is a header block").blockId("fake_block_id").build();
 ```
 
 </TypeScript>
@@ -298,12 +291,12 @@ MarkdownBlock(
 <TypeScript>
 
 ```ts
-import { markdownBlock } from "@nicklambourne/slackblocks";
+import { MarkdownBlock } from "@nicklambourne/slackblocks";
 
-markdownBlock({
-  text: "**Hello!** Markdown blocks support _GitHub-flavored_ syntax.",
-  blockId: "fake_block_id",
-});
+MarkdownBlock()
+  .text("**Hello!** Markdown blocks support _GitHub-flavored_ syntax.")
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -351,14 +344,14 @@ ImageBlock(
 <TypeScript>
 
 ```ts
-import { imageBlock } from "@nicklambourne/slackblocks";
+import { ImageBlock } from "@nicklambourne/slackblocks";
 
-imageBlock({
-  imageUrl: "https://api.slack.com/img/blocks/bkb_template_images/beagle.png",
-  altText: "a beagle",
-  title: "dog",
-  blockId: "fake_block_id",
-});
+ImageBlock()
+  .imageUrl("https://api.slack.com/img/blocks/bkb_template_images/beagle.png")
+  .altText("a beagle")
+  .title("dog")
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -415,15 +408,15 @@ InputBlock(
 <TypeScript>
 
 ```ts
-import { inputBlock, plainText, plainTextInput } from "@nicklambourne/slackblocks";
+import { InputBlock, PlainText, PlainTextInput } from "@nicklambourne/slackblocks";
 
-inputBlock({
-  label: plainText("Label", { emoji: true }),
-  hint: plainText("Hint", { emoji: true }),
-  element: plainTextInput({ actionId: "action" }),
-  blockId: "fake_block_id",
-  optional: true,
-});
+InputBlock()
+  .label(PlainText().text("Label").emoji(true))
+  .hint(PlainText().text("Hint").emoji(true))
+  .element(PlainTextInput().actionId("action"))
+  .blockId("fake_block_id")
+  .optional(true)
+  .build();
 ```
 
 </TypeScript>
@@ -483,9 +476,9 @@ DividerBlock(block_id="fake_block_id")
 <TypeScript>
 
 ```ts
-import { dividerBlock } from "@nicklambourne/slackblocks";
+import { DividerBlock } from "@nicklambourne/slackblocks";
 
-dividerBlock({ blockId: "fake_block_id" });
+DividerBlock().blockId("fake_block_id").build();
 ```
 
 </TypeScript>
@@ -533,12 +526,9 @@ FileBlock(
 <TypeScript>
 
 ```ts
-import { fileBlock } from "@nicklambourne/slackblocks";
+import { FileBlock } from "@nicklambourne/slackblocks";
 
-fileBlock({
-  externalId: "external_id",
-  blockId: "fake_block_id",
-});
+FileBlock().externalId("external_id").blockId("fake_block_id").build();
 ```
 
 </TypeScript>
@@ -591,12 +581,12 @@ ContextBlock(
 <TypeScript>
 
 ```ts
-import { contextBlock, mrkdwn } from "@nicklambourne/slackblocks";
+import { ContextBlock, Markdown } from "@nicklambourne/slackblocks";
 
-contextBlock({
-  elements: [mrkdwn("Hello, world!")],
-  blockId: "fake_block_id",
-});
+ContextBlock()
+  .elements(Markdown().text("Hello, world!"))
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -656,23 +646,23 @@ ActionsBlock(
 <TypeScript>
 
 ```ts
-import { actionsBlock, checkboxes, mrkdwn, option, plainText } from "@nicklambourne/slackblocks";
+import { ActionsBlock, Checkboxes, Markdown, Option, PlainText } from "@nicklambourne/slackblocks";
 
-actionsBlock({
-  blockId: "fake_block_id",
-  elements: [
-    checkboxes({
-      actionId: "actionId-0",
-      options: ["a", "b", "c"].map((value) =>
-        option({
-          text: mrkdwn(`*${value}*`),
-          value,
-          description: plainText(`*${value}*`),
-        }),
+ActionsBlock()
+  .blockId("fake_block_id")
+  .elements(
+    Checkboxes()
+      .actionId("actionId-0")
+      .options(
+        ["a", "b", "c"].map((value) =>
+          Option()
+            .text(Markdown().text(`*${value}*`))
+            .value(value)
+            .description(PlainText().text(`*${value}*`)),
+        ),
       ),
-    }),
-  ],
-});
+  )
+  .build();
 ```
 
 </TypeScript>
@@ -792,40 +782,38 @@ TableBlock(
 
 ```ts
 import {
-  columnSettings,
-  rawText,
-  richText,
-  richTextBlock,
-  richTextLink,
-  richTextSection,
-  tableBlock,
+  ColumnSettings,
+  RawText,
+  RichText,
+  RichTextBlock,
+  RichTextLink,
+  RichTextSection,
+  TableBlock,
 } from "@nicklambourne/slackblocks";
 
-tableBlock({
-  blockId: "fake_block_id",
-  columnSettings: [
-    columnSettings({ align: "right", isWrapped: true }),
-    columnSettings({ align: "left" }),
-  ],
-  rows: [
-    [
-      richTextBlock({
-        elements: [richTextSection([richText("Header 1", { bold: true })])],
-      }),
-      richTextBlock({
-        elements: [richTextSection([richText("Header 2", { bold: true })])],
-      }),
-    ],
-    [
-      rawText("Datum 1"),
-      richTextBlock({
-        elements: [
-          richTextSection([richTextLink({ url: "https://slack.com", text: "Datum 2" })]),
-        ],
-      }),
-    ],
-  ],
-});
+TableBlock()
+  .blockId("fake_block_id")
+  .columnSettings(
+    ColumnSettings().align("right").isWrapped(true),
+    ColumnSettings().align("left"),
+  )
+  .rows([
+    RichTextBlock().elements(
+      RichTextSection().elements(RichText().text("Header 1").style({ bold: true })),
+    ),
+    RichTextBlock().elements(
+      RichTextSection().elements(RichText().text("Header 2").style({ bold: true })),
+    ),
+  ])
+  .rows([
+    RawText().text("Datum 1"),
+    RichTextBlock().elements(
+      RichTextSection().elements(
+        RichTextLink().url("https://slack.com").text("Datum 2"),
+      ),
+    ),
+  ])
+  .build();
 ```
 
 </TypeScript>
@@ -952,19 +940,19 @@ VideoBlock(
 <TypeScript>
 
 ```ts
-import { videoBlock } from "@nicklambourne/slackblocks";
+import { VideoBlock } from "@nicklambourne/slackblocks";
 
-videoBlock({
-  altText: "How to use slackblocks",
-  blockId: "fake_block_id",
-  thumbnailUrl: "https://example.com/thumb.png",
-  title: "Getting Started",
-  videoUrl: "https://example.com/video.mp4",
-  authorName: "The slackblocks docs",
-  description: "A short walkthrough.",
-  providerName: "example.com",
-  titleUrl: "https://example.com",
-});
+VideoBlock()
+  .altText("How to use slackblocks")
+  .blockId("fake_block_id")
+  .thumbnailUrl("https://example.com/thumb.png")
+  .title("Getting Started")
+  .videoUrl("https://example.com/video.mp4")
+  .authorName("The slackblocks docs")
+  .description("A short walkthrough.")
+  .providerName("example.com")
+  .titleUrl("https://example.com")
+  .build();
 ```
 
 </TypeScript>
@@ -1024,13 +1012,13 @@ AlertBlock(
 <TypeScript>
 
 ```ts
-import { alertBlock } from "@nicklambourne/slackblocks";
+import { AlertBlock } from "@nicklambourne/slackblocks";
 
-alertBlock({
-  text: "The deployment needs attention.",
-  level: "warning",
-  blockId: "fake_block_id",
-});
+AlertBlock()
+  .text("The deployment needs attention.")
+  .level("warning")
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1085,15 +1073,15 @@ CardBlock(
 <TypeScript>
 
 ```ts
-import { button, cardBlock, slackIcon } from "@nicklambourne/slackblocks";
+import { Button, CardBlock, SlackIcon } from "@nicklambourne/slackblocks";
 
-cardBlock({
-  title: "Build complete",
-  body: "Version 2.1.0 is ready to deploy.",
-  slackIcon: slackIcon("rocket"),
-  actions: [button({ text: "Open build", actionId: "open_build" })],
-  blockId: "fake_block_id",
-});
+CardBlock()
+  .title("Build complete")
+  .body("Version 2.1.0 is ready to deploy.")
+  .slackIcon(SlackIcon().name("rocket"))
+  .actions(Button().text("Open build").actionId("open_build"))
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1162,15 +1150,15 @@ CarouselBlock([
 <TypeScript>
 
 ```ts
-import { cardBlock, carouselBlock } from "@nicklambourne/slackblocks";
+import { CardBlock, CarouselBlock } from "@nicklambourne/slackblocks";
 
-carouselBlock({
-  elements: [
-    cardBlock({ title: "First result", blockId: "card_1" }),
-    cardBlock({ title: "Second result", blockId: "card_2" }),
-  ],
-  blockId: "fake_block_id",
-});
+CarouselBlock()
+  .elements(
+    CardBlock().title("First result").blockId("card_1"),
+    CardBlock().title("Second result").blockId("card_2"),
+  )
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1239,22 +1227,19 @@ ContainerBlock(
 <TypeScript>
 
 ```ts
-import { containerBlock, sectionBlock } from "@nicklambourne/slackblocks";
+import { ContainerBlock, SectionBlock } from "@nicklambourne/slackblocks";
 
-containerBlock({
-  title: "Deployment summary",
-  childBlocks: [
-    sectionBlock({
-      text: "All systems operational.",
-      blockId: "child_1",
-    }),
-  ],
-  width: "standard",
-  isCollapsible: false,
-  defaultCollapsed: false,
-  hasHeaderDivider: true,
-  blockId: "fake_block_id",
-});
+ContainerBlock()
+  .title("Deployment summary")
+  .childBlocks(
+    SectionBlock().text("All systems operational.").blockId("child_1"),
+  )
+  .width("standard")
+  .isCollapsible(false)
+  .defaultCollapsed(false)
+  .hasHeaderDivider(true)
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1322,18 +1307,17 @@ ContextActionsBlock([
 <TypeScript>
 
 ```ts
-import { contextActionsBlock, feedbackButton, feedbackButtons } from "@nicklambourne/slackblocks";
+import { ContextActionsBlock, FeedbackButton, FeedbackButtons } from "@nicklambourne/slackblocks";
 
-contextActionsBlock({
-  elements: [
-    feedbackButtons({
-      actionId: "response_feedback",
-      positiveButton: feedbackButton({ text: "Good", value: "positive" }),
-      negativeButton: feedbackButton({ text: "Bad", value: "negative" }),
-    }),
-  ],
-  blockId: "fake_block_id",
-});
+ContextActionsBlock()
+  .elements(
+    FeedbackButtons()
+      .actionId("response_feedback")
+      .positiveButton(FeedbackButton().text("Good").value("positive"))
+      .negativeButton(FeedbackButton().text("Bad").value("negative")),
+  )
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1404,16 +1388,14 @@ DataTableBlock(
 <TypeScript>
 
 ```ts
-import { dataTableBlock, rawNumber, rawText } from "@nicklambourne/slackblocks";
+import { DataTableBlock, RawNumber, RawText } from "@nicklambourne/slackblocks";
 
-dataTableBlock({
-  caption: "Team scores",
-  rows: [
-    [rawText("Name"), rawText("Score")],
-    [rawText("Alice"), rawNumber(42, "42")],
-  ],
-  blockId: "fake_block_id",
-});
+DataTableBlock()
+  .caption("Team scores")
+  .rows([RawText().text("Name"), RawText().text("Score")])
+  .rows([RawText().text("Alice"), RawNumber().value(42).text("42")])
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1490,16 +1472,18 @@ DataVisualizationBlock(
 <TypeScript>
 
 ```ts
-import { chartSegment, dataVisualizationBlock, pieChart } from "@nicklambourne/slackblocks";
+import { ChartSegment, DataVisualizationBlock, PieChart } from "@nicklambourne/slackblocks";
 
-dataVisualizationBlock({
-  title: "Incidents by severity",
-  chart: pieChart([
-    chartSegment({ label: "High", value: 3 }),
-    chartSegment({ label: "Low", value: 12 }),
-  ]),
-  blockId: "fake_block_id",
-});
+DataVisualizationBlock()
+  .title("Incidents by severity")
+  .chart(
+    PieChart().segments(
+      ChartSegment().label("High").value(3),
+      ChartSegment().label("Low").value(12),
+    ),
+  )
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1563,15 +1547,15 @@ TaskCardBlock(
 <TypeScript>
 
 ```ts
-import { taskCardBlock, urlSource } from "@nicklambourne/slackblocks";
+import { TaskCardBlock, UrlSource } from "@nicklambourne/slackblocks";
 
-taskCardBlock({
-  taskId: "weather_1",
-  title: "Fetch weather data",
-  status: "complete",
-  sources: [urlSource({ url: "https://weather.com/", text: "weather.com" })],
-  blockId: "fake_block_id",
-});
+TaskCardBlock()
+  .taskId("weather_1")
+  .title("Fetch weather data")
+  .status("complete")
+  .sources(UrlSource().url("https://weather.com/").text("weather.com"))
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1632,16 +1616,16 @@ PlanBlock(
 <TypeScript>
 
 ```ts
-import { planBlock, taskCardBlock } from "@nicklambourne/slackblocks";
+import { PlanBlock, TaskCardBlock } from "@nicklambourne/slackblocks";
 
-planBlock({
-  title: "Release plan",
-  tasks: [
-    taskCardBlock({ taskId: "test", title: "Run the test suite", status: "complete" }),
-    taskCardBlock({ taskId: "deploy", title: "Deploy the release", status: "pending" }),
-  ],
-  blockId: "fake_block_id",
-});
+PlanBlock()
+  .title("Release plan")
+  .tasks(
+    TaskCardBlock().taskId("test").title("Run the test suite").status("complete"),
+    TaskCardBlock().taskId("deploy").title("Deploy the release").status("pending"),
+  )
+  .blockId("fake_block_id")
+  .build();
 ```
 
 </TypeScript>
@@ -1677,3 +1661,77 @@ planBlock({
 
 </TabItem>
 </Tabs>
+
+<LanguageContent>
+<TypeScript>
+
+## Higher-Level Components
+
+Components package common layout behavior while still producing ordinary Block Kit
+blocks. Pass them directly to a fluent collection setter such as `Message().blocks()`;
+the parent expands the component when you call `.build()`.
+
+### Paginator
+
+`Paginator()` selects one page of content and adds standard context and actions blocks
+for navigation. Its previous and next button values contain the one-based page number
+your interaction handler should render next.
+
+```ts
+import { Message, Paginator, SectionBlock } from "@nicklambourne/slackblocks";
+
+const payload = Message()
+  .channel("C01234567")
+  .text("Search results")
+  .blocks(
+    Paginator()
+      .blocks(
+        SectionBlock().text("Result one"),
+        SectionBlock().text("Result two"),
+        SectionBlock().text("Result three"),
+      )
+      .actionIdPrefix("search-results")
+      .page(1)
+      .pageSize(2),
+  )
+  .build();
+```
+
+The component is deliberately state-free: your Slack action handler reads the button
+value, creates the same paginator with that page, and updates the message.
+
+### Accordion
+
+`Accordion()` expands into Slack-native collapsible container blocks, so expanding and
+collapsing sections does not require an application-side interaction handler.
+
+```ts
+import {
+  Accordion,
+  AccordionSection,
+  Message,
+  SectionBlock,
+} from "@nicklambourne/slackblocks";
+
+const payload = Message()
+  .channel("C01234567")
+  .text("Deployment details")
+  .blocks(
+    Accordion().sections(
+      AccordionSection()
+        .title("Summary")
+        .expanded(true)
+        .blocks(SectionBlock().text("Version 2.2.0 is ready.")),
+      AccordionSection()
+        .title("Checks")
+        .blocks(SectionBlock().text("All required checks passed.")),
+    ),
+  )
+  .build();
+```
+
+See [Components](../reference/typescript/components) for every setter and validation
+rule.
+
+</TypeScript>
+</LanguageContent>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -134,13 +134,12 @@ const TYPESCRIPT_TYPE_ALIAS_NAMES = new Set([
 
 const TYPESCRIPT_DOMAIN_TITLES: Record<string, string> = {
   blocks: "Blocks",
+  components: "Components",
   elements: "Elements",
   errors: "Errors",
-  messages: "Messages",
   objects: "Composition Objects",
-  "rich-text": "Rich Text",
+  payloads: "Payloads",
   utilities: "Utilities",
-  views: "Views",
 };
 
 function typescriptDomainTitle({ rawName }: { rawName: string }): string {
@@ -225,12 +224,11 @@ const config: Config = {
       {
         name: "TypeScript API reference",
         entryPoints: [
-          "../typescript/src/legacy/blocks.ts",
-          "../typescript/src/legacy/elements.ts",
-          "../typescript/src/legacy/objects.ts",
-          "../typescript/src/legacy/rich-text.ts",
-          "../typescript/src/legacy/messages.ts",
-          "../typescript/src/legacy/views.ts",
+          "../typescript/src/fluent/blocks.ts",
+          "../typescript/src/fluent/components.ts",
+          "../typescript/src/fluent/elements.ts",
+          "../typescript/src/fluent/objects.ts",
+          "../typescript/src/fluent/payloads.ts",
           "../typescript/src/utilities-reference.ts",
           "../typescript/src/errors.ts",
         ],
@@ -280,6 +278,10 @@ const config: Config = {
           { from: "/reference/rich_text", to: "/reference/python/rich_text" },
           { from: "/reference/utils", to: "/reference/python/builder" },
           { from: "/reference/views", to: "/reference/python/views" },
+          {
+            from: "/reference/typescript/rich-text",
+            to: "/reference/typescript/objects",
+          },
         ],
         createRedirects: legacyTypeScriptRedirect,
       },

--- a/docs/scripts/check_typescript_api_docs.mjs
+++ b/docs/scripts/check_typescript_api_docs.mjs
@@ -3,24 +3,20 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 const SOURCE_FILES = [
-  "../../typescript/src/legacy/blocks.ts",
-  "../../typescript/src/legacy/elements.ts",
-  "../../typescript/src/legacy/objects.ts",
-  "../../typescript/src/legacy/rich-text.ts",
-  "../../typescript/src/legacy/messages.ts",
-  "../../typescript/src/legacy/views.ts",
+  "../../typescript/src/fluent/blocks.ts",
+  "../../typescript/src/fluent/components.ts",
+  "../../typescript/src/fluent/elements.ts",
+  "../../typescript/src/fluent/objects.ts",
+  "../../typescript/src/fluent/payloads.ts",
   "../../typescript/src/builder.ts",
   "../../typescript/src/types.ts",
   "../../typescript/src/validation.ts",
   "../../typescript/src/errors.ts",
 ];
 
-const THROWS_REQUIRED_FILES = new Set([
-  "../../typescript/src/legacy/blocks.ts",
-  "../../typescript/src/legacy/elements.ts",
-  "../../typescript/src/legacy/messages.ts",
-  "../../typescript/src/legacy/views.ts",
-]);
+const FLUENT_FILES = new Set(
+  SOURCE_FILES.filter((sourcePath) => sourcePath.includes("/fluent/")),
+);
 
 const failures = [];
 
@@ -134,16 +130,13 @@ for (const sourcePath of SOURCE_FILES) {
     if (!isExported(statement) || !statement.name) continue;
     const location = `${sourcePath}:${statement.name.getText()}`;
     if (ts.isFunctionDeclaration(statement)) {
-      inspectFunction(statement, location, THROWS_REQUIRED_FILES.has(sourcePath));
-      if (sourcePath.endsWith("/elements.ts")) {
-        const input = statement.parameters.find(
-          (parameter) => parameter.name.getText() === "input",
-        );
-        if (input?.type?.getText().includes("ActionInput")) {
-          failures.push(
-            `${location}(input): use a documented factory-specific input type`,
-          );
+      if (FLUENT_FILES.has(sourcePath)) {
+        requireDocumentation(statement, location);
+        if (!/^[A-Z]/.test(statement.name.getText())) {
+          failures.push(`${location}: fluent builders must use PascalCase`);
         }
+      } else {
+        inspectFunction(statement, location, false);
       }
     } else if (ts.isInterfaceDeclaration(statement)) inspectInterface(statement, location);
     else if (ts.isClassDeclaration(statement)) inspectClass(statement, location);

--- a/docs/scripts/check_typescript_api_rendering.mjs
+++ b/docs/scripts/check_typescript_api_rendering.mjs
@@ -33,6 +33,18 @@ const blocks = await readFile(
   path.join(referenceDirectory, "blocks.md"),
   "utf8",
 );
+const components = await readFile(
+  path.join(referenceDirectory, "components.md"),
+  "utf8",
+);
+const payloads = await readFile(
+  path.join(referenceDirectory, "payloads.md"),
+  "utf8",
+);
+const objects = await readFile(
+  path.join(referenceDirectory, "objects.md"),
+  "utf8",
+);
 
 function functionSection(contents, name) {
   const heading = `## ${name}()`;
@@ -42,46 +54,45 @@ function functionSection(contents, name) {
   return contents.slice(start, end === -1 ? contents.length : end);
 }
 
-const blockFactories = [
-  ...blocks.matchAll(/^## ([A-Za-z_$][\w$]*Block)\(\)$/gm),
-];
+const fluentPages = [blocks, components, elements, objects, payloads];
+const blockFactories = [...blocks.matchAll(/^## ([A-Z][\w$]*Block)\(\)$/gm)];
 assert.ok(blockFactories.length > 0, "No block factories were rendered");
 
 for (const [, name] of blockFactories) {
   const section = functionSection(blocks, name);
   assert.match(
     section,
-    /^### Input fields$/m,
-    `${name} must show its object fields directly`,
+    /^### Chainable setters$/m,
+    `${name} must show its fluent setters directly`,
   );
   assert.doesNotMatch(
     section,
-    /^### Parameters$/m,
-    `${name} must not group its object fields under a parameter`,
+    /^### Input fields$/m,
+    `${name} must not document the retired object-input convention`,
   );
   assert.match(
     section,
-    /^### Settings$/m,
-    `${name} must keep factory settings separate from its input fields`,
+    /^### Validation and errors$/m,
+    `${name} must document build-time validation`,
   );
 }
 
-const channelMultiSelect = functionSection(elements, "channelMultiSelect");
+const channelMultiSelect = functionSection(elements, "ChannelMultiSelect");
 assert.match(
   channelMultiSelect,
-  /^### Input fields$/m,
-  "Named input interfaces must be expanded beside their factories",
+  /^### Chainable setters$/m,
+  "Named input interfaces must be expanded beside their fluent builders",
 );
 assert.match(
   channelMultiSelect,
-  /^\| `initialChannels\?` \|/m,
-  "Expanded input tables must retain named interface fields",
+  /^\| `\.initialChannels\(\.\.\.values\)` \|/m,
+  "Fluent setter tables must retain named interface fields",
 );
 
 assert.doesNotMatch(
-  elements,
-  /\| `input` \| \[`ActionInput`\]/,
-  "Element factories must not render an opaque ActionInput parameter",
+  fluentPages.join("\n"),
+  /^## [a-z][A-Za-z0-9_$]*\(\)$/m,
+  "The fluent reference must not render legacy lowercase factories",
 );
 
 for (const property of [
@@ -91,12 +102,22 @@ for (const property of [
   "minLines",
   "maxLines",
 ]) {
-  const requiredProperty = "`" + property;
   assert.ok(
-    elements.includes(requiredProperty + "` |") ||
-      elements.includes(requiredProperty + "?` |"),
-    `${property} is missing from the rendered element input tables`,
+    elements.includes("`." + property + "("),
+    `${property} is missing from the rendered element setter tables`,
   );
+}
+
+for (const contents of fluentPages) {
+  for (const [, name] of contents.matchAll(/^## ([A-Z][\w$]*)\(\)$/gm)) {
+    const section = functionSection(contents, name);
+    assert.match(section, /^### Chainable setters$/m, `${name} lacks setter details`);
+    assert.match(
+      section,
+      /^### Validation and errors$/m,
+      `${name} lacks validation details`,
+    );
+  }
 }
 
 for (const name of ["SlackObject", "SlackWire"]) {

--- a/docs/scripts/typedoc-domain-groups.mjs
+++ b/docs/scripts/typedoc-domain-groups.mjs
@@ -1,15 +1,120 @@
 import { MarkdownPageEvent } from "typedoc-plugin-markdown";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import ts from "typescript";
 
 const DOMAIN_TITLES = {
   blocks: "Blocks",
+  components: "Components",
   elements: "Elements",
   errors: "Errors",
-  messages: "Messages",
   objects: "Composition Objects",
-  "rich-text": "Rich Text",
+  payloads: "Payloads",
   utilities: "Utilities",
-  views: "Views",
 };
+
+const fluentSetters = new Map();
+const fluentNames = new Set();
+const scriptsDirectory = path.dirname(fileURLToPath(import.meta.url));
+const typescriptDirectory = path.resolve(scriptsDirectory, "../../typescript");
+const fluentSourceFiles = [
+  "blocks.ts",
+  "components.ts",
+  "elements.ts",
+  "objects.ts",
+  "payloads.ts",
+].map((file) => path.join(typescriptDirectory, "src/fluent", file));
+
+function fluentTerminology(value) {
+  let result = value;
+  for (const name of fluentNames) {
+    const legacyName = name[0].toLowerCase() + name.slice(1);
+    result = result.replaceAll(`\`${legacyName}\``, `\`${name}()\``);
+  }
+  return result;
+}
+
+function markdownType(value) {
+  return value
+    .replace(/import\("[^"]+"\)\./g, "")
+    .replaceAll("|", "\\|");
+}
+
+function collectFluentSetters() {
+  const configPath = path.join(typescriptDirectory, "tsconfig.typedoc.json");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (config.error) {
+    throw new Error(
+      ts.flattenDiagnosticMessageText(config.error.messageText, "\n"),
+    );
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    typescriptDirectory,
+    undefined,
+    configPath,
+  );
+  const program = ts.createProgram(parsed.fileNames, parsed.options);
+  const checker = program.getTypeChecker();
+  const functions = fluentSourceFiles.flatMap((file) => {
+    const source = program.getSourceFile(file);
+    if (!source) throw new Error(`TypeScript API source is missing: ${file}`);
+    return source.statements.filter(
+      (statement) =>
+        ts.isFunctionDeclaration(statement) &&
+        statement.name &&
+        statement.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+        ),
+    );
+  });
+
+  for (const declaration of functions) fluentNames.add(declaration.name.text);
+
+  for (const declaration of functions) {
+    if (
+      !declaration.type ||
+      !ts.isTypeReferenceNode(declaration.type) ||
+      !["FluentBuilder", "FluentGroupBuilder"].includes(
+        declaration.type.typeName.getText(),
+      )
+    ) {
+      continue;
+    }
+
+    const inputNode = declaration.type.typeArguments?.[0];
+    if (!inputNode) continue;
+    const input = checker.getTypeFromTypeNode(inputNode);
+    const fields = checker.getPropertiesOfType(input);
+    if (fields.length === 0) continue;
+
+    fluentSetters.set(
+      declaration.name.text,
+      fields.map((field) => {
+        const location =
+          field.valueDeclaration ?? field.declarations?.[0] ?? inputNode;
+        const type = checker.getTypeOfSymbolAtLocation(field, location);
+        const nonNullableType = checker.getNonNullableType(type);
+        return {
+          collection:
+            checker.isArrayType(nonNullableType) ||
+            checker.isTupleType(nonNullableType) ||
+            nonNullableType.symbol?.name === "ReadonlyArray",
+          description: fluentTerminology(
+            ts.displayPartsToString(field.getDocumentationComment(checker)),
+          ),
+          name: field.name,
+          optional: (field.flags & ts.SymbolFlags.Optional) !== 0,
+          type: markdownType(
+            checker.typeToString(type, location, ts.TypeFormatFlags.NoTruncation),
+          ),
+        };
+      }),
+    );
+  }
+}
 
 function renderGenericSyntax(contents) {
   const escapedContents = contents
@@ -153,8 +258,60 @@ function renderFactoryInputs(contents) {
   return lines.join("\n");
 }
 
+function renderFluentSetters(contents) {
+  const lines = contents.split("\n");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const functionName = lines[index].match(/^## ([A-Z][A-Za-z0-9_$]*)\(\)$/)?.[1];
+    const fields = fluentSetters.get(functionName);
+    if (!fields) continue;
+
+    const sectionEnd = lines.findIndex(
+      (line, nestedIndex) => nestedIndex > index && line === "***",
+    );
+    const returnsHeading = lines.findIndex(
+      (line, nestedIndex) =>
+        nestedIndex > index &&
+        (sectionEnd === -1 || nestedIndex < sectionEnd) &&
+        line === "### Returns",
+    );
+    if (returnsHeading === -1) continue;
+
+    const hasCollections = fields.some(({ collection }) => collection);
+    const replacement = [
+      "### Chainable setters",
+      "",
+      "Call these setters in any order before `.build()`. Repeating a singular setter replaces its previous value.",
+      ...(hasCollections
+        ? [
+            "Collection setters accept individual values, nested builders, or arrays and append each call.",
+          ]
+        : []),
+      "",
+      "| Setter | Value type | Required | Description |",
+      "| ------ | ------ | ------ | ------ |",
+      ...fields.map(
+        ({ collection, description, name, optional, type }) =>
+          `| \`.${name}(${collection ? "...values" : "value"})\` | \`${type}\` | ${optional ? "No" : "Yes"} | ${description || "—"} |`,
+      ),
+      "",
+      "### Validation and errors",
+      "",
+      "`.build()` materializes nested builders and validates the finished Slack object. It throws a typed slackblocks validation error when a required value is missing, a value has the wrong type or range, mutually exclusive setters are combined, or Slack rejects the resulting shape. Pass `{ validate: false }` to `.build()` only when intentionally creating an intermediate partial object.",
+      "",
+    ];
+
+    lines.splice(returnsHeading, 0, ...replacement);
+    index += replacement.length;
+  }
+
+  return lines.join("\n");
+}
+
 /** Flatten TypeDoc's kind-based index groups inside each domain. */
 export function load(app) {
+  collectFluentSetters();
+
   app.converter.on(
     "resolveEnd",
     (context) => {
@@ -186,6 +343,14 @@ export function load(app) {
   app.renderer.on(MarkdownPageEvent.END, (page) => {
     page.contents = renderGenericSyntax(page.contents);
     page.contents = renderFactoryInputs(page.contents);
+    page.contents = renderFluentSetters(page.contents);
+
+    if (page.url === "objects.md") {
+      page.contents = page.contents.replace(
+        "## Markdown()",
+        '<a id="mrkdwn"></a>\n\n## Markdown()',
+      );
+    }
 
     if (page.url !== "index.md") {
       page.contents = [

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -9,6 +9,11 @@
   --ifm-code-font-size: 92%;
 }
 
+/* Historical TypeScript URLs remain linkable without appearing in navigation. */
+.api-redirect {
+  display: none;
+}
+
 [data-theme="dark"] {
   --ifm-color-primary: #d8a7db;
   --ifm-color-primary-dark: #ca8bce;

--- a/docs/typescript-api-intro.md
+++ b/docs/typescript-api-intro.md
@@ -1,5 +1,12 @@
 # TypeScript API reference
 
-This is the complete guide to slackblocks' public TypeScript API. Use it to find the factory, input type, or validation error you need while building a message, modal, or home tab.
+This is the complete guide to slackblocks' public TypeScript API. Use it to find the builder, setter, or validation error you need while building a message, modal, or home tab.
 
-Most applications start with a factory such as `message()`, `sectionBlock()`, or `modal()`. The interfaces describe their camelCase inputs, while the returned objects use the snake_case fields expected by Slack.
+Most applications start with `Message()`, add blocks such as `SectionBlock()`,
+and call `.build()` once the payload is complete. Singular setters replace the
+previous value, collection setters append, and nested builders are materialized
+automatically. The result is the plain snake_case object expected by Slack.
+
+The compatibility factories from earlier TypeScript releases remain available
+at the package root for v2 applications, but are intentionally omitted here.
+New code should use the fluent PascalCase API.

--- a/python/test/docs/test_examples.py
+++ b/python/test/docs/test_examples.py
@@ -13,10 +13,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 USING_BLOCKS = REPO_ROOT / "docs/docs/usage/using_blocks.mdx"
 
 # Block sections in using_blocks.mdx whose Python snippet cannot be executed
-# and compared against the JSON tab by this harness. Empty today: every
-# section parses and round-trips. Add a section title here (with a comment
-# explaining why) only if a future section's Tabs structure resists parsing.
-EXCLUDED_SECTIONS: set[str] = set()
+# and compared against one JSON tab by this harness. Higher-level components
+# are TypeScript-only and have multiple examples rather than one block plus
+# one JSON tab; their payloads are covered by the TypeScript component tests.
+EXCLUDED_SECTIONS: set[str] = {"Higher-Level Components"}
 
 PYTHON_FENCE = re.compile(r"```python\n(.*?)```", re.DOTALL)
 JSON_FENCE = re.compile(r"```json\n(.*?)```", re.DOTALL)

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the TypeScript package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Fluent PascalCase builders for every composition object, element, block, message,
+  attachment, response, modal, and App Home payload.
+- Higher-level `Paginator` and Slack-native `Accordion` components that expand inside
+  fluent collection setters.
+- Complete payload-level validation for message block and attachment limits, required
+  channels, supported block surfaces, and modal submission rules.
+
+### Changed
+
+- Fluent builders are now the documented and recommended TypeScript API.
+- The generated API reference describes every chainable setter and its build-time
+  validation behavior.
+
+### Deprecated
+
+- Lowercase object-input factories remain available for v2 compatibility but are no
+  longer documented. They are scheduled for removal in v3.0; see the project roadmap.
+
 ## [2.1.1] — 2026-08-16
 
 A documentation-only patch; no library behaviour changes.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -18,15 +18,15 @@ This release conforms to the shared cross-language slackblocks specification.
 
 ## Why `slackblocks`?
 
-- **Concise** — `sectionBlock({ text: "Hello, *world*!" })` instead of a 10-line JSON object.
+- **Concise** — `SectionBlock().text("Hello, *world*!").build()` instead of a 10-line JSON object.
 - **Validated** — character limits, required fields, mutually-exclusive options, and
   element-type restrictions are enforced at construction time, with a typed error
   hierarchy (`LengthError`, `MissingRequiredError`, …), so you find out *before* hitting
   Slack's API.
-- **Typed** — strict factory inputs reject typo'd and excess properties at compile time;
-  what you get back is the plain Slack-shaped object, ready for the wire.
+- **Typed** — chainable setters reject typo'd properties and invalid values at compile time;
+  `.build()` returns the plain Slack-shaped object, ready for the wire.
 - **Drop-in compatible** with the official [`@slack/web-api`](https://www.npmjs.com/package/@slack/web-api)
-  and [Bolt](https://www.npmjs.com/package/@slack/bolt) — pass a `message(...)` payload
+  and [Bolt](https://www.npmjs.com/package/@slack/bolt) — pass a `Message().build()` payload
   straight to `client.chat.postMessage(payload)`.
 - **The same library in two languages** — the Python
   [`slackblocks`](https://pypi.org/project/slackblocks/) shares the blocks, the
@@ -40,38 +40,39 @@ This release conforms to the shared cross-language slackblocks specification.
 npm install @nicklambourne/slackblocks
 ```
 
-Requires Node `20.19+` or `22.12+`. The package ships as ESM; on these Node versions
-CommonJS consumers can `require()` it directly.
+Requires Node `20.19+` or `22.12+`. The package ships as ESM; CommonJS consumers
+can load it with dynamic `import()`.
 
 ## Quickstart
 
 ```ts
 import {
-  actionsBlock,
-  button,
-  dividerBlock,
-  headerBlock,
-  message,
-  sectionBlock,
+  ActionsBlock,
+  Button,
+  DividerBlock,
+  HeaderBlock,
+  Message,
+  SectionBlock,
 } from "@nicklambourne/slackblocks";
 
-const payload = message({
-  channel: "#general",
-  text: "Build #482 passed", // plain-text fallback for notifications
-  blocks: [
-    headerBlock({ text: "Build #482 passed :white_check_mark:" }),
-    sectionBlock({
-      fields: ["*Branch*\n`main`", "*Author*\n@nick", "*Duration*\n3m 12s", "*Tests*\n1,247 passed"],
-    }),
-    dividerBlock(),
-    actionsBlock({
-      elements: [
-        button({ text: "View build", actionId: "view", url: "https://ci.example.com/482" }),
-        button({ text: "Re-run", actionId: "rerun", value: "482", style: "primary" }),
-      ],
-    }),
-  ],
-});
+const payload = Message()
+  .channel("#general")
+  .text("Build #482 passed") // plain-text fallback for notifications
+  .blocks(
+    HeaderBlock().text("Build #482 passed :white_check_mark:"),
+    SectionBlock().fields(
+      "*Branch*\n`main`",
+      "*Author*\n@nick",
+      "*Duration*\n3m 12s",
+      "*Tests*\n1,247 passed",
+    ),
+    DividerBlock(),
+    ActionsBlock().elements(
+      Button().text("View build").actionId("view").url("https://ci.example.com/482"),
+      Button().text("Re-run").actionId("rerun").value("482").style("primary"),
+    ),
+  )
+  .build();
 ```
 
 `payload` can be sent in one line with the official Slack SDK:
@@ -87,9 +88,10 @@ await client.chat.postMessage(payload);
   <img src="https://github.com/nicklambourne/slackblocks/raw/master/docs/static/img/usage/build_notification.png" alt="The build notification rendered in Slack" width="600px" />
 </p>
 
-Factory inputs use idiomatic camelCase and return plain Slack-shaped objects with
-snake_case keys. Factories validate eagerly; pass `{ validate: false }` as the final
-argument for Slack features that have moved ahead of this package's limits registry.
+Builders use idiomatic camelCase setters and return plain Slack-shaped objects with
+snake_case keys from `.build()`. Validation runs when the complete object is built;
+pass `{ validate: false }` to `.build()` only when Slack has moved ahead of this
+package's limits registry.
 
 ## Documentation
 
@@ -98,11 +100,12 @@ argument for Slack features that have moved ahead of this package's limits regis
 - [Using Blocks](https://nicklambourne.github.io/slackblocks/usage/using_blocks) — every
   block type with code in both languages, the JSON it produces, and screenshots.
 - [Sending Messages](https://nicklambourne.github.io/slackblocks/usage/sending_messages)
-- [Cookbook](https://nicklambourne.github.io/slackblocks/usage/cookbook) — end-to-end
+- [Recipe Book](https://nicklambourne.github.io/slackblocks/usage/cookbook) — end-to-end
   recipes for build notifications, approval requests, modals, and more.
 - [TypeScript API Reference](https://nicklambourne.github.io/slackblocks/reference/typescript)
 - [Troubleshooting & FAQ](https://nicklambourne.github.io/slackblocks/usage/troubleshooting)
 - [Changelog](https://github.com/nicklambourne/slackblocks/blob/master/typescript/CHANGELOG.md)
+- [Roadmap](https://github.com/nicklambourne/slackblocks/blob/master/ROADMAP.md)
 
 ## Licensing
 

--- a/typescript/src/fluent/blocks.ts
+++ b/typescript/src/fluent/blocks.ts
@@ -1,4 +1,8 @@
-/** Fluent builders for messages, modal, and App Home blocks. */
+/**
+ * Fluent builders for messages, modal, and App Home blocks.
+ *
+ * @module blocks
+ */
 import {
   actionsBlock as createActionsBlock,
   alertBlock as createAlertBlock,

--- a/typescript/src/fluent/components.ts
+++ b/typescript/src/fluent/components.ts
@@ -1,4 +1,8 @@
-/** Higher-level fluent components that render ordinary Block Kit blocks. */
+/**
+ * Higher-level fluent components that render ordinary Block Kit blocks.
+ *
+ * @module components
+ */
 import {
   actionsBlock,
   containerBlock,

--- a/typescript/src/fluent/elements.ts
+++ b/typescript/src/fluent/elements.ts
@@ -1,4 +1,8 @@
-/** Fluent builders for Block Kit interactive and visual elements. */
+/**
+ * Fluent builders for Block Kit interactive and visual elements.
+ *
+ * @module elements
+ */
 import {
   button as createButton,
   channelMultiSelect as createChannelMultiSelect,
@@ -133,9 +137,13 @@ export function FileInput(): FluentBuilder<
   return createFluentBuilder(createFileInput, { collections: { filetypes: "flat" } });
 }
 
+/** Values configured through {@link ImageElement}. */
 interface ImageElementBuilderInput {
+  /** Alternative text for screen readers and unavailable images. */
   altText: string;
+  /** Public URL of the image. Mutually exclusive with `slackFile`. */
   imageUrl?: string;
+  /** Slack-hosted file object. Mutually exclusive with `imageUrl`. */
   slackFile?: JsonObject;
 }
 

--- a/typescript/src/fluent/objects.ts
+++ b/typescript/src/fluent/objects.ts
@@ -1,4 +1,8 @@
-/** Fluent builders for Block Kit composition and rich-text objects. */
+/**
+ * Fluent builders for Block Kit composition and rich-text objects.
+ *
+ * @module objects
+ */
 import {
   areaChart as createAreaChart,
   axisConfig as createAxisConfig,
@@ -53,7 +57,9 @@ import { createFluentBuilder, type FluentBuilder } from "./core.js";
 
 type FirstInput<Factory extends (...args: never[]) => unknown> = Parameters<Factory>[0];
 
+/** Values configured through {@link PlainText}. */
 interface PlainTextBuilderInput extends PlainTextOptions {
+  /** Text to display. */
   text: string;
 }
 
@@ -64,7 +70,9 @@ export function PlainText(): FluentBuilder<PlainTextBuilderInput, TextObject> {
   );
 }
 
+/** Values configured through {@link Markdown}. */
 interface MarkdownBuilderInput extends MarkdownOptions {
+  /** Slack mrkdwn text to display. */
   text: string;
 }
 
@@ -192,8 +200,11 @@ export function PieChart(): FluentBuilder<
   );
 }
 
+/** Values configured through {@link BarChart}, {@link AreaChart}, or {@link LineChart}. */
 interface AxisChartBuilderInput {
+  /** One or more named data series to plot. */
   series: JsonObject[];
+  /** Axis labels and category configuration. */
   axisConfig: JsonObject;
 }
 
@@ -225,8 +236,11 @@ export function LineChart(): FluentBuilder<AxisChartBuilderInput, SlackObject<"l
   return axisChart(createLineChart);
 }
 
+/** Values configured through {@link RichText}. */
 interface RichTextBuilderInput {
+  /** Text content for this run. */
   text: string;
+  /** Optional Slack rich-text styling. */
   style?: RichTextStyle;
 }
 
@@ -237,8 +251,11 @@ export function RichText(): FluentBuilder<RichTextBuilderInput, JsonObject> {
   );
 }
 
+/** Values configured through rich-text mention builders. */
 interface RichTextMentionBuilderInput {
+  /** Slack channel, user, or user-group identifier. */
   id: string;
+  /** Optional Slack rich-text styling. */
   style?: RichTextStyle;
 }
 
@@ -286,8 +303,11 @@ export function RichTextList(): FluentBuilder<FirstInput<typeof createRichTextLi
   return createFluentBuilder(createRichTextList, { collections: { elements: "flat" } });
 }
 
+/** Values configured through rich-text layout builders. */
 interface RichTextLayoutBuilderInput {
+  /** Rich-text elements displayed inside the layout. */
   elements: JsonObject[];
+  /** Optional border width. */
   border?: number;
 }
 

--- a/typescript/src/fluent/payloads.ts
+++ b/typescript/src/fluent/payloads.ts
@@ -1,4 +1,8 @@
-/** Fluent builders for messages, webhooks, interaction responses, and views. */
+/**
+ * Fluent builders for messages, webhooks, interaction responses, and views.
+ *
+ * @module payloads
+ */
 import {
   attachment as createAttachment,
   message as createMessage,

--- a/typescript/test/docs-examples.test.ts
+++ b/typescript/test/docs-examples.test.ts
@@ -8,11 +8,10 @@ import * as slackblocks from "@nicklambourne/slackblocks";
 import { payload } from "../../docs/examples/typescript/section_hello.js";
 
 // Block sections in using_blocks.mdx whose TypeScript snippet cannot be
-// executed and compared against the JSON tab by this harness. Empty today:
-// every section parses and round-trips. Add a section title here (with a
-// comment explaining why) only if a future section's Tabs structure resists
-// parsing.
-const EXCLUDED_SECTIONS = new Set<string>();
+// executed and compared against one JSON tab by this harness. Higher-level
+// components have multiple examples and variable output rather than one block
+// plus one JSON tab; their payloads are covered by components.test.ts.
+const EXCLUDED_SECTIONS = new Set(["Higher-Level Components"]);
 
 const usingBlocksPath = resolve(
   import.meta.dirname,


### PR DESCRIPTION
## Summary
- replace every live TypeScript guide and README example with the fluent PascalCase API
- generate the TypeScript reference from fluent blocks, elements, objects, payloads, and components only
- render required/optional chainable setter tables, field descriptions, and build-time validation details for every builder
- document Paginator and Accordion as higher-level components
- keep historical message/view URLs linkable without adding them to navigation
- add the v3.0 roadmap for complete removal of the deprecated lowercase compatibility layer

## Stack
- depends on #298
- draft only; do not merge until the full train is approved

## Validation
- 325 TypeScript tests
- TypeScript typecheck
- npm package build, Publint, and Are the Types Wrong
- 670 Python unit, conformance, and docs-example tests
- Ruff lint and format checks for the adjusted Python docs harness
- production Docusaurus build, link/anchor checks, TypeScript API rendering checks, and all 22 historical documentation snapshots