### PR TITLE
Add fluent Go accordion and paginator components

### DIFF
--- a/go/capabilities_test.go
+++ b/go/capabilities_test.go
@@ -59,6 +59,7 @@ func TestEveryConstructorMapsToSharedCapability(t *testing.T) {
 	for constructor := range capabilityByConstructor {
 		mapped = append(mapped, constructor)
 	}
+	mapped = append(mapped, "NewAccordion", "NewAccordionSection", "NewPaginator")
 	sort.Strings(mapped)
 	if !reflect.DeepEqual(constructors, mapped) {
 		t.Fatalf("constructor registry mismatch\nexported: %v\nmapped:   %v", constructors, mapped)

--- a/go/components.go
+++ b/go/components.go
@@ -1,0 +1,237 @@
+package slackblocks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	slackapi "github.com/slack-go/slack"
+)
+
+type builtSlackBlock struct {
+	object Object
+}
+
+func (b builtSlackBlock) BlockType() slackapi.MessageBlockType {
+	return slackapi.MessageBlockType(objectType(b.object))
+}
+
+func (b builtSlackBlock) ID() string {
+	value, _ := b.object["block_id"].(string)
+	return value
+}
+
+func (b builtSlackBlock) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.object)
+}
+
+func nativeSlackBlocks(objects []Object) []slackapi.Block {
+	blocks := make([]slackapi.Block, len(objects))
+	for index, object := range objects {
+		blocks[index] = builtSlackBlock{object: object}
+	}
+	return blocks
+}
+
+// NewAccordionSection creates one Slack-native collapsible container for an
+// accordion. Add its content with Blocks and choose its initial state with
+// Expanded.
+func NewAccordionSection() *AccordionSectionBuilder {
+	builder := newBuilder("AccordionSection", "container").
+		coerce("title", plainTextLike).
+		coerce("subtitle", markdownLike)
+	builder.values["is_collapsible"] = true
+	builder.values["default_collapsed"] = true
+	return newAccordionSectionBuilder(builder.withTransform(func(object Object) (Object, error) {
+		if blocks, ok := object["blocks"]; ok {
+			object["child_blocks"] = blocks
+			delete(object, "blocks")
+		}
+		if expanded, ok := object["_expanded"].(bool); ok {
+			object["default_collapsed"] = !expanded
+			delete(object, "_expanded")
+		}
+		return object, nil
+	}))
+}
+
+// AccordionBuilder assembles independently collapsible sections.
+type AccordionBuilder struct {
+	sections []any
+}
+
+// NewAccordion creates a Slack-native accordion component.
+func NewAccordion() *AccordionBuilder { return &AccordionBuilder{} }
+
+// Sections appends accordion sections in display order.
+func (b *AccordionBuilder) Sections(values ...any) *AccordionBuilder {
+	b.sections = append(b.sections, values...)
+	return b
+}
+
+// BuildMany materialises the accordion as ordinary container blocks.
+func (b *AccordionBuilder) BuildMany() ([]Object, error) {
+	if b == nil || len(b.sections) == 0 {
+		return nil, validationError(MissingRequired, "Accordion.sections", "expected at least one section")
+	}
+	result := make([]Object, 0, len(b.sections))
+	for index, raw := range b.sections {
+		built, err := materialise(raw)
+		if err != nil {
+			return nil, err
+		}
+		section, ok := built.(Object)
+		if !ok || objectType(section) != "container" || section["is_collapsible"] != true {
+			return nil, validationError(TypeMismatch, fmt.Sprintf("Accordion.sections[%d]", index), "expected an AccordionSection")
+		}
+		result = append(result, section)
+	}
+	return result, nil
+}
+
+// SlackBlocks expands the accordion for direct use with slack-go.
+func (b *AccordionBuilder) SlackBlocks() ([]slackapi.Block, error) {
+	objects, err := b.BuildMany()
+	if err != nil {
+		return nil, err
+	}
+	return nativeSlackBlocks(objects), nil
+}
+
+// PaginatorBuilder renders one page of blocks plus navigation controls.
+type PaginatorBuilder struct {
+	blocks            []any
+	actionIDPrefix    string
+	page              int
+	pageSize          int
+	previousText      string
+	nextText          string
+	showPageIndicator bool
+	blockID           string
+}
+
+// NewPaginator creates a pure Block Kit paginator. Interaction handling remains
+// in the application; generated button values contain the next one-based page.
+func NewPaginator() *PaginatorBuilder {
+	return &PaginatorBuilder{
+		page:              1,
+		pageSize:          5,
+		previousText:      "Previous",
+		nextText:          "Next",
+		showPageIndicator: true,
+	}
+}
+
+// Blocks appends source blocks in display order.
+func (b *PaginatorBuilder) Blocks(values ...any) *PaginatorBuilder {
+	b.blocks = append(b.blocks, values...)
+	return b
+}
+
+// ActionIDPrefix sets the prefix used for generated action IDs.
+func (b *PaginatorBuilder) ActionIDPrefix(value string) *PaginatorBuilder {
+	b.actionIDPrefix = value
+	return b
+}
+
+// Page selects the one-based page to render.
+func (b *PaginatorBuilder) Page(value int) *PaginatorBuilder { b.page = value; return b }
+
+// PageSize sets the number of source blocks displayed per page.
+func (b *PaginatorBuilder) PageSize(value int) *PaginatorBuilder { b.pageSize = value; return b }
+
+// PreviousText sets the previous-page button label.
+func (b *PaginatorBuilder) PreviousText(value string) *PaginatorBuilder {
+	b.previousText = value
+	return b
+}
+
+// NextText sets the next-page button label.
+func (b *PaginatorBuilder) NextText(value string) *PaginatorBuilder {
+	b.nextText = value
+	return b
+}
+
+// ShowPageIndicator controls the Page n of m context block.
+func (b *PaginatorBuilder) ShowPageIndicator(value bool) *PaginatorBuilder {
+	b.showPageIndicator = value
+	return b
+}
+
+// BlockID sets the generated actions block identifier.
+func (b *PaginatorBuilder) BlockID(value string) *PaginatorBuilder { b.blockID = value; return b }
+
+// BuildMany materialises the selected page and its controls.
+func (b *PaginatorBuilder) BuildMany() ([]Object, error) {
+	if b == nil || len(b.blocks) == 0 {
+		return nil, validationError(MissingRequired, "Paginator.blocks", "expected at least one block")
+	}
+	if b.actionIDPrefix == "" {
+		return nil, validationError(MissingRequired, "Paginator.actionIDPrefix", "expected a non-empty prefix")
+	}
+	if b.page < 1 {
+		return nil, validationError(OutOfRange, "Paginator.page", "expected a positive integer")
+	}
+	if b.pageSize < 1 {
+		return nil, validationError(OutOfRange, "Paginator.pageSize", "expected a positive integer")
+	}
+
+	blocks := make([]Object, 0, len(b.blocks))
+	for index, raw := range b.blocks {
+		built, err := materialise(raw)
+		if err != nil {
+			return nil, err
+		}
+		block, ok := built.(Object)
+		if !ok || objectType(block) == "" {
+			return nil, validationError(TypeMismatch, fmt.Sprintf("Paginator.blocks[%d]", index), "expected a block")
+		}
+		blocks = append(blocks, block)
+	}
+
+	pageCount := (len(blocks) + b.pageSize - 1) / b.pageSize
+	if b.page > pageCount {
+		return nil, validationError(OutOfRange, "Paginator.page", "expected a value between 1 and %d", pageCount)
+	}
+	start := (b.page - 1) * b.pageSize
+	end := start + b.pageSize
+	if end > len(blocks) {
+		end = len(blocks)
+	}
+	result := append([]Object(nil), blocks[start:end]...)
+	if pageCount == 1 {
+		return result, nil
+	}
+
+	controls := []any{}
+	if b.page > 1 {
+		controls = append(controls, NewButton().Text(b.previousText).ActionID(b.actionIDPrefix+".previous").Value(fmt.Sprint(b.page-1)))
+	}
+	if b.page < pageCount {
+		controls = append(controls, NewButton().Text(b.nextText).ActionID(b.actionIDPrefix+".next").Value(fmt.Sprint(b.page+1)))
+	}
+	if b.showPageIndicator {
+		indicator, err := NewContextBlock().Elements(NewMarkdown().Text(fmt.Sprintf("Page %d of %d", b.page, pageCount))).Build()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, indicator)
+	}
+	actions := NewActionsBlock().Elements(controls...)
+	if b.blockID != "" {
+		actions.BlockID(b.blockID)
+	}
+	builtActions, err := actions.Build()
+	if err != nil {
+		return nil, err
+	}
+	return append(result, builtActions), nil
+}
+
+// SlackBlocks expands the selected page for direct use with slack-go.
+func (b *PaginatorBuilder) SlackBlocks() ([]slackapi.Block, error) {
+	objects, err := b.BuildMany()
+	if err != nil {
+		return nil, err
+	}
+	return nativeSlackBlocks(objects), nil
+}

