### PR TITLE
Prepare coordinated Go module releases

### DIFF
--- a/.github/scripts/extract-go-release-notes.awk
+++ b/.github/scripts/extract-go-release-notes.awk
@@ -1,0 +1,4 @@
+$0 ~ "^## \\[" version "\\]" { capture = 1; next }
+capture && /^## \[/ { exit }
+capture && !started && /^[[:space:]]*$/ { next }
+capture { print; started = 1 }

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,12 +7,14 @@ on:
       - "go/**"
       - "spec/**"
       - "docs/examples/go/**"
+      - ".github/scripts/extract-go-release-notes.awk"
       - ".github/workflows/go.yml"
   pull_request:
     paths:
       - "go/**"
       - "spec/**"
       - "docs/examples/go/**"
+      - ".github/scripts/extract-go-release-notes.awk"
       - ".github/workflows/go.yml"
 
 permissions:
@@ -55,6 +57,11 @@ jobs:
         run: |
           go generate ./...
           git diff --exit-code -- concrete_builders_gen.go
+
+      - name: Verify release-note extraction
+        run: |
+          notes=$(printf '## [9.9.9] — 2099-01-01\n\nExpected notes.\n\n## [9.9.8] — 2098-01-01\n\nOlder notes.\n' | awk -v version="9.9.9" -f ../.github/scripts/extract-go-release-notes.awk)
+          test "$notes" = "Expected notes."
 
       - name: Run vet
         run: go vet ./...

--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -1,0 +1,87 @@
+name: Publish Go Module
+
+on:
+  push:
+    tags:
+      - "go/v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify tagged Go module
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: stable
+          cache: false
+
+      - name: Verify coordinated version and module path
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#go/v}"
+          python_version=$(node -e "const text = require('fs').readFileSync('../python/pyproject.toml', 'utf8'); const match = text.match(/^version = \"([^\"]+)\"$/m); if (!match) process.exit(1); process.stdout.write(match[1]);")
+          typescript_version=$(node -p "require('../typescript/package.json').version")
+          module=$(go list -m -f '{{.Path}}')
+          if [ "$python_version" != "$typescript_version" ]; then
+            echo "::error::Python version '$python_version' does not match TypeScript version '$typescript_version'. Releases are coordinated; bump both together."
+            exit 1
+          fi
+          if [ "$tag" != "$python_version" ]; then
+            echo "::error::Go tag '$tag' does not match the coordinated package version '$python_version'."
+            exit 1
+          fi
+          if [ "$module" != "github.com/nicklambourne/slackblocks/go/v2" ]; then
+            echo "::error::Unexpected Go module path '$module'."
+            exit 1
+          fi
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Run vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test -race -cover ./...
+
+  github-release:
+    name: Create GitHub Release
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Create release from changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release for $GITHUB_REF_NAME already exists; skipping."
+            exit 0
+          fi
+          version="${GITHUB_REF_NAME#go/v}"
+          awk -v version="$version" -f .github/scripts/extract-go-release-notes.awk go/CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            gh release create "$GITHUB_REF_NAME" --title "Go v$version" --notes-file release-notes.md
+          else
+            echo "::warning::Could not extract changelog section for $version; using generated notes."
+            gh release create "$GITHUB_REF_NAME" --title "Go v$version" --generate-notes
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing
 
-The Python (`slackblocks` on PyPI) and TypeScript (`@nicklambourne/slackblocks`
-on npm) packages are released together and always carry the same version
-number.
+The Python (`slackblocks` on PyPI), TypeScript
+(`@nicklambourne/slackblocks` on npm), and Go
+(`github.com/nicklambourne/slackblocks/go/v2`) packages are released together
+and always carry the same version number.
 
 ## Tag scheme
 
@@ -12,13 +13,15 @@ Releases are triggered by pushing tags:
 |---|---|---|
 | `python/vX.Y.Z` | [`.github/workflows/publish.yml`](.github/workflows/publish.yml) | `slackblocks` to PyPI |
 | `ts/vX.Y.Z` | [`.github/workflows/publish-npm.yml`](.github/workflows/publish-npm.yml) | `@nicklambourne/slackblocks` to npm |
+| `go/vX.Y.Z` | [`.github/workflows/publish-go.yml`](.github/workflows/publish-go.yml) | `github.com/nicklambourne/slackblocks/go/v2` to the Go module ecosystem |
 
 Plain `v*` tags (used by the pre-monorepo 1.x/2.0 releases) no longer trigger
 anything.
 
-Both workflows fail fast if the tag does not match the package manifest
-version, or if `python/pyproject.toml` and `typescript/package.json` disagree
-with each other.
+The Python and TypeScript workflows fail fast if the tag does not match their
+package manifest. Every workflow also verifies that `python/pyproject.toml`
+and `typescript/package.json` agree, and the Go workflow requires its tag to
+match that coordinated version.
 
 ## One-time setup
 
@@ -45,6 +48,12 @@ These must be in place before the workflows can publish:
       workflow `publish-npm.yml`, environment `npm`), then **delete the
       `NPM_TOKEN` secret**. Subsequent publishes use OIDC automatically; the
       token path only runs while the secret is present.
