### PR TITLE
Add fluent Go module foundation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,62 @@
+name: Go
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "go/**"
+      - "spec/**"
+      - "docs/examples/go/**"
+      - ".github/workflows/go.yml"
+  pull_request:
+    paths:
+      - "go/**"
+      - "spec/**"
+      - "docs/examples/go/**"
+      - ".github/workflows/go.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Go ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.22.x", "stable"]
+    defaults:
+      run:
+        working-directory: go
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: false
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Check module tidiness
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Run vet
+        run: go vet ./...
+
+      - name: Run staticcheck
+        if: matrix.go-version == 'stable'
+        run: go run honnef.co/go/tools/cmd/staticcheck@v0.8.1 ./...
+
+      - name: Run tests
+        run: go test -race -cover ./...

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to the Go module are documented here. Go releases use the
+same version number as the Python and TypeScript packages.
+
+## Unreleased
+
+- Add the initial fluent Go implementation.

--- a/go/LICENSE
+++ b/go/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2019 Nicholas Lambourne
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/go/LICENSE.BSD-3-Clause
+++ b/go/LICENSE.BSD-3-Clause
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, Nicholas Lambourne
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,14 @@
+# slackblocks for Go
+
+Build validated Slack Block Kit payloads with a fluent Go API and no runtime
+dependencies.
+
+```go
+block, err := slackblocks.NewSectionBlock().
+    Text("Hello, *world*!").
+    Build()
+```
+
+The module path is `github.com/nicklambourne/slackblocks/go/v2`. This directory
+is part of the coordinated slackblocks monorepo; full installation, usage, and
+API documentation will be published with the completed Go implementation.

--- a/go/blocks.go
+++ b/go/blocks.go
@@ -1,0 +1,12 @@
+package slackblocks
+
+// NewSectionBlock creates a section block. String text and fields are coerced
+// to Slack mrkdwn objects.
+func NewSectionBlock() *Builder {
+	return newBuilder("SectionBlock", "section").
+		coerce("text", markdownLike).
+		coerce("fields", markdownLike)
+}
+
+// NewDividerBlock creates a visual divider block.
+func NewDividerBlock() *Builder { return newBuilder("DividerBlock", "divider") }