--- a/go/components_test.go
+++ b/go/components_test.go
@@ -1,0 +1,153 @@
+package slackblocks_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	slackblocks "github.com/nicklambourne/slackblocks/go/v2"
+	slackapi "github.com/slack-go/slack"
+)
+
+func TestAccordionExpandsInsideParentBlocks(t *testing.T) {
+	message, err := slackblocks.NewMessage().Channel("C123").Blocks(
+		slackblocks.NewAccordion().Sections(
+			slackblocks.NewAccordionSection().Title("First").Expanded(true).Blocks(slackblocks.NewSectionBlock().Text("One")),
+			slackblocks.NewAccordionSection().Title("Second").Blocks(slackblocks.NewSectionBlock().Text("Two")),
+		),
+	).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks := message["blocks"].([]any)
+	if len(blocks) != 2 {
+		t.Fatalf("expected two expanded blocks, got %d", len(blocks))
+	}
+	first := blocks[0].(slackblocks.Object)
+	second := blocks[1].(slackblocks.Object)
+	if first["default_collapsed"] != false || second["default_collapsed"] != true {
+		t.Fatalf("unexpected accordion state: %#v %#v", first, second)
+	}
+}
+
+func TestPaginatorRendersPageAndControls(t *testing.T) {
+	blocks, err := slackblocks.NewPaginator().
+		Blocks(
+			slackblocks.NewSectionBlock().Text("One"),
+			slackblocks.NewSectionBlock().Text("Two"),
+			slackblocks.NewSectionBlock().Text("Three"),
+		).
+		ActionIDPrefix("results").
+		PageSize(1).
+		Page(2).
+		BuildMany()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := []string{blocks[0]["type"].(string), blocks[1]["type"].(string), blocks[2]["type"].(string)}; !reflect.DeepEqual(got, []string{"section", "context", "actions"}) {
+		t.Fatalf("unexpected block sequence: %v", got)
+	}
+	controls := blocks[2]["elements"].([]any)
+	if len(controls) != 2 {
+		t.Fatalf("expected previous and next controls, got %d", len(controls))
+	}
+}
+
+func TestPaginatorValidatesInputs(t *testing.T) {
+	_, err := slackblocks.NewPaginator().Blocks(slackblocks.NewDividerBlock()).ActionIDPrefix("pages").Page(2).BuildMany()
+	if err == nil {
+		t.Fatal("expected page range error")
+	}
+}
+
+func TestPaginatorRendersCustomNavigationOptions(t *testing.T) {
+	blocks, err := slackblocks.NewPaginator().
+		Blocks(
+			slackblocks.NewDividerBlock(),
+			slackblocks.NewDividerBlock(),
+			slackblocks.NewDividerBlock(),
+		).
+		ActionIDPrefix("results").
+		PageSize(1).
+		Page(2).
+		PreviousText("Back").
+		NextText("More").
+		ShowPageIndicator(false).
+		BlockID("results-navigation").
+		BuildMany()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 2 || blocks[1]["type"] != "actions" {
+		t.Fatalf("unexpected block sequence: %#v", blocks)
+	}
+	if blocks[1]["block_id"] != "results-navigation" {
+		t.Fatalf("unexpected navigation block ID: %#v", blocks[1]["block_id"])
+	}
+	controls := blocks[1]["elements"].([]any)
+	labels := make([]string, len(controls))
+	for index, raw := range controls {
+		button := raw.(slackblocks.Object)
+		labels[index] = button["text"].(slackblocks.Object)["text"].(string)
+	}
+	if !reflect.DeepEqual(labels, []string{"Back", "More"}) {
+		t.Fatalf("unexpected navigation labels: %v", labels)
+	}
+}
+
+func TestPaginatorSlackBlocksPreservesValidation(t *testing.T) {
+	_, err := slackblocks.NewPaginator().SlackBlocks()
+	if err == nil {
+		t.Fatal("expected missing blocks validation error")
+	}
+}
+
+func TestAccordionInModalPreservesSurfaceValidation(t *testing.T) {
+	_, err := slackblocks.NewModal().
+		Title("Details").
+		Blocks(slackblocks.NewAccordion().Sections(
+			slackblocks.NewAccordionSection().Title("More").Blocks(
+				slackblocks.NewSectionBlock().Text("Not supported in modal containers"),
+			),
+		)).
+		Build()
+	if err == nil {
+		t.Fatal("expected modal surface validation error")
+	}
+}
+
+func TestPaginatorExpandsToNativeSlackBlocks(t *testing.T) {
+	blocks, err := slackblocks.NewPaginator().
+		Blocks(
+			slackblocks.NewSectionBlock().Text("One").BlockID("page-item"),
+			slackblocks.NewSectionBlock().Text("Two"),
+		).
+		ActionIDPrefix("results").
+		PageSize(1).
+		SlackBlocks()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = slackapi.MsgOptionBlocks(blocks...)
+	if got := []string{string(blocks[0].BlockType()), string(blocks[1].BlockType()), string(blocks[2].BlockType())}; !reflect.DeepEqual(got, []string{"section", "context", "actions"}) {
+		t.Fatalf("unexpected block sequence: %v", got)
+	}
+	if blocks[0].ID() != "page-item" {
+		t.Fatalf("unexpected block ID: %q", blocks[0].ID())
+	}
+	encoded, err := json.Marshal(blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) != `[{"block_id":"page-item","text":{"text":"One","type":"mrkdwn"},"type":"section"},{"elements":[{"text":"Page 1 of 2","type":"mrkdwn"}],"type":"context"},{"elements":[{"action_id":"results.next","text":{"text":"Next","type":"plain_text"},"type":"button","value":"2"}],"type":"actions"}]` {
+		t.Fatalf("unexpected native block JSON: %s", encoded)
+	}
+}
+
+func TestAccordionSlackBlocksPreservesValidation(t *testing.T) {
+	_, err := slackblocks.NewAccordion().SlackBlocks()
+	if err == nil {
+		t.Fatal("expected missing sections validation error")
+	}
+}

