### PR TITLE
Link footer author name to GitHub

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -328,7 +328,7 @@ const config: Config = {
     },
     footer: {
       style: "light",
-      copyright: `Copyright © ${new Date().getFullYear()} Nicholas Lambourne`,
+      copyright: `Copyright © ${new Date().getFullYear()} <a href="https://github.com/nicklambourne">Nicholas Lambourne</a>`,
     },
   },
 };

--- a/docs/scripts/check_typescript_api_rendering.mjs
+++ b/docs/scripts/check_typescript_api_rendering.mjs
@@ -54,6 +54,11 @@ const blocksHtml = await readFile(
   path.resolve(scriptsDirectory, "../build/reference/typescript/blocks.html"),
   "utf8",
 );
+assert.match(
+  blocksHtml,
+  /<a href="https:\/\/github\.com\/nicklambourne">Nicholas Lambourne<\/a>/,
+  "The footer author name must link to the GitHub profile",
+);
 
 function functionSection(contents, name) {
   const heading = `## ${name}()`;


### PR DESCRIPTION
## Summary
- link Nicholas Lambourne in the site footer to the GitHub profile
- verify the link in rendered documentation output

## Validation
- pnpm --dir docs build