--- a/go/core.go
+++ b/go/core.go
@@ -1,0 +1,206 @@
+package slackblocks
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Object is a JSON-compatible Slack wire object.
+type Object map[string]any
+
+// Buildable is implemented by every fluent Slack object builder.
+type Buildable interface {
+	Build() (Object, error)
+}
+
+type coercion func(any) (any, error)
+
+// Builder incrementally configures one Slack wire object. Named constructors
+// provide the discriminator and field-specific coercions; Build validates the
+// completed result.
+type Builder struct {
+	name      string
+	values    Object
+	coercions map[string]coercion
+	err       error
+}
+
+func newBuilder(name, objectType string) *Builder {
+	values := Object{}
+	if objectType != "" {
+		values["type"] = objectType
+	}
+	return &Builder{name: name, values: values, coercions: map[string]coercion{}}
+}
+
+func (b *Builder) coerce(field string, fn coercion) *Builder {
+	b.coercions[field] = fn
+	return b
+}
+
+func (b *Builder) set(field string, value any) *Builder {
+	if b.err != nil {
+		return b
+	}
+	if fn := b.coercions[field]; fn != nil {
+		value, b.err = fn(value)
+		if b.err != nil {
+			return b
+		}
+	}
+	b.values[field] = value
+	return b
+}
+
+func (b *Builder) append(field string, values ...any) *Builder {
+	if b.err != nil {
+		return b
+	}
+	current, _ := b.values[field].([]any)
+	for _, value := range values {
+		if slice, ok := value.([]any); ok {
+			for _, item := range slice {
+				if fn := b.coercions[field]; fn != nil {
+					item, b.err = fn(item)
+					if b.err != nil {
+						return b
+					}
+				}
+				current = append(current, item)
+			}
+			continue
+		}
+		if fn := b.coercions[field]; fn != nil {
+			value, b.err = fn(value)
+			if b.err != nil {
+				return b
+			}
+		}
+		current = append(current, value)
+	}
+	b.values[field] = current
+	return b
+}
+
+// Set configures an advanced wire-format field that does not yet have a
+// dedicated fluent method. Prefer named methods for ordinary Block Kit use.
+func (b *Builder) Set(field string, value any) *Builder {
+	if field == "" {
+		b.err = validationError(MissingRequired, "Builder.Set", "field must not be empty")
+		return b
+	}
+	return b.set(field, value)
+}
+
+// Build materialises nested builders and validates the completed Slack object.
+func (b *Builder) Build() (Object, error) {
+	if b == nil {
+		return nil, validationError(InvalidUsage, "Builder", "cannot build a nil builder")
+	}
+	if b.err != nil {
+		return nil, b.err
+	}
+	materialised, err := materialise(b.values)
+	if err != nil {
+		return nil, err
+	}
+	object, ok := materialised.(Object)
+	if !ok {
+		return nil, validationError(TypeMismatch, b.name, "expected an object")
+	}
+	if err := Validate(object); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+// MustBuild is Build for package-level declarations and tests. It panics when
+// the configured object is invalid.
+func (b *Builder) MustBuild() Object {
+	object, err := b.Build()
+	if err != nil {
+		panic(err)
+	}
+	return object
+}
+
+// MarshalJSON lets a completed builder be passed directly to encoding/json.
+func (b *Builder) MarshalJSON() ([]byte, error) {
+	object, err := b.Build()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(object)
+}
+
+func materialise(value any) (any, error) {
+	switch typed := value.(type) {
+	case Buildable:
+		return typed.Build()
+	case Object:
+		result := Object{}
+		for key, nested := range typed {
+			built, err := materialise(nested)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = built
+		}
+		return result, nil
+	case map[string]any:
+		return materialise(Object(typed))
+	case []Object:
+		result := make([]any, 0, len(typed))
+		for _, nested := range typed {
+			built, err := materialise(nested)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, built)
+		}
+		return result, nil
+	case []Buildable:
+		result := make([]any, 0, len(typed))
+		for _, nested := range typed {
+			built, err := materialise(nested)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, built)
+		}
+		return result, nil
+	case []any:
+		result := make([]any, 0, len(typed))
+		for _, nested := range typed {
+			built, err := materialise(nested)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, built)
+		}
+		return result, nil
+	default:
+		return value, nil
+	}
+}
+
+func markdownLike(value any) (any, error) {
+	if text, ok := value.(string); ok {
+		return Object{"type": "mrkdwn", "text": text}, nil
+	}
+	return value, nil
+}
+
+func plainTextLike(value any) (any, error) {
+	if text, ok := value.(string); ok {
+		return Object{"type": "plain_text", "text": text}, nil
+	}
+	return value, nil
+}
+
+func child(path, field string) string {
+	if path == "" {
+		return field
+	}
+	return fmt.Sprintf("%s.%s", path, field)
+}