--- a/go/concrete_builders_gen.go
+++ b/go/concrete_builders_gen.go
@@ -2,6 +2,45 @@
 
 package slackblocks
 
+// AccordionSectionBuilder is the concrete fluent builder returned by NewAccordionSection.
+type AccordionSectionBuilder struct{ *concreteBuilder }
+
+func newAccordionSectionBuilder(core *builder) *AccordionSectionBuilder {
+	return &AccordionSectionBuilder{concreteBuilder: newConcreteBuilder(core)}
+}
+
+// Title sets a title field.
+func (b *AccordionSectionBuilder) Title(value any) *AccordionSectionBuilder {
+	b.core.Title(value)
+	return b
+}
+
+// Subtitle sets secondary heading copy.
+func (b *AccordionSectionBuilder) Subtitle(value any) *AccordionSectionBuilder {
+	b.core.Subtitle(value)
+	return b
+}
+
+// Blocks appends Block Kit blocks.
+func (b *AccordionSectionBuilder) Blocks(values ...any) *AccordionSectionBuilder {
+	b.core.Blocks(values...)
+	return b
+}
+
+// Expanded controls whether an accordion section starts open. It stores a
+// private sentinel that the accordion-section transform converts to Slack's
+// inverse default_collapsed field during Build.
+func (b *AccordionSectionBuilder) Expanded(value bool) *AccordionSectionBuilder {
+	b.core.Expanded(value)
+	return b
+}
+
+// BlockID assigns an application-defined block identifier.
+func (b *AccordionSectionBuilder) BlockID(value string) *AccordionSectionBuilder {
+	b.core.BlockID(value)
+	return b
+}
+
 // ActionsBlockBuilder is the concrete fluent builder returned by NewActionsBlock.
 type ActionsBlockBuilder struct{ *slackBlockBuilder }
 

