### PR TITLE
chore: prepare the coordinated 2.2.0 release

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `slackblocks` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] — 2026-08-29
+
+This coordinated release introduces the fluent TypeScript API while keeping the Python
+and TypeScript packages on one release number. Python constructor signatures are
+unchanged.
+
+### Changed
+
+- Complete message payloads now enforce Slack's 50-block and 100-attachment limits and
+  require a non-empty channel.
+- Message, modal, and App Home block collections now reject blocks that Slack does not
+  support on that surface.
+- Modals containing an input block now require submit text, matching Slack's view rules.
+- The shared cross-language conformance contract is now version 1.1.0 and covers these
+  complete-payload rules in both implementations.
+
 ## [2.1.1] — 2026-08-16
 
 A documentation and packaging-metadata patch; no library behaviour changes.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slackblocks"
-version = "2.1.1"
+version = "2.2.0"
 description = "Python wrapper for the Slack Blocks API"
 authors = [
     { name = "Nicholas Lambourne", email = "dev@ndl.im" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1603,7 +1603,7 @@ wheels = [
 
 [[package]]
 name = "slackblocks"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the TypeScript package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] — 2026-08-29
 
 ### Added
 
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fluent builders are now the documented and recommended TypeScript API.
 - The generated API reference describes every chainable setter and its build-time
   validation behavior.
+- Lowercase compatibility factories now live in the internal `src/legacy` area while
+  retaining their v2 root-package exports.
 
 ### Deprecated
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicklambourne/slackblocks",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Typed Block Kit construction with eager, path-aware validation",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- bump the Python and TypeScript package manifests together from 2.1.1 to 2.2.0
- synchronize the Python editable-package lock metadata
- finalize the 2.2.0 changelog sections for both packages
- record Python payload-validation changes and the TypeScript fluent API, components, and v3 legacy deprecation

## Stack
- depends on #300
- release preparation only: this PR creates no tags and publishes nothing
- draft only; do not merge until the full train is approved

## Validation
- release-snapshot guard passes with 2.2.0 current and 2.1.1 frozen
- 325 TypeScript tests and typecheck
- npm artifact builds as 2.2.0; Publint passes; Are the Types Wrong passes for the supported ESM profile
- 670 Python tests at 93.19% coverage
- Python 2.2.0 wheel and sdist build, pass strict Twine checks, and import successfully in isolated smoke tests
- production Docusaurus build and all reference, link, anchor, search, and historical snapshot checks