--- a/go/core_test.go
+++ b/go/core_test.go
@@ -1,0 +1,104 @@
+package slackblocks_test
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	slackblocks "github.com/nicklambourne/slackblocks/go/v2"
+)
+
+func TestSectionBlockFluentBuild(t *testing.T) {
+	block, err := slackblocks.NewSectionBlock().
+		Text("Hello, *world*!").
+		Fields("*Status*\nReady").
+		BlockID("status").
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := slackblocks.Object{
+		"type": "section",
+		"text": slackblocks.Object{"type": "mrkdwn", "text": "Hello, *world*!"},
+		"fields": []any{
+			slackblocks.Object{"type": "mrkdwn", "text": "*Status*\nReady"},
+		},
+		"block_id": "status",
+	}
+	if !reflect.DeepEqual(block, want) {
+		t.Fatalf("unexpected block:\nwant: %#v\n got: %#v", want, block)
+	}
+}
+
+func TestNestedBuildersMaterialise(t *testing.T) {
+	option, err := slackblocks.NewOption().Text("Deploy").Value("deploy").Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := slackblocks.Object{
+		"text":  slackblocks.Object{"type": "plain_text", "text": "Deploy"},
+		"value": "deploy",
+	}
+	if !reflect.DeepEqual(option, want) {
+		t.Fatalf("unexpected option: %#v", option)
+	}
+}
+
+func TestValidationErrorCategory(t *testing.T) {
+	_, err := slackblocks.NewPlainText().Text("").Build()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var validation *slackblocks.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	if validation.Category != slackblocks.LengthExceeded {
+		t.Fatalf("unexpected category: %s", validation.Category)
+	}
+}
+
+func TestBuilderMarshalsAsSlackJSON(t *testing.T) {
+	encoded, err := json.Marshal(slackblocks.NewMarkdown().Text("Hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) != `{"text":"Hello","type":"mrkdwn"}` {
+		t.Fatalf("unexpected JSON: %s", encoded)
+	}
+}
+
+func TestMustBuild(t *testing.T) {
+	built := slackblocks.NewDividerBlock().MustBuild()
+	if !reflect.DeepEqual(built, slackblocks.Object{"type": "divider"}) {
+		t.Fatalf("unexpected block: %#v", built)
+	}
+
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("expected MustBuild to panic for an invalid object")
+		}
+	}()
+	slackblocks.NewPlainText().Text("").MustBuild()
+}
+
+func TestValidationErrorFormatting(t *testing.T) {
+	withPath := (&slackblocks.ValidationError{
+		Category: slackblocks.MissingRequired,
+		Path:     "SectionBlock.text",
+		Detail:   "text or fields is required",
+	}).Error()
+	if withPath != "missing-required at SectionBlock.text: text or fields is required" {
+		t.Fatalf("unexpected error: %q", withPath)
+	}
+
+	withoutPath := (&slackblocks.ValidationError{
+		Category: slackblocks.InvalidUsage,
+		Detail:   "invalid value",
+	}).Error()
+	if withoutPath != "invalid-usage: invalid value" {
+		t.Fatalf("unexpected error: %q", withoutPath)
+	}
+}

--- a/go/doc.go
+++ b/go/doc.go
@@ -1,0 +1,4 @@
+// Package slackblocks provides fluent, validated builders for Slack Block Kit
+// payloads. Builders materialise ordinary JSON-compatible objects, so their
+// output can be passed to any Slack client without a runtime dependency.
+package slackblocks

--- a/go/errors.go
+++ b/go/errors.go
@@ -1,0 +1,39 @@
+package slackblocks
+
+import "fmt"
+
+// ErrorCategory identifies a language-neutral conformance error category.
+type ErrorCategory string
+
+const (
+	// LengthExceeded reports a value outside an allowed length bound.
+	LengthExceeded ErrorCategory = "length-exceeded"
+	// OutOfRange reports a numeric value outside its allowed range.
+	OutOfRange ErrorCategory = "out-of-range"
+	// MutuallyExclusive reports fields that cannot be used together.
+	MutuallyExclusive ErrorCategory = "mutually-exclusive"
+	// TypeMismatch reports a value with an unexpected wire type.
+	TypeMismatch ErrorCategory = "type-mismatch"
+	// MissingRequired reports an absent value required by Slack's schema.
+	MissingRequired ErrorCategory = "missing-required"
+	// InvalidUsage reports a structurally invalid combination of values.
+	InvalidUsage ErrorCategory = "invalid-usage"
+)
+
+// ValidationError reports why a completed Slack object is invalid.
+type ValidationError struct {
+	Category ErrorCategory
+	Path     string
+	Detail   string
+}
+
+func (e *ValidationError) Error() string {
+	if e.Path == "" {
+		return fmt.Sprintf("%s: %s", e.Category, e.Detail)
+	}
+	return fmt.Sprintf("%s at %s: %s", e.Category, e.Path, e.Detail)
+}
+
+func validationError(category ErrorCategory, path, format string, args ...any) error {
+	return &ValidationError{Category: category, Path: path, Detail: fmt.Sprintf(format, args...)}
+}