--- a/go/concrete_builders_test.go
+++ b/go/concrete_builders_test.go
@@ -126,9 +126,16 @@ func newModuleAwareImporter() types.Importer {
 	// using additional slack-go symbols.
 	const path = "github.com/slack-go/slack"
 	pkg := types.NewPackage(path, "slack")
-	name := types.NewTypeName(token.NoPos, pkg, "MessageBlockType", nil)
-	types.NewNamed(name, types.Typ[types.String], nil)
-	pkg.Scope().Insert(name)
+	messageBlockTypeName := types.NewTypeName(token.NoPos, pkg, "MessageBlockType", nil)
+	messageBlockType := types.NewNamed(messageBlockTypeName, types.Typ[types.String], nil)
+	pkg.Scope().Insert(messageBlockTypeName)
+	blockMethods := []*types.Func{
+		types.NewFunc(token.NoPos, pkg, "BlockType", types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(token.NoPos, pkg, "", messageBlockType)), false)),
+		types.NewFunc(token.NoPos, pkg, "ID", types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(token.NoPos, pkg, "", types.Typ[types.String])), false)),
+	}
+	blockName := types.NewTypeName(token.NoPos, pkg, "Block", nil)
+	types.NewNamed(blockName, types.NewInterfaceType(blockMethods, nil).Complete(), nil)
+	pkg.Scope().Insert(blockName)
 	pkg.MarkComplete()
 	return moduleAwareImporter{standard: importer.Default(), slack: pkg}
 }

