### PR TITLE
Remove redundant language layer from API breadcrumbs

### DIFF
--- a/docs/scripts/check_python_api_rendering.mjs
+++ b/docs/scripts/check_python_api_rendering.mjs
@@ -80,6 +80,16 @@ for (const domain of ["blocks", "objects"]) {
     /id="from_dict"/,
     `from_dict must remain documented on the ${domain} page`,
   );
+
+  const breadcrumbs = html.match(
+    /<nav[^>]+aria-label="Breadcrumbs">[\s\S]*?<\/nav>/,
+  )?.[0];
+  assert.ok(breadcrumbs, `${domain}.html is missing its breadcrumbs`);
+  assert.doesNotMatch(
+    breadcrumbs,
+    />Python API reference</,
+    `Python API breadcrumbs must omit the redundant language level on ${domain}`,
+  );
 }
 
 console.log("Python API rendering checks passed.");

--- a/docs/scripts/check_typescript_api_rendering.mjs
+++ b/docs/scripts/check_typescript_api_rendering.mjs
@@ -116,6 +116,16 @@ assert.doesNotMatch(
   "TypeScript factory names in the right-side navigation must omit parentheses",
 );
 
+const breadcrumbs = blocksHtml.match(
+  /<nav[^>]+aria-label="Breadcrumbs">[\s\S]*?<\/nav>/,
+)?.[0];
+assert.ok(breadcrumbs, "blocks.html is missing its breadcrumbs");
+assert.doesNotMatch(
+  breadcrumbs,
+  />TypeScript API reference</,
+  "TypeScript API breadcrumbs must omit the redundant language level",
+);
+
 const blockFactories = [...blocks.matchAll(/^## ([A-Z][\w$]*Block)\(\)$/gm)];
 assert.ok(blockFactories.length > 0, "No block factories were rendered");
 

--- a/docs/src/theme/DocBreadcrumbs/index.tsx
+++ b/docs/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,89 @@
+import React, { type ReactNode } from "react";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import { useSidebarBreadcrumbs } from "@docusaurus/plugin-content-docs/client";
+import { useHomePageRoute } from "@docusaurus/theme-common/internal";
+import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
+import HomeBreadcrumbItem from "@theme/DocBreadcrumbs/Items/Home";
+import DocBreadcrumbsStructuredData from "@theme/DocBreadcrumbs/StructuredData";
+
+import styles from "./styles.module.css";
+
+function BreadcrumbsItemLink({
+  children,
+  href,
+  isLast,
+}: {
+  children: ReactNode;
+  href: string | undefined;
+  isLast: boolean;
+}): ReactNode {
+  const className = "breadcrumbs__link";
+  if (isLast) return <span className={className}>{children}</span>;
+
+  return href ? (
+    <Link className={className} href={href}>
+      <span>{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({
+  children,
+  active,
+}: {
+  children: ReactNode;
+  active?: boolean;
+}): ReactNode {
+  return (
+    <li
+      className={`breadcrumbs__item${active ? " breadcrumbs__item--active" : ""}`}
+    >
+      {children}
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs(): ReactNode {
+  const sidebarBreadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  const breadcrumbs = sidebarBreadcrumbs?.filter(
+    ({ label }) => !/^(?:Python|TypeScript) API reference$/i.test(label),
+  );
+
+  if (!breadcrumbs) return null;
+
+  return (
+    <>
+      <DocBreadcrumbsStructuredData breadcrumbs={breadcrumbs} />
+      <nav
+        className={`${ThemeClassNames.docs.docBreadcrumbs} ${styles.breadcrumbsContainer}`}
+        aria-label={translate({
+          id: "theme.docs.breadcrumbs.navAriaLabel",
+          message: "Breadcrumbs",
+          description: "The ARIA label for the breadcrumbs",
+        })}
+      >
+        <ul className="breadcrumbs">
+          {homePageRoute && <HomeBreadcrumbItem />}
+          {breadcrumbs.map((item, index) => {
+            const isLast = index === breadcrumbs.length - 1;
+            const href =
+              item.type === "category" && item.linkUnlisted
+                ? undefined
+                : item.href;
+            return (
+              <BreadcrumbsItem key={`${item.label}-${index}`} active={isLast}>
+                <BreadcrumbsItemLink href={href} isLast={isLast}>
+                  {item.label}
+                </BreadcrumbsItemLink>
+              </BreadcrumbsItem>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/docs/src/theme/DocBreadcrumbs/styles.module.css
+++ b/docs/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,4 @@
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- remove the redundant Python/TypeScript API reference category from API-page breadcrumbs
- preserve the remaining breadcrumb hierarchy and structured data
- add rendered-output regression coverage for both languages

## Validation
- pnpm --dir docs build