--- a/go/fields.go
+++ b/go/fields.go
@@ -1,0 +1,158 @@
+package slackblocks
+
+// Text sets a text-bearing field. Constructors coerce strings to the Slack
+// text-object form required by that field.
+func (b *Builder) Text(value any) *Builder { return b.set("text", value) }
+
+// Emoji controls Slack emoji shortcode conversion for plain text.
+func (b *Builder) Emoji(value bool) *Builder { return b.set("emoji", value) }
+
+// Verbatim controls automatic Slack mrkdwn parsing.
+func (b *Builder) Verbatim(value bool) *Builder { return b.set("verbatim", value) }
+
+// BlockID assigns an application-defined block identifier.
+func (b *Builder) BlockID(value string) *Builder { return b.set("block_id", value) }
+
+// Fields appends section fields in display order.
+func (b *Builder) Fields(values ...any) *Builder { return b.append("fields", values...) }
+
+// Accessory sets the optional section accessory element.
+func (b *Builder) Accessory(value any) *Builder { return b.set("accessory", value) }
+
+// Title sets a title field.
+func (b *Builder) Title(value any) *Builder { return b.set("title", value) }
+
+// Confirm sets a confirmation object or its confirm-button label, according to
+// the builder being configured.
+func (b *Builder) Confirm(value any) *Builder { return b.set("confirm", value) }
+
+// Deny sets the denial-button label on a confirmation object.
+func (b *Builder) Deny(value any) *Builder { return b.set("deny", value) }
+
+// Style sets a Slack-supported visual or layout style.
+func (b *Builder) Style(value string) *Builder { return b.set("style", value) }
+
+// Value sets an application-defined value.
+func (b *Builder) Value(value any) *Builder { return b.set("value", value) }
+
+// URL sets a URL field.
+func (b *Builder) URL(value string) *Builder { return b.set("url", value) }
+
+// Description sets supporting descriptive text.
+func (b *Builder) Description(value any) *Builder { return b.set("description", value) }
+
+// Options appends selectable option objects.
+func (b *Builder) Options(values ...any) *Builder { return b.append("options", values...) }
+
+// OptionGroups appends selectable option groups.
+func (b *Builder) OptionGroups(values ...any) *Builder {
+	return b.append("option_groups", values...)
+}
+
+// Label sets a label field.
+func (b *Builder) Label(value any) *Builder { return b.set("label", value) }
+
+// Include appends conversation kinds to a conversation filter.
+func (b *Builder) Include(values ...string) *Builder {
+	items := make([]any, len(values))
+	for index, value := range values {
+		items[index] = value
+	}
+	return b.append("include", items...)
+}
+
+// ExcludeExternalSharedChannels configures conversation filtering.
+func (b *Builder) ExcludeExternalSharedChannels(value bool) *Builder {
+	return b.set("exclude_external_shared_channels", value)
+}
+
+// ExcludeBotUsers configures conversation filtering.
+func (b *Builder) ExcludeBotUsers(value bool) *Builder {
+	return b.set("exclude_bot_users", value)
+}
+
+// TriggerActionsOn appends dispatch-action trigger names.
+func (b *Builder) TriggerActionsOn(values ...string) *Builder {
+	items := make([]any, len(values))
+	for index, value := range values {
+		items[index] = value
+	}
+	return b.append("trigger_actions_on", items...)
+}
+
+// Name sets a named Slack value.
+func (b *Builder) Name(value string) *Builder { return b.set("name", value) }
+
+// Trigger sets a workflow trigger.
+func (b *Builder) Trigger(value any) *Builder { return b.set("trigger", value) }
+
+// CustomizableInputParameters appends workflow parameters.
+func (b *Builder) CustomizableInputParameters(values ...any) *Builder {
+	return b.append("customizable_input_parameters", values...)
+}
+
+// ID sets an identifier field.
+func (b *Builder) ID(value string) *Builder { return b.set("id", value) }
+
+// SlackFileID sets a Slack-hosted file identifier.
+func (b *Builder) SlackFileID(value string) *Builder { return b.set("id", value) }
+
+// SlackFileURL sets a Slack-hosted file URL.
+func (b *Builder) SlackFileURL(value string) *Builder { return b.set("url", value) }
+
+// Align sets table-column alignment.
+func (b *Builder) Align(value string) *Builder { return b.set("align", value) }
+
+// Wrap controls table-column text wrapping.
+func (b *Builder) Wrap(value bool) *Builder { return b.set("wrap", value) }
+
+// Data appends data points.
+func (b *Builder) Data(values ...any) *Builder { return b.append("data", values...) }
+
+// Series appends chart series.
+func (b *Builder) Series(values ...any) *Builder { return b.append("series", values...) }
+
+// Segments appends pie-chart segments.
+func (b *Builder) Segments(values ...any) *Builder { return b.append("segments", values...) }
+
+// Categories appends chart axis categories.
+func (b *Builder) Categories(values ...string) *Builder {
+	items := make([]any, len(values))
+	for index, value := range values {
+		items[index] = value
+	}
+	return b.append("categories", items...)
+}
+
+// XLabel sets a chart x-axis label.
+func (b *Builder) XLabel(value string) *Builder { return b.set("x_label", value) }
+
+// YLabel sets a chart y-axis label.
+func (b *Builder) YLabel(value string) *Builder { return b.set("y_label", value) }
+
+// AxisConfig sets chart-axis configuration.
+func (b *Builder) AxisConfig(value any) *Builder { return b.set("axis_config", value) }
+
+// Elements appends Slack elements.
+func (b *Builder) Elements(values ...any) *Builder { return b.append("elements", values...) }
+
+// Border sets a rich-text border depth.
+func (b *Builder) Border(value int) *Builder { return b.set("border", value) }
+
+// Offset sets a rich-text list nesting offset.
+func (b *Builder) Offset(value int) *Builder { return b.set("offset", value) }
+
+// Indent sets a rich-text list indent level.
+func (b *Builder) Indent(value int) *Builder { return b.set("indent", value) }
+
+// SkinTone sets an emoji skin-tone index.
+func (b *Builder) SkinTone(value int) *Builder { return b.set("skin_tone", value) }
+
+// ChannelID sets a Slack channel ID.
+func (b *Builder) ChannelID(value string) *Builder { return b.set("channel_id", value) }
+
+// UserID sets a Slack user ID.
+func (b *Builder) UserID(value string) *Builder { return b.set("user_id", value) }
+
+// UserGroupID sets a Slack user-group ID.
+func (b *Builder) UserGroupID(value string) *Builder { return b.set("usergroup_id", value) }

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/nicklambourne/slackblocks/go/v2
+
+go 1.22