--- a/go/core.go
+++ b/go/core.go
@@ -17,6 +17,12 @@ type Buildable interface {
 	Build() (Object, error)
 }
 
+// GroupBuildable is implemented by higher-level components that expand to
+// multiple ordinary Slack objects inside a parent collection.
+type GroupBuildable interface {
+	BuildMany() ([]Object, error)
+}
+
 type coercion func(any) (any, error)
 
 // builder incrementally configures one Slack wire object. Named constructors
@@ -275,6 +281,16 @@ func materialise(value any) (any, error) {
 	case []any:
 		result := make([]any, 0, len(typed))
 		for _, nested := range typed {
+			if group, ok := nested.(GroupBuildable); ok {
+				built, err := group.BuildMany()
+				if err != nil {
+					return nil, err
+				}
+				for _, item := range built {
+					result = append(result, item)
+				}
+				continue
+			}
 			built, err := materialise(nested)
 			if err != nil {
 				return nil, err

--- a/go/fields.go
+++ b/go/fields.go
@@ -227,6 +227,11 @@ func (b *builder) DefaultCollapsed(value bool) *builder {
 	return b.set("default_collapsed", value)
 }
 
+// Expanded controls whether an accordion section starts open. It stores a
+// private sentinel that the accordion-section transform converts to Slack's
+// inverse default_collapsed field during Build.
+func (b *builder) Expanded(value bool) *builder { return b.set("_expanded", value) }
+
 // DefaultToCurrentConversation selects the current conversation by default.
 func (b *builder) DefaultToCurrentConversation(value bool) *builder {
 	return b.set("default_to_current_conversation", value)

--- a/go/internal/builder_methods.json
+++ b/go/internal/builder_methods.json
@@ -1,4 +1,11 @@
 {
+	"NewAccordionSection": [
+		"Title",
+		"Subtitle",
+		"Blocks",
+		"Expanded",
+		"BlockID"
+	],
 	"NewActionsBlock": [
 		"Elements",
 		"BlockID"


### PR DESCRIPTION
Stack 3 of 5 for the Go implementation; depends on #313.

## Scope
- add a Slack-native `Accordion` component with typed sections
- add a stateful `Paginator` component with previous/next controls and page metadata
- keep `BuildMany()` for expansion inside raw slackblocks payloads
- add `SlackBlocks()` to both components for direct `[]slack.Block` expansion into `slack.MsgOptionBlocks(blocks...)`
- cover custom navigation labels, page-indicator suppression, navigation block IDs, native expansion errors, and nested surface validation
- keep the private accordion expansion sentinel with the canonical field-method definitions

## Validation
- `go test -race -cover ./...`
- `go vet ./...` and staticcheck
- generated-builder drift check
- `gofmt` clean

Do not merge until the full train is approved.
