### PR TITLE
Prepare the first Go v2.2.0 release

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -5,4 +5,23 @@ same version number as the Python and TypeScript packages.
 
 ## Unreleased
 
-- Add the initial fluent Go implementation, with top-level block builders implementing `slack.Block` for direct use with `slack-go/slack`.
+## [2.2.0] — 2026-09-02
+
+The first public Go release of slackblocks, versioned in step with the Python
+and TypeScript packages. The module supports Go 1.22 and newer.
+
+### Added
+
+- Fluent concrete builders for Slack Block Kit composition objects, elements,
+  blocks, messages, attachments, responses, modals, and App Home payloads.
+- Typed validation errors and complete payload validation for required fields,
+  length and collection limits, supported block surfaces, and modal submission
+  rules.
+- Direct `slack-go/slack` interoperability: top-level block builders implement
+  `slack.Block` and can be passed directly to `slack.MsgOptionBlocks`.
+- Shared conformance coverage against the same valid and invalid JSON fixtures
+  used by the Python and TypeScript implementations.
+- Higher-level `Accordion` and `Paginator` components that expand into ordinary
+  Slack blocks.
+- Dedicated documentation, examples, generated-builder verification, and a CI
+  matrix covering Go 1.22 and the latest stable Go release.


### PR DESCRIPTION
## Summary
- turn the initial Go implementation notes into a dated v2.2.0 changelog entry
- document the fluent API, validation, conformance, slack-go integration, higher-level components, and Go 1.22 support
- prepare the repository for the coordinated `go/v2.2.0` module tag

## Validation
- release-note extraction returns the complete v2.2.0 entry
- module tidiness and generated builders are unchanged
- Go 1.22 generation and vet pass
- Go 1.22 Linux test suite compiles successfully
- latest stable Go passes vet, staticcheck, and race-enabled tests with coverage

The local Go 1.22 test executable cannot launch on the current macOS loader because that old toolchain emits a Mach-O binary without `LC_UUID`; the PR Ubuntu Go 1.22 matrix is the authoritative execution check.