### PR TITLE
Remove TypeScript factory parentheses from docs TOC

### DIFF
--- a/docs/scripts/check_typescript_api_rendering.mjs
+++ b/docs/scripts/check_typescript_api_rendering.mjs
@@ -50,6 +50,10 @@ const errors = await readFile(
   path.join(referenceDirectory, "errors.md"),
   "utf8",
 );
+const blocksHtml = await readFile(
+  path.resolve(scriptsDirectory, "../build/reference/typescript/blocks.html"),
+  "utf8",
+);
 
 function functionSection(contents, name) {
   const heading = `## ${name}()`;
@@ -99,6 +103,17 @@ assert.match(
   objects,
   /^```ts\ntype TextLike = string \| TextObject;\n```$/m,
   "Type aliases must render as TypeScript code blocks",
+);
+
+const toc = blocksHtml.match(
+  /<ul class="table-of-contents table-of-contents__left-border">[\s\S]*?<\/ul>/,
+)?.[0];
+
+assert.ok(toc, "blocks.html is missing its right-side table of contents");
+assert.doesNotMatch(
+  toc,
+  />[A-Z][A-Za-z0-9_$]*\(\)<\//,
+  "TypeScript factory names in the right-side navigation must omit parentheses",
 );
 
 const blockFactories = [...blocks.matchAll(/^## ([A-Z][\w$]*Block)\(\)$/gm)];

--- a/docs/src/theme/TOCItems/index.tsx
+++ b/docs/src/theme/TOCItems/index.tsx
@@ -1,10 +1,23 @@
 import { useEffect, useState } from "react";
+import { useLocation } from "@docusaurus/router";
 import { useLanguage } from "@site/src/components/LanguageContext";
 import TOCItems from "@theme-original/TOCItems";
 import type { Props } from "@theme/TOCItems";
 
 function isVisibleTocValue(language: string, value: string): boolean {
   return language !== "python" || value !== "from_dict";
+}
+
+function displayTocValues(
+  stripFactoryParentheses: boolean,
+  toc: Props["toc"],
+): Props["toc"] {
+  if (!stripFactoryParentheses) return toc;
+
+  return toc.map((item) => ({
+    ...item,
+    value: item.value.replace(/\(\)$/, ""),
+  }));
 }
 
 function visibleHeadingIds(language: string, toc: Props["toc"]): Set<string> {
@@ -23,6 +36,7 @@ function visibleHeadingIds(language: string, toc: Props["toc"]): Set<string> {
 }
 
 export default function LanguageTOCItems(props: Props) {
+  const { pathname } = useLocation();
   const { language } = useLanguage();
   const [visibleIds, setVisibleIds] = useState<Set<string> | null>(null);
 
@@ -30,11 +44,19 @@ export default function LanguageTOCItems(props: Props) {
     setVisibleIds(visibleHeadingIds(language, props.toc));
   }, [language, props.toc]);
 
-  const toc = (
+  const visibleToc = (
     visibleIds
       ? props.toc.filter((item) => visibleIds.has(item.id))
       : props.toc
   ).filter((item) => isVisibleTocValue(language, item.value));
 
-  return <TOCItems {...props} toc={toc} />;
+  return (
+    <TOCItems
+      {...props}
+      toc={displayTocValues(
+        pathname.includes("/reference/typescript/"),
+        visibleToc,
+      )}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

- remove trailing parentheses from TypeScript factory entries in the API right-side table of contents
- keep the documented headings and signatures unchanged
- add a production rendering regression check

## Validation

- `pnpm --dir docs build`