--- a/go/objects.go
+++ b/go/objects.go
@@ -1,0 +1,116 @@
+package slackblocks
+
+// NewPlainText creates a plain-text composition object.
+func NewPlainText() *Builder { return newBuilder("PlainText", "plain_text") }
+
+// NewMarkdown creates a Slack mrkdwn composition object.
+func NewMarkdown() *Builder { return newBuilder("Markdown", "mrkdwn") }
+
+// NewConfirmation creates a confirmation-dialog composition object.
+func NewConfirmation() *Builder {
+	return newBuilder("Confirmation", "").
+		coerce("title", plainTextLike).
+		coerce("text", markdownLike).
+		coerce("confirm", plainTextLike).
+		coerce("deny", plainTextLike)
+}
+
+// NewOption creates a selectable option composition object.
+func NewOption() *Builder {
+	return newBuilder("Option", "").
+		coerce("text", plainTextLike).
+		coerce("description", plainTextLike)
+}
+
+// NewOptionGroup creates a labelled group of selectable options.
+func NewOptionGroup() *Builder {
+	return newBuilder("OptionGroup", "").coerce("label", plainTextLike)
+}
+
+// NewConversationFilter creates a conversation select-menu filter.
+func NewConversationFilter() *Builder { return newBuilder("ConversationFilter", "") }
+
+// NewDispatchActionConfiguration creates an input dispatch configuration.
+func NewDispatchActionConfiguration() *Builder {
+	return newBuilder("DispatchActionConfiguration", "")
+}
+
+// NewInputParameter creates a customizable workflow input parameter.
+func NewInputParameter() *Builder { return newBuilder("InputParameter", "") }
+
+// NewTrigger creates a workflow link trigger.
+func NewTrigger() *Builder { return newBuilder("Trigger", "") }
+
+// NewWorkflow creates a workflow composition object.
+func NewWorkflow() *Builder { return newBuilder("Workflow", "") }
+
+// NewSlackFile creates a Slack-hosted file reference.
+func NewSlackFile() *Builder { return newBuilder("SlackFile", "") }
+
+// NewColumnSettings creates table-column display settings.
+func NewColumnSettings() *Builder { return newBuilder("ColumnSettings", "") }
+
+// NewRawText creates an unformatted table cell.
+func NewRawText() *Builder { return newBuilder("RawText", "raw_text") }
+
+// NewRawNumber creates a numeric data-table cell.
+func NewRawNumber() *Builder { return newBuilder("RawNumber", "raw_number") }
+
+// NewSlackIcon creates a named Slack-rendered icon.
+func NewSlackIcon() *Builder { return newBuilder("SlackIcon", "icon") }
+
+// NewChartSegment creates a labelled pie-chart segment.
+func NewChartSegment() *Builder { return newBuilder("ChartSegment", "") }
+
+// NewDataPoint creates a labelled chart data point.
+func NewDataPoint() *Builder { return newBuilder("DataPoint", "") }
+
+// NewDataSeries creates a named chart data series.
+func NewDataSeries() *Builder { return newBuilder("DataSeries", "") }
+
+// NewAxisConfig creates category and label settings for a chart axis.
+func NewAxisConfig() *Builder { return newBuilder("AxisConfig", "") }
+
+// NewPieChart creates a pie-chart object.
+func NewPieChart() *Builder { return newBuilder("PieChart", "pie") }
+
+// NewBarChart creates a bar-chart object.
+func NewBarChart() *Builder { return newBuilder("BarChart", "bar") }
+
+// NewAreaChart creates an area-chart object.
+func NewAreaChart() *Builder { return newBuilder("AreaChart", "area") }
+
+// NewLineChart creates a line-chart object.
+func NewLineChart() *Builder { return newBuilder("LineChart", "line") }
+
+// NewRichText creates a rich-text text run.
+func NewRichText() *Builder { return newBuilder("RichText", "text") }
+
+// NewRichTextChannel creates a rich-text channel mention.
+func NewRichTextChannel() *Builder { return newBuilder("RichTextChannel", "channel") }
+
+// NewRichTextEmoji creates a rich-text emoji run.
+func NewRichTextEmoji() *Builder { return newBuilder("RichTextEmoji", "emoji") }
+
+// NewRichTextLink creates a rich-text link run.
+func NewRichTextLink() *Builder { return newBuilder("RichTextLink", "link") }
+
+// NewRichTextUser creates a rich-text user mention.
+func NewRichTextUser() *Builder { return newBuilder("RichTextUser", "user") }
+
+// NewRichTextUserGroup creates a rich-text user-group mention.
+func NewRichTextUserGroup() *Builder { return newBuilder("RichTextUserGroup", "usergroup") }
+
+// NewRichTextSection creates a rich-text inline section.
+func NewRichTextSection() *Builder { return newBuilder("RichTextSection", "rich_text_section") }
+
+// NewRichTextList creates an ordered or bullet rich-text list.
+func NewRichTextList() *Builder { return newBuilder("RichTextList", "rich_text_list") }
+
+// NewRichTextCodeBlock creates a preformatted rich-text block.
+func NewRichTextCodeBlock() *Builder {
+	return newBuilder("RichTextCodeBlock", "rich_text_preformatted")
+}
+
+// NewRichTextQuote creates a quoted rich-text block.
+func NewRichTextQuote() *Builder { return newBuilder("RichTextQuote", "rich_text_quote") }