+4. **Go requires no registry credentials** — Go modules are published by
+   pushing the correctly prefixed repository tag. Because the module lives in
+   the `go/` subdirectory and declares the `/v2` module path, its tags must use
+   the exact form `go/vX.Y.Z`. The workflow verifies the module and creates the
+   corresponding GitHub Release; consumers and the public Go proxy resolve it
+   directly from the repository.
 
 ## Coordinated release procedure
 
@@ -73,24 +82,31 @@ missing from `docs/versions.json` (or the legacy manifest).
 2. Bump the version in **both** manifests on the same branch:
    - `python/pyproject.toml` (`project.version`)
    - `typescript/package.json` (`version`)
-3. Add a `## [X.Y.Z] — YYYY-MM-DD` section to both `python/CHANGELOG.md` and
-   `typescript/CHANGELOG.md`. The publish workflows extract this section for
-   the GitHub Release notes.
+
+   For a new major release, also change the Go semantic import path in
+   `go/go.mod` from `/v2` to `/vN`, update every Go import in code and docs,
+   and update the module-path assertion in `publish-go.yml`. A coordinated
+   Python/TypeScript 3.0.0 release therefore requires a Go `/v3` module; the
+   existing `/v2` path cannot publish `go/v3.0.0`.
+3. Add a `## [X.Y.Z] — YYYY-MM-DD` section to `python/CHANGELOG.md`,
+   `typescript/CHANGELOG.md`, and `go/CHANGELOG.md`. The publish workflows
+   extract the matching section for their GitHub Release notes.
 4. Merge to `master` and wait for CI to pass.
-5. Tag and push, Python first (either order works; the guards only require
-   the two manifests to agree):
+5. Tag and push all three releases. Any order works; every workflow checks the
+   same two package manifests:
 
    ```sh
    git tag python/vX.Y.Z && git push origin python/vX.Y.Z
    git tag ts/vX.Y.Z && git push origin ts/vX.Y.Z
+   git tag go/vX.Y.Z && git push origin go/vX.Y.Z
    ```
 
-6. Each workflow publishes to its registry and then creates a GitHub Release
-   for its tag with the changelog section as notes.
+6. Each workflow publishes or verifies its package and then creates a GitHub
+   Release for its tag with the changelog section as notes.
 
 ## Partial-failure recovery
 
-Both workflows are safe to re-run from the Actions UI:
+All three workflows are safe to re-run from the Actions UI:
 
 - **PyPI** — `uv publish` runs with
   `--check-url https://pypi.org/simple/slackblocks/`, so files already
@@ -98,6 +114,9 @@ Both workflows are safe to re-run from the Actions UI:
 - **npm** — the publish is a single atomic upload; if it failed, re-running
   simply retries it. If it already succeeded, npm rejects the duplicate
   version, which tells you the registry side is done.
+- **Go** — the tag is the published module version. Re-run the workflow if only
+  verification or GitHub Release creation failed; do not move or replace a
+  public module tag.
 - **GitHub Releases** — the release step skips itself if a release for the
   tag already exists.
 
@@ -107,8 +126,10 @@ After a failure, check:
   the sdist and the wheel.
 - npm: https://www.npmjs.com/package/@nicklambourne/slackblocks shows the new
   version (with provenance).
-- GitHub: a Release exists for each of the two tags with the changelog notes.
+- Go: https://pkg.go.dev/github.com/nicklambourne/slackblocks/go/v2 lists the
+  new module version.
+- GitHub: a Release exists for each of the three tags with the changelog notes.
 
 If a bad artifact was published, do not delete and re-upload: registries
 reject reused file names and versions. Yank/deprecate the broken version and
-release a new patch version of **both** packages.
+release a new coordinated patch version of **all three** packages.

--- a/docs/scripts/check_release_snapshots.mjs
+++ b/docs/scripts/check_release_snapshots.mjs
@@ -37,8 +37,8 @@ function snapshottedVersions() {
   return versions;
 }
 
-// Python and TypeScript are released together under the same version number, so
-// the `python/v*` tags are the authoritative list of released versions. Plain
+// Python, TypeScript, and Go are released together under one version number, so
+// the `python/v*` tags remain the authoritative released-version list. Plain
 // `v*` tags belong to the pre-monorepo 1.x/2.0 line and are covered by the
 // legacy manifest instead.
 function releasedVersions() {


### PR DESCRIPTION
Stack 5 of 5 for the Go implementation; depends on #315.

## Scope
- add a pinned `go/v*` tag workflow for the nested `/go/v2` module
- verify each Go tag against the coordinated Python/TypeScript manifest version and exact module path
- run formatting, vet, and race-enabled tests before creating the Go GitHub Release
- extract Go release notes with a reusable AWK program that is smoke-tested by normal Go CI
- document Go module publication, recovery, verification, the `/vN` module-path change required for future major releases, and the three-tag coordinated release procedure
- retain Python release tags as the authoritative historical-doc snapshot list

No package versions are bumped and no tags are created by this PR. The next coordinated version remains an explicit release decision after the train is approved.

## Validation
- local release-note extraction smoke test
- local tag/version/module guard simulation
- Go 1.22.12 tidy/vet and stable Go release gates
- docs release-snapshot guard
- GitHub-hosted Go 1.22.x and stable jobs

Do not merge until the full train is approved.
