### PR TITLE
Restore two-state docs theme switcher

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -334,7 +334,7 @@ const config: Config = {
     },
     colorMode: {
       defaultMode: "light",
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
     footer: {
       style: "light",

--- a/docs/scripts/check_typescript_api_rendering.mjs
+++ b/docs/scripts/check_typescript_api_rendering.mjs
@@ -59,6 +59,16 @@ assert.match(
   /<a href="https:\/\/github\.com\/nicklambourne">Nicholas Lambourne<\/a>/,
   "The footer author name must link to the GitHub profile",
 );
+assert.match(
+  blocksHtml,
+  /setAttribute\("data-theme",([A-Za-z_$][\w$]*)\|\|"light"\),document\.documentElement\.setAttribute\("data-theme-choice",\1\|\|"light"\)/,
+  "The theme switcher must initialize with an explicit light or dark choice",
+);
+assert.doesNotMatch(
+  blocksHtml,
+  /prefers-color-scheme/,
+  "The theme switcher must not expose a third system-preference state",
+);
 
 function functionSection(contents, name) {
   const heading = `## ${name}()`;


### PR DESCRIPTION
## Summary
- disable Docusaurus system-preference mode so the theme button cycles only between light and dark
- keep the default theme explicit and predictable for visitors without a stored choice
- add a rendered-output regression that rejects the third system state

## Validation
- pnpm --dir docs build
- pnpm --dir docs check:typescript-api-rendering
- local built site returns HTTP 200 at /slackblocks/

The in-app browser controller could not connect because the desktop sandbox rejected the repository's symlinked writable root; no system browser was used.