--- a/go/validation.go
+++ b/go/validation.go
@@ -1,0 +1,86 @@
+package slackblocks
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+var requiredFields = map[string][]string{
+	"button":                 {"text", "action_id"},
+	"channel":                {"channel_id"},
+	"emoji":                  {"name"},
+	"link":                   {"url"},
+	"rich_text_list":         {"style", "elements"},
+	"rich_text_preformatted": {"elements"},
+	"rich_text_quote":        {"elements"},
+	"rich_text_section":      {"elements"},
+	"text":                   {"text"},
+	"user":                   {"user_id"},
+	"usergroup":              {"usergroup_id"},
+}
+
+// Validate recursively checks a Slack wire object.
+func Validate(object Object) error { return validateObject(object, "") }
+
+func validateObject(object Object, path string) error {
+	typeName, _ := object["type"].(string)
+	for _, field := range requiredFields[typeName] {
+		if _, ok := object[field]; !ok {
+			return validationError(MissingRequired, path, "expected %s", field)
+		}
+	}
+
+	if blockID, ok := object["block_id"].(string); ok && utf8.RuneCountInString(blockID) > 255 {
+		return validationError(LengthExceeded, child(path, "block_id"), "exceeds maximum 255")
+	}
+	if actionID, ok := object["action_id"].(string); ok && utf8.RuneCountInString(actionID) > 255 {
+		return validationError(LengthExceeded, child(path, "action_id"), "exceeds maximum 255")
+	}
+
+	switch typeName {
+	case "plain_text", "mrkdwn":
+		text, ok := object["text"].(string)
+		if !ok {
+			return validationError(TypeMismatch, child(path, "text"), "expected a string")
+		}
+		length := utf8.RuneCountInString(text)
+		if length < 1 || length > 3000 {
+			return validationError(LengthExceeded, child(path, "text"), "length %d is outside 1..3000", length)
+		}
+	case "section":
+		_, hasText := object["text"]
+		_, hasFields := object["fields"]
+		if !hasText && !hasFields {
+			return validationError(MissingRequired, path, "expected text, fields, or both")
+		}
+	case "pie":
+		segments, ok := object["segments"].([]any)
+		if !ok || len(segments) == 0 {
+			return validationError(LengthExceeded, child(path, "segments"), "expected at least one segment")
+		}
+	}
+
+	for field, value := range object {
+		if field == "type" {
+			continue
+		}
+		if err := validateNested(value, child(path, field)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNested(value any, path string) error {
+	switch typed := value.(type) {
+	case Object:
+		return validateObject(typed, path)
+	case []any:
+		for index, nested := range typed {
+			if err := validateNested(nested, fmt.Sprintf("%s[%d]", path, index)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Stack 1 of 5 for the Go implementation.

## Scope
- add the `github.com/nicklambourne/slackblocks/go/v2` module with Go 1.22 support
- keep the core fluent-builder foundation standard-library-only; the `slack-go/slack` delivery integration follows in #313
- establish the fluent `Builder`, JSON `Object`, typed validation errors, and core coercion/validation helpers
- add module documentation, licences, changelog, unit tests, and a Go 1.22/stable CI matrix
- keep generated modules tidy and run staticcheck on the stable toolchain

## Validation
- `go test -race -cover ./...`
- `go vet ./...`
- `go mod tidy` with a clean module diff (compatible with Go 1.22)
- `staticcheck ./...` on stable Go
- `gofmt` clean

This PR intentionally contains only the foundation. The complete API, client integration, components, docs, and release plumbing follow in stacked PRs. Do not merge until the full train is approved.
