### PR TITLE
Coordinate Python, TypeScript, and Go releases

### DIFF
--- a/.github/workflows/coordinated-release.yml
+++ b/.github/workflows/coordinated-release.yml
@@ -1,0 +1,183 @@
+name: Coordinated Release
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/coordinated-release.yml"
+      - ".github/workflows/publish.yml"
+      - ".github/workflows/publish-npm.yml"
+      - ".github/workflows/publish-go.yml"
+      - "python/pyproject.toml"
+      - "typescript/package.json"
+      - "python/CHANGELOG.md"
+      - "typescript/CHANGELOG.md"
+      - "go/CHANGELOG.md"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version (X.Y.Z)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coordinated-release-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate coordinated release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate version and release notes
+        id: version
+        env:
+          RELEASE_EVENT: ${{ github.event_name }}
+          RELEASE_REF: ${{ github.ref }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          typescript_version=$(node -p "require('./typescript/package.json').version")
+          python_version=$(node -e "const text = require('fs').readFileSync('python/pyproject.toml', 'utf8'); const match = text.match(/^version = \"([^\"]+)\"$/m); if (!match) process.exit(1); process.stdout.write(match[1]);")
+          version="${REQUESTED_VERSION:-$typescript_version}"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '$version' must use the stable X.Y.Z format."
+            exit 1
+          fi
+          if [ "$python_version" != "$typescript_version" ]; then
+            echo "::error::Python version '$python_version' does not match TypeScript version '$typescript_version'."
+            exit 1
+          fi
+          if [ "$version" != "$python_version" ]; then
+            echo "::error::Requested version '$version' does not match the package manifests ('$python_version')."
+            exit 1
+          fi
+          if [ "$RELEASE_EVENT" = "workflow_dispatch" ] && [ "$RELEASE_REF" != "refs/heads/master" ]; then
+            echo "::error::Coordinated releases must be dispatched from the master branch."
+            exit 1
+          fi
+
+          for changelog in python/CHANGELOG.md typescript/CHANGELOG.md go/CHANGELOG.md; do
+            if ! grep -Fq "## [$version]" "$changelog"; then
+              echo "::error file=$changelog::Missing release notes for version $version."
+              exit 1
+            fi
+          done
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Validated coordinated release $version."
+
+  create-tags:
+    name: Create coordinated tags
+    if: github.event_name == 'workflow_dispatch'
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Create or verify release tags
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          tags=("python/v$VERSION" "ts/v$VERSION" "go/v$VERSION")
+          existing=0
+
+          for tag in "${tags[@]}"; do
+            if git show-ref --verify --quiet "refs/tags/$tag"; then
+              existing=$((existing + 1))
+              target=$(git rev-list -n 1 "$tag")
+              if [ "$target" != "$GITHUB_SHA" ]; then
+                echo "::error::Existing tag '$tag' points to $target instead of $GITHUB_SHA."
+                exit 1
+              fi
+            fi
+          done
+
+          if [ "$existing" -eq 3 ]; then
+            echo "All coordinated tags already point to $GITHUB_SHA; reusing them."
+            exit 0
+          fi
+          if [ "$existing" -ne 0 ]; then
+            echo "::error::Only $existing of the three release tags already exist. Resolve the partial release before retrying."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --annotate "python/v$VERSION" --message "slackblocks $VERSION (Python)"
+          git tag --annotate "ts/v$VERSION" --message "@nicklambourne/slackblocks $VERSION (TypeScript)"
+          git tag --annotate "go/v$VERSION" --message "slackblocks $VERSION (Go)"
+          git push --atomic origin "${tags[@]}"
+
+  publish:
+    name: Publish ${{ matrix.language }}
+    if: github.event_name == 'workflow_dispatch'
+    needs:
+      - validate
+      - create-tags
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: Python
+            workflow: publish.yml
+            tag_prefix: python/v
+          - language: TypeScript
+            workflow: publish-npm.yml
+            tag_prefix: ts/v
+          - language: Go
+            workflow: publish-go.yml
+            tag_prefix: go/v
+    steps:
+      - name: Dispatch and monitor publisher
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PUBLISH_WORKFLOW: ${{ matrix.workflow }}
+          RELEASE_TAG: ${{ format('{0}{1}', matrix.tag_prefix, needs.validate.outputs.version) }}
+        run: |
+          set -euo pipefail
+
+          previous_run=$(gh run list --workflow "$PUBLISH_WORKFLOW" --event workflow_dispatch --branch "$RELEASE_TAG" --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          gh workflow run "$PUBLISH_WORKFLOW" --ref "$RELEASE_TAG"
+
+          run_id=""
+          for _ in {1..12}; do
+            run_id=$(gh run list --workflow "$PUBLISH_WORKFLOW" --event workflow_dispatch --branch "$RELEASE_TAG" --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+            if [ -n "$run_id" ] && [ "$run_id" != "$previous_run" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if [ -z "$run_id" ] || [ "$run_id" = "$previous_run" ]; then
+            echo "::error::Could not find the dispatched $PUBLISH_WORKFLOW run for $RELEASE_TAG."
+            exit 1
+          fi
+
+          run_url=$(gh run view "$run_id" --json url --jq .url)
+          echo "Monitoring $run_url"
+          echo "- [${RELEASE_TAG} publisher](${run_url})" >> "$GITHUB_STEP_SUMMARY"
+          gh run watch "$run_id" --exit-status

--- a/.github/workflows/publish-go.yml
+++ b/.github/workflows/publish-go.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "go/v*"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "ts/v*"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "python/v*"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,11 @@ The Python (`slackblocks` on PyPI), TypeScript
 (`github.com/nicklambourne/slackblocks/go/v2`) packages are released together
 and always carry the same version number.
 
+The recommended entry point is the **Coordinated Release** workflow in GitHub
+Actions. Run it from `master` with one `X.Y.Z` input; it validates the shared
+version and changelogs, creates all three annotated tags in one atomic push,
+dispatches each existing publisher at its tag, and waits for all three runs.
+
 ## Tag scheme
 
 Releases are triggered by pushing tags:
@@ -17,6 +22,10 @@ Releases are triggered by pushing tags:
 
 Plain `v*` tags (used by the pre-monorepo 1.x/2.0 releases) no longer trigger
 anything.
+
+The three publisher workflows also accept a manual dispatch at an existing,
+matching language tag. The coordinator uses those entry points so the PyPI and
+npm jobs retain their existing trusted-publisher workflow identities.
 
 The Python and TypeScript workflows fail fast if the tag does not match their
 package manifest. Every workflow also verifies that `python/pyproject.toml`
@@ -92,19 +101,40 @@ missing from `docs/versions.json` (or the legacy manifest).
    `typescript/CHANGELOG.md`, and `go/CHANGELOG.md`. The publish workflows
    extract the matching section for their GitHub Release notes.
 4. Merge to `master` and wait for CI to pass.
-5. Tag and push all three releases. Any order works; every workflow checks the
-   same two package manifests:
+5. In GitHub Actions, open **Coordinated Release**, select **Run workflow**,
+   keep the branch set to `master`, and enter `X.Y.Z`. The equivalent CLI
+   command is:
 
    ```sh
-   git tag python/vX.Y.Z && git push origin python/vX.Y.Z
-   git tag ts/vX.Y.Z && git push origin ts/vX.Y.Z
-   git tag go/vX.Y.Z && git push origin go/vX.Y.Z
+   gh workflow run coordinated-release.yml --ref master -f version=X.Y.Z
    ```
 
-6. Each workflow publishes or verifies its package and then creates a GitHub
-   Release for its tag with the changelog section as notes.
+6. The coordinator atomically pushes `python/vX.Y.Z`, `ts/vX.Y.Z`, and
+   `go/vX.Y.Z`, then dispatches and monitors the three existing publishers.
+   Each publisher creates its own GitHub Release after its registry step
+   succeeds.
+
+If the coordinator is unavailable, the direct tag triggers remain as a manual
+fallback. Create all three signed tags at the same commit and push them
+atomically:
+
+```sh
+git tag -s python/vX.Y.Z -m "slackblocks X.Y.Z (Python)"
+git tag -s ts/vX.Y.Z -m "@nicklambourne/slackblocks X.Y.Z (TypeScript)"
+git tag -s go/vX.Y.Z -m "slackblocks X.Y.Z (Go)"
+git push --atomic origin python/vX.Y.Z ts/vX.Y.Z go/vX.Y.Z
+```
+
+Tags created by the coordinator are annotated as `github-actions[bot]` but
+are not signed with a maintainer's personal key; CI deliberately does not
+store that private key.
 
 ## Partial-failure recovery
+
+The three tags are created atomically, but three external registries cannot be
+updated as one transaction. If one publisher fails after another succeeds,
+re-run the failed publisher from its existing workflow run; never move the
+tags or republish an already released version.
 
 All three workflows are safe to re-run from the Actions UI:
 


### PR DESCRIPTION
## Summary

- add a single manually triggered Coordinated Release workflow with one X.Y.Z input
- validate master, both package manifests, and all three changelogs before mutation
- atomically create the Python, TypeScript, and Go annotated tags
- dispatch the existing trusted-publisher workflows at their matching tags and monitor all three runs
- preserve direct tag pushes and manual publisher dispatches for recovery
- document the coordinated path, signed manual fallback, and partial-failure behavior

## Safety

Pull requests run validation only. Tag creation and publishing are gated to workflow_dispatch on master. The existing publish workflow filenames remain the OIDC identities trusted by PyPI and npm.

Coordinator-created tags are annotated as github-actions[bot] and intentionally do not store a maintainer signing key in CI.

## Validation

- actionlint v1.7.12 on all four affected workflows
- local coordinated manifest and changelog validation
- git diff --cached --check
- runner audit: all affected jobs remain on the explicitly approved GitHub-hosted ubuntu-latest runners