### PR TITLE
Remove documentation edit links

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -196,10 +196,6 @@ const config: Config = {
         docs: {
           routeBasePath: "/",
           sidebarPath: "./sidebars.ts",
-          editUrl: ({ version, docPath }) =>
-            version === "current"
-              ? `https://github.com/nicklambourne/slackblocks/tree/master/docs/${docPath}`
-              : undefined,
           showLastUpdateTime: true,
           lastVersion: "current",
           versions: {


### PR DESCRIPTION
## Summary

- remove the global Docusaurus edit URL
- hide the Edit this page footer link across current documentation

## Validation

- `pnpm build`