### PR TITLE
Label the Python CI badge explicitly

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Python
 
 on:
   push:


### PR DESCRIPTION
## Summary
- rename the Python test workflow from `Unit Tests` to `Python`
- make the README badge render as Python alongside the TypeScript and Go badges
- leave all job names, matrices, and required check names unchanged

## Validation
- workflow diff is limited to the top-level display name
- `git diff